### PR TITLE
run: Add per test check for Suricata version

### DIFF
--- a/run.py
+++ b/run.py
@@ -558,6 +558,7 @@ class TestRunner:
             FilterCheck(check, self.output, self.suricata_config.version).run()
         except TestError as te:
             print("FAIL: {}".format(te))
+            check_args_fail()
             count["failure"] += 1
         except UnsatisfiedRequirementError as ue:
             print("SKIPPED: {}".format(ue))
@@ -572,6 +573,7 @@ class TestRunner:
             ShellCheck(check).run()
         except TestError as te:
             print("FAIL : {}".format(te))
+            check_args_fail()
             count["failure"] += 1
         else:
             print("OK")
@@ -583,6 +585,7 @@ class TestRunner:
             StatsCheck(check, self.output).run()
         except TestError as te:
             print("FAIL: {}".format(te))
+            check_args_fail()
             count["failure"] += 1
         else:
             print("OK")
@@ -716,6 +719,12 @@ class TestRunner:
         t.start()
         self.readers.append(t)
 
+
+def check_args_fail():
+    if args.fail:
+        sys.exit(1)
+
+
 def check_deps():
     try:
         subprocess.check_call("jq --version > /dev/null 2>&1", shell=True)
@@ -733,6 +742,7 @@ def check_deps():
 
 def main():
     global TOPDIR
+    global args
 
     if not check_deps():
         return 1
@@ -816,9 +826,8 @@ def main():
             skipped += 1
         except TestError as te:
             print("FAILED: {}".format(te))
+            check_args_fail()
             failed += 1
-        if args.fail:
-            return 1
 
     print("")
     print("PASSED:  %d" % (passed))

--- a/tests/alert-testmyids/test.yaml
+++ b/tests/alert-testmyids/test.yaml
@@ -6,9 +6,15 @@ checks:
 
   # Check that we only have one alert event type in eve.
   - filter:
+      version: 2
       count: 1
       match:
         event_type: alert
+  - filter:
+      version: 5.0
+      count: 1
+      match:
+          event_type: alert
 
   # Check how many lines were logged to fast.log.
   - shell:


### PR DESCRIPTION
Some tests in the latest versions might fail due to compatibility issues
because of the changes in features with every version. In order to avoid
failure in such cases, add per test checks that allow to check for the
current Suricata version and in case it does not match the version of
Suricata required to run that particular test, skip that test with an
appropriate message.

Sample conf
-----------
```
requires:
  features:
    - HAVE_LIBJANSSON

checks:

  # Check that we only have one alert event type in eve.
  - filter:
      version: 4.0.2
      count: 1
      match:
        event_type: alert

  # Check how many lines were logged to fast.log.
  - shell:
      args: cat fast.log | wc -l | xargs
      expect: 1
```

Running `tests/alert-testmyids` with above configuration (test.yaml)
gives the following output when run from a directory having Suricata
version 5.0.0-dev.
```
===> alert-testmyids: SKIPPED: Suricata v4.0.2 not found
```

In case someone specifies `min-version` as well as `version` as a part
of the configuration, the test fails with an error as below.
```
===> alert-testmyids: FAIL: Specify either min-version or version
```

Closes redmine ticket [#2924](https://redmine.openinfosecfoundation.org/issues/2924)