### PR TITLE
Tests: add more coverage for invalid rule syntax

### DIFF
--- a/tests/test-bad-byte-extract-rule-1/suricata.yaml
+++ b/tests/test-bad-byte-extract-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-byte-extract-rule-1/test.rules
+++ b/tests/test-bad-byte-extract-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert tcp any any -> any any (msg:"Byte_Extract Example Using depth"; content:"Alice"; depth:d; byte_extract:2,1,size; content:"Bob"; sid:1111;)

--- a/tests/test-bad-byte-extract-rule-1/test.yaml
+++ b/tests/test-bad-byte-extract-rule-1/test.yaml
@@ -1,0 +1,23 @@
+requires:
+  min-version: 5.0.0
+
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "unknown byte_extract var seen in depth - d."
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-byte-extract-rule-2/suricata.yaml
+++ b/tests/test-bad-byte-extract-rule-2/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-byte-extract-rule-2/test.rules
+++ b/tests/test-bad-byte-extract-rule-2/test.rules
@@ -1,0 +1,1 @@
+alert tcp any any -> any any (msg:"bad depth value rule"; content:"first"; depth:-5; byte_extract:2,0,size; sid:111232; rev:1;)

--- a/tests/test-bad-byte-extract-rule-2/test.yaml
+++ b/tests/test-bad-byte-extract-rule-2/test.yaml
@@ -1,0 +1,23 @@
+requires:
+  min-version: 5.0.0
+
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "invalid value for depth: -5."
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-content-quotes-rule-1/suricata.yaml
+++ b/tests/test-bad-content-quotes-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-content-quotes-rule-1/test.rules
+++ b/tests/test-bad-content-quotes-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert tcp any any -> any any (msg:"invalid quotes in content"; content:"thisisbad""; sid:1234546; rev:1;)

--- a/tests/test-bad-content-quotes-rule-1/test.yaml
+++ b/tests/test-bad-content-quotes-rule-1/test.yaml
@@ -1,0 +1,23 @@
+requires:
+  min-version: 5.0.0
+
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "Invalid unescaped double quote within content section."
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-hex-rule-1/suricata.yaml
+++ b/tests/test-bad-hex-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-hex-rule-1/test.rules
+++ b/tests/test-bad-hex-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert tcp any any -> any any (msg:"invalid hex test rule"; content:"|l0 01 01|"; sid:12345; rev:1;)

--- a/tests/test-bad-hex-rule-1/test.yaml
+++ b/tests/test-bad-hex-rule-1/test.yaml
@@ -1,0 +1,23 @@
+requires:
+  min-version: 5.0.0
+
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "Invalid hex code in content - |l0 01 01|, hex l. Invalidating signature."
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-hex-rule-2/suricata.yaml
+++ b/tests/test-bad-hex-rule-2/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-hex-rule-2/test.rules
+++ b/tests/test-bad-hex-rule-2/test.rules
@@ -1,0 +1,1 @@
+alert tcp any any -> any any (msg:"invalid hex test rule"; content:"|01 10 0j|"; sid:12346; rev:1;)

--- a/tests/test-bad-hex-rule-2/test.yaml
+++ b/tests/test-bad-hex-rule-2/test.yaml
@@ -1,0 +1,23 @@
+requires:
+  min-version: 5.0.0
+
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "Invalid hex code in content - \u0001\u00101 10 0j|, hex j. Invalidating signature."
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-hex-rule-3/suricata.yaml
+++ b/tests/test-bad-hex-rule-3/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-hex-rule-3/test.rules
+++ b/tests/test-bad-hex-rule-3/test.rules
@@ -1,0 +1,1 @@
+alert tcp any any -> any any (msg:"invalid hex test rule 3"; content:"|1"; sid:1232222; rev:1;)

--- a/tests/test-bad-hex-rule-3/test.yaml
+++ b/tests/test-bad-hex-rule-3/test.yaml
@@ -1,0 +1,23 @@
+requires:
+  min-version: 5.0.0
+
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "Invalid hex code assembly in content - |1.  Invalidating signature."
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-negate-fast-pattern-rule-1/suricata.yaml
+++ b/tests/test-bad-negate-fast-pattern-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-negate-fast-pattern-rule-1/test.rules
+++ b/tests/test-bad-negate-fast-pattern-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert tcp any any -> any any (msg:"bad relative negated keyword with fast_pattern"; content:"first"; content:!"second"; fast_pattern; offset:6;  sid:5542341; rev:1;)

--- a/tests/test-bad-negate-fast-pattern-rule-1/test.yaml
+++ b/tests/test-bad-negate-fast-pattern-rule-1/test.yaml
@@ -1,0 +1,23 @@
+requires:
+  min-version: 5.0.0
+
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "can't have a relative negated keyword set along with 'fast_pattern'."
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"

--- a/tests/test-bad-relative-keyword-fast-pattern-rule-1/suricata.yaml
+++ b/tests/test-bad-relative-keyword-fast-pattern-rule-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-bad-relative-keyword-fast-pattern-rule-1/test.rules
+++ b/tests/test-bad-relative-keyword-fast-pattern-rule-1/test.rules
@@ -1,0 +1,1 @@
+alert tcp any any -> any any (msg:"bad relative keyword with fast_pattern:only"; content:"first"; content:"second"; fast_pattern:only; offset:6; sid:5542341; rev:1;)

--- a/tests/test-bad-relative-keyword-fast-pattern-rule-1/test.yaml
+++ b/tests/test-bad-relative-keyword-fast-pattern-rule-1/test.yaml
@@ -1,0 +1,23 @@
+requires:
+  min-version: 5.0.0
+
+  features:
+    - HAVE_LIBJANSSON
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entres in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "can't have a relative keyword set along with 'fast_pattern:only;'."
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.error: "SC_ERR_NO_RULES_LOADED"


### PR DESCRIPTION
This PR adds some more tests that validate logic in the detect engine for various bad rule scenarios.

v2 adds more tests from v1 and fixed a potential run time issue with a couple of the tests. 