### PR TITLE
Add invalid rule tests #317 v2

### DIFF
--- a/tests/test-bad-content-dsize-rule-1/suricata.yaml
+++ b/tests/test-bad-content-dsize-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-content-dsize-rule-1/test.rules
+++ b/tests/test-bad-content-dsize-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert udp any any -> any any (msg:"TEST SUCCESFULL - Content Greater than Dsize INVALID combination "; dsize:10; content:"thisstringisgreaterthan10bytes"; sid:6666662; rev:1;)

--- a/tests/test-bad-content-dsize-rule-1/test.yaml
+++ b/tests/test-bad-content-dsize-rule-1/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "signature can't match as content length 30 is bigger than dsize 10"
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-depth-depth-rule-1/suricata.yaml
+++ b/tests/test-bad-depth-depth-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-depth-depth-rule-1/test.rules
+++ b/tests/test-bad-depth-depth-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert udp any any -> any any (msg:"TEST SUCCESFULL - Depth/Depth INVALID combination "; content:"AA"; depth:50; depth:20; sid:5555554; rev:1;)

--- a/tests/test-bad-depth-depth-rule-1/test.yaml
+++ b/tests/test-bad-depth-depth-rule-1/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "can't use multiple depths for the same content."
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-depth-distance-rule-1/suricata.yaml
+++ b/tests/test-bad-depth-distance-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-depth-distance-rule-1/test.rules
+++ b/tests/test-bad-depth-distance-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert udp any any -> any any (msg:"TEST SUCCESFULL - Depth/Distance INVALID combination "; content:"AA"; content:"BB"; depth:50; distance:5; sid:5555557; rev:1;)

--- a/tests/test-bad-depth-distance-rule-1/test.yaml
+++ b/tests/test-bad-depth-distance-rule-1/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "can't use a relative keyword like within\/distance with a absolute relative keyword like depth\/offset for the same content."
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-depth-distance-rule-2/suricata.yaml
+++ b/tests/test-bad-depth-distance-rule-2/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-depth-distance-rule-2/test.rules
+++ b/tests/test-bad-depth-distance-rule-2/test.rules
@@ -1,0 +1,1 @@
+alert udp any any -> any any (msg:"TEST SUCCESFULL - Depth/Distance INVALID combination "; content:"AA"; depth:50; distance:5; sid:5555556; rev:1;)

--- a/tests/test-bad-depth-distance-rule-2/test.yaml
+++ b/tests/test-bad-depth-distance-rule-2/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "can't use a relative keyword like within\/distance with a absolute relative keyword like depth\/offset for the same content."
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-depth-distance-rule-2/test.yaml
+++ b/tests/test-bad-depth-distance-rule-2/test.yaml
@@ -12,7 +12,7 @@ checks:
       count: 1
       match:
         event_type: engine
-        engine.message: "can't use a relative keyword like within\/distance with a absolute relative keyword like depth\/offset for the same content."
+        engine.message: "can't use a relative keyword like within/distance with a absolute relative keyword like depth/offset for the same content."
 
   - filter:
       count: 1

--- a/tests/test-bad-depth-rule-1/suricata.yaml
+++ b/tests/test-bad-depth-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-depth-rule-1/test.rules
+++ b/tests/test-bad-depth-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert udp any any -> any any (msg:"TEST SUCCESFULL - Depth by itself INVALID combination "; depth:50; sid:5555551; rev:1;)

--- a/tests/test-bad-depth-rule-1/test.yaml
+++ b/tests/test-bad-depth-rule-1/test.yaml
@@ -12,7 +12,7 @@ checks:
       count: 1
       match:
         event_type: engine
-        engine.message: "depth needs preceding content, uricontent option, http_client_body, http_server_body, http_header option, http_raw_header option, http_method option, http_cookie, http_raw_uri, http_stat_msg, http_stat_code, http_user_agent, http_host, http_raw_host or file_data\/dce_stub_data sticky buffer options"
+        engine.message: "depth needs preceding content, uricontent option, http_client_body, http_server_body, http_header option, http_raw_header option, http_method option, http_cookie, http_raw_uri, http_stat_msg, http_stat_code, http_user_agent, http_host, http_raw_host or file_data/dce_stub_data sticky buffer options"
 
   - filter:
       count: 1

--- a/tests/test-bad-depth-rule-1/test.yaml
+++ b/tests/test-bad-depth-rule-1/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "depth needs preceding content, uricontent option, http_client_body, http_server_body, http_header option, http_raw_header option, http_method option, http_cookie, http_raw_uri, http_stat_msg, http_stat_code, http_user_agent, http_host, http_raw_host or file_data\/dce_stub_data sticky buffer options"
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-depth-within-rule-1/suricata.yaml
+++ b/tests/test-bad-depth-within-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-depth-within-rule-1/test.rules
+++ b/tests/test-bad-depth-within-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert udp any any -> any any (msg:"TEST SUCCESFULL - Depth/Within INVALID combination "; content:"AA"; content:"BB"; depth:50; within:5; sid:5555553; rev:1;)

