### PR TITLE
tests: Update anomaly logging to use new config

### DIFF
--- a/tests/output-eve-anomaly-packethdr/suricata.yaml
+++ b/tests/output-eve-anomaly-packethdr/suricata.yaml
@@ -7,5 +7,6 @@ outputs:
       filetype: regular
       types:
         - anomaly:
-            protodecode: yes
+            types:
+              packet: yes
             packethdr: yes            # enable dumping of packet header

--- a/tests/output-eve-anomaly/suricata.yaml
+++ b/tests/output-eve-anomaly/suricata.yaml
@@ -7,4 +7,5 @@ outputs:
       filetype: regular
       types:
         - anomaly:
-            protodecode: yes
+            types:
+              packet: yes


### PR DESCRIPTION
This PR is dependent on [Suricata #4100](https://github.com/OISF/suricata/pull/4100) and provides updates per the configuration changes in that PR.

Both PRs are required for successful tests.