### PR TITLE
file-store: add tests for stream-depth

### DIFF
--- a/tests/filestore-v1-stream-depth/suricata.yaml
+++ b/tests/filestore-v1-stream-depth/suricata.yaml
@@ -1,0 +1,23 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      types:
+        - files
+        - stats
+  - file-store:
+      version: 1
+      enabled: yes
+      force-filestore: yes
+      stream-depth: 0
+      
+app-layer:
+  protocols:
+    http:
+      enabled: yes
+      libhtp:
+        default-config:
+          personality: IDS
+          response-body-limit: 100kb

--- a/tests/filestore-v1-stream-depth/test.rules
+++ b/tests/filestore-v1-stream-depth/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (filestore; sid:1; rev:1;)

--- a/tests/filestore-v1-stream-depth/test.yaml
+++ b/tests/filestore-v1-stream-depth/test.yaml
@@ -1,0 +1,17 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+args:
+  - -k none
+
+pcap: ../filestore-v2.1-forced/suricata-update-pdf.pcap
+
+checks:
+
+  - filter:
+      count: 1
+      match:
+        event_type: fileinfo
+        fileinfo.state: "CLOSED"
+        fileinfo.stored: true

--- a/tests/filestore-v2.6-stream-depth/suricata.yaml
+++ b/tests/filestore-v2.6-stream-depth/suricata.yaml
@@ -1,0 +1,23 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      types:
+        - files
+        - stats
+  - file-store:
+      version: 2
+      enabled: yes
+      force-filestore: yes
+      stream-depth: 0
+      
+app-layer:
+  protocols:
+    http:
+      enabled: yes
+      libhtp:
+        default-config:
+          personality: IDS
+          response-body-limit: 100kb

--- a/tests/filestore-v2.6-stream-depth/test.rules
+++ b/tests/filestore-v2.6-stream-depth/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (filestore; sid:1; rev:1;)

--- a/tests/filestore-v2.6-stream-depth/test.yaml
+++ b/tests/filestore-v2.6-stream-depth/test.yaml
@@ -1,0 +1,17 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+args:
+  - -k none
+
+pcap: ../filestore-v2.1-forced/suricata-update-pdf.pcap
+
+checks:
+
+  - filter:
+      count: 1
+      match:
+        event_type: fileinfo
+        fileinfo.state: "CLOSED"
+        fileinfo.stored: true


### PR DESCRIPTION
This adds some tests related to filestore stream-depth patchset: https://github.com/OISF/suricata/pull/3792.