--- a/tests/test-bad-depth-within-rule-1/test.yaml
+++ b/tests/test-bad-depth-within-rule-1/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "can't use a relative keyword like within\/distance with a absolute relative keyword like depth\/offset for the same content."
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-depth-within-rule-1/test.yaml
+++ b/tests/test-bad-depth-within-rule-1/test.yaml
@@ -12,7 +12,7 @@ checks:
       count: 1
       match:
         event_type: engine
-        engine.message: "can't use a relative keyword like within\/distance with a absolute relative keyword like depth\/offset for the same content."
+        engine.message: "can't use a relative keyword like within/distance with a absolute relative keyword like depth/offset for the same content."
 
   - filter:
       count: 1

--- a/tests/test-bad-depth-within-rule-2/suricata.yaml
+++ b/tests/test-bad-depth-within-rule-2/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-depth-within-rule-2/test.rules
+++ b/tests/test-bad-depth-within-rule-2/test.rules
@@ -1,0 +1,1 @@
+alert udp any any -> any any (msg:"TEST SUCCESFULL - Depth/Within INVALID combination "; depth:50; within:5; sid:5555552; rev:1;)

--- a/tests/test-bad-depth-within-rule-2/test.yaml
+++ b/tests/test-bad-depth-within-rule-2/test.yaml
@@ -12,7 +12,7 @@ checks:
       count: 1
       match:
         event_type: engine
-        engine.message: "depth needs preceding content, uricontent option, http_client_body, http_server_body, http_header option, http_raw_header option, http_method option, http_cookie, http_raw_uri, http_stat_msg, http_stat_code, http_user_agent, http_host, http_raw_host or file_data\/dce_stub_data sticky buffer options"
+        engine.message: "depth needs preceding content, uricontent option, http_client_body, http_server_body, http_header option, http_raw_header option, http_method option, http_cookie, http_raw_uri, http_stat_msg, http_stat_code, http_user_agent, http_host, http_raw_host or file_data/dce_stub_data sticky buffer options"
 
   - filter:
       count: 1

--- a/tests/test-bad-depth-within-rule-2/test.yaml
+++ b/tests/test-bad-depth-within-rule-2/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "depth needs preceding content, uricontent option, http_client_body, http_server_body, http_header option, http_raw_header option, http_method option, http_cookie, http_raw_uri, http_stat_msg, http_stat_code, http_user_agent, http_host, http_raw_host or file_data\/dce_stub_data sticky buffer options"
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-dsize-offset-rule-1/suricata.yaml
+++ b/tests/test-bad-dsize-offset-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-dsize-offset-rule-1/test.rules
+++ b/tests/test-bad-dsize-offset-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert udp any any -> any any (msg:"TEST SUCCESFULL - dsize/offset INVALID combination "; dsize:50; content:"AA"; offset:100; sid:6666661; rev:1;)

--- a/tests/test-bad-dsize-offset-rule-1/test.yaml
+++ b/tests/test-bad-dsize-offset-rule-1/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "signature can't match as content length 2 with offset 100 (=102) is bigger than dsize 50"
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-dsize-range-offset-rule-1/suricata.yaml
+++ b/tests/test-bad-dsize-range-offset-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-dsize-range-offset-rule-1/test.rules
+++ b/tests/test-bad-dsize-range-offset-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert udp any any -> any any (msg:"TEST SUCCESFULL - dsize/offset INVALID combination "; dsize:5<>10; content:"AAAA"; offset:8; sid:6666665; rev:1;)

--- a/tests/test-bad-dsize-range-offset-rule-1/test.yaml
+++ b/tests/test-bad-dsize-range-offset-rule-1/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "signature can't match as content length 4 with offset 8 (=12) is bigger than dsize 10"
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-dsize-range-rule-1/suricata.yaml
+++ b/tests/test-bad-dsize-range-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-dsize-range-rule-1/test.rules
+++ b/tests/test-bad-dsize-range-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert udp any any -> any any (msg:"TEST SUCCESFULL - dsize with range INVALID combination "; dsize:5<>10; content:"thisstringisgreaterthan10bytes"; sid:6666664; rev:1;)

--- a/tests/test-bad-dsize-range-rule-1/test.yaml
+++ b/tests/test-bad-dsize-range-rule-1/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "signature can't match as content length 30 is bigger than dsize 10"
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-offset-distance-rule-1/suricata.yaml
+++ b/tests/test-bad-offset-distance-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-offset-distance-rule-1/test.rules
+++ b/tests/test-bad-offset-distance-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert udp any any -> any any (msg:"TEST SUCCESFULL - Offset/Distance INVALID combination "; content:"AA"; content:"BB"; offset:20; distance:5; sid:5555560; rev:1;)

--- a/tests/test-bad-offset-distance-rule-1/test.yaml
+++ b/tests/test-bad-offset-distance-rule-1/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "can't use a relative keyword like within\/distance with a absolute relative keyword like depth\/offset for the same content."
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-offset-distance-rule-1/test.yaml
+++ b/tests/test-bad-offset-distance-rule-1/test.yaml
@@ -12,7 +12,7 @@ checks:
       count: 1
       match:
         event_type: engine
-        engine.message: "can't use a relative keyword like within\/distance with a absolute relative keyword like depth\/offset for the same content."
+        engine.message: "can't use a relative keyword like within/distance with a absolute relative keyword like depth/offset for the same content."
 
   - filter:
       count: 1

--- a/tests/test-bad-offset-offset-rule-1/suricata.yaml
+++ b/tests/test-bad-offset-offset-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-offset-offset-rule-1/test.rules
+++ b/tests/test-bad-offset-offset-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert udp any any -> any any (msg:"TEST SUCCESFULL - Offset/Offset INVALID combination "; content:"AA"; offset:20; offset:20; sid:5555559; rev:1;)

--- a/tests/test-bad-offset-offset-rule-1/test.yaml
+++ b/tests/test-bad-offset-offset-rule-1/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "can't use multiple offsets for the same content."
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-offset-offset-rule-1/test.yaml
+++ b/tests/test-bad-offset-offset-rule-1/test.yaml
@@ -12,7 +12,7 @@ checks:
       count: 1
       match:
         event_type: engine
-        engine.message: "can't use multiple offsets for the same content."
+        engine.message: "can't use multiple offsets for the same content. "
 
   - filter:
       count: 1

--- a/tests/test-bad-offset-within-rule-1/suricata.yaml
+++ b/tests/test-bad-offset-within-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-offset-within-rule-1/test.rules
+++ b/tests/test-bad-offset-within-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert udp any any -> any any (msg:"TEST SUCCESFULL - Offset/Within INVALID combination "; content:"AA"; content:"BB"; offset:10; within:5; sid:5555561; rev:1;)

--- a/tests/test-bad-offset-within-rule-1/test.yaml
+++ b/tests/test-bad-offset-within-rule-1/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "can't use a relative keyword like within\/distance with a absolute relative keyword like depth\/offset for the same content."
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-offset-within-rule-1/test.yaml
+++ b/tests/test-bad-offset-within-rule-1/test.yaml
@@ -12,7 +12,7 @@ checks:
       count: 1
       match:
         event_type: engine
-        engine.message: "can't use a relative keyword like within\/distance with a absolute relative keyword like depth\/offset for the same content."
+        engine.message: "can't use a relative keyword like within/distance with a absolute relative keyword like depth/offset for the same content."
 
   - filter:
       count: 1

--- a/tests/test-bad-quotation-marks-rule-1/suricata.yaml
+++ b/tests/test-bad-quotation-marks-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-quotation-marks-rule-1/test.rules
+++ b/tests/test-bad-quotation-marks-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert udp any any -> any any (msg:"TEST SUCCESFULL - Missing-Quotation-Marks INVALID combination "; content:AA; sid:6666667; rev:1;)

--- a/tests/test-bad-quotation-marks-rule-1/test.yaml
+++ b/tests/test-bad-quotation-marks-rule-1/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "invalid formatting to content keyword: value must be double quoted 'content'"
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-semicolon-rule-1/suricata.yaml
+++ b/tests/test-bad-semicolon-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-semicolon-rule-1/test.rules
+++ b/tests/test-bad-semicolon-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert udp any any -> any any (msg:"TEST SUCCESFULL - Missing Semicolon INVALID combination "; content:"AA" depth:20; sid:6666666; rev:1;)

--- a/tests/test-bad-semicolon-rule-1/test.yaml
+++ b/tests/test-bad-semicolon-rule-1/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "bad option value formatting (possible missing semicolon) for keyword content: '\"AA\" depth:20'"
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-semicolon-rule-2/suricata.yaml
+++ b/tests/test-bad-semicolon-rule-2/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-semicolon-rule-2/test.rules
+++ b/tests/test-bad-semicolon-rule-2/test.rules
@@ -1,0 +1,1 @@
+alert udp any any -> any any (msg:"TEST SUCCESFULL - Too Many Semicolons INVALID combination "; content:"AA"; content:"BB";; within:5; sid:6666668; rev:1;)

--- a/tests/test-bad-semicolon-rule-2/test.yaml
+++ b/tests/test-bad-semicolon-rule-2/test.yaml
@@ -12,7 +12,7 @@ checks:
       count: 1
       match:
         event_type: engine
-        engine.message: "can't use a relative keyword like within/distance with a absolute relative keyword like depth/offset for the same content."
+        engine.message: "unknown rule keyword ''."
 
   - filter:
       count: 1

--- a/tests/test-bad-within-within-rule-1/suricata.yaml
+++ b/tests/test-bad-within-within-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-within-within-rule-1/test.rules
+++ b/tests/test-bad-within-within-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert udp any any -> any any (msg:"TEST SUCCESFULL - Depth/Within INVALID combination "; content:"AA"; content:"BB"; within:3; within:3; sid:5555555; rev:1;)

--- a/tests/test-bad-within-within-rule-1/test.yaml
+++ b/tests/test-bad-within-within-rule-1/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "can't use multiple withins for the same content."
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"


### PR DESCRIPTION
This PR takes the rules attached to redmine issue #317 and makes tests for them.
There is one invalid rule that is being loaded by suricata master branch, redmine #2982 is tracking that.

This PR has updates from v1 that resolve python parsing issues of escaped json strings.