### PR TITLE
tests: update for anomaly filters

### DIFF
--- a/tests/output-eve-anomaly-packethdr/suricata.yaml
+++ b/tests/output-eve-anomaly-packethdr/suricata.yaml
@@ -7,4 +7,5 @@ outputs:
       filetype: regular
       types:
         - anomaly:
+            protodecode: yes
             packethdr: yes            # enable dumping of packet header

--- a/tests/output-eve-anomaly/suricata.yaml
+++ b/tests/output-eve-anomaly/suricata.yaml
@@ -7,3 +7,4 @@ outputs:
       filetype: regular
       types:
         - anomaly:
+            protodecode: yes


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [2958](https://redmine.openinfosecfoundation.org/issues/2958)

This PR updates the eve output anomaly tests with the anomaly filter that enables engine decode events.

This PR is required for the suricata PR: [`logging/anomaly: Support configuration filter types`](https://github.com/OISF/suricata/pull/4033)