### PR TITLE
dns test: add check for dns object in alert

### DIFF
--- a/tests/dns-eve-v2-udp-dig-a-www-suricata-ids-org/suricata.yaml
+++ b/tests/dns-eve-v2-udp-dig-a-www-suricata-ids-org/suricata.yaml
@@ -7,6 +7,7 @@ outputs:
   - eve-log:
       enabled: true
       types:
+        - alert:
         - dns:
             enabled: true
             version: 2

--- a/tests/dns-eve-v2-udp-dig-a-www-suricata-ids-org/test.rules
+++ b/tests/dns-eve-v2-udp-dig-a-www-suricata-ids-org/test.rules
@@ -1,0 +1,1 @@
+alert dns any any -> any any (msg:"TEST dns_query"; dns_query; content:"suricata-ids.org"; sid:1; rev:1;)

--- a/tests/dns-eve-v2-udp-dig-a-www-suricata-ids-org/test.yaml
+++ b/tests/dns-eve-v2-udp-dig-a-www-suricata-ids-org/test.yaml
@@ -2,8 +2,6 @@ requires:
   features:
     - HAVE_LIBJANSSON
   min-version: 4.1.0
-  script:
-    - grep OutputAnswerV2 src/output-json-dns.c > /dev/null 2>&1
 
 checks:
 
@@ -24,3 +22,11 @@ checks:
         dns.answers[0].rrtype: CNAME
         dns.answers[1].rrtype: A
         dns.answers[2].rrtype: A
+
+  # Check that the alert contains a DNS object.
+  - filter:
+      count: 1
+      comment: alert with dns object
+      match:
+        event_type: alert
+        dns.query[0].type: query


### PR DESCRIPTION
Extend an existing test to check that the DNS object exists
on a DNS alert.

For Suricata PR https://github.com/OISF/suricata/pull/3623.
