### PR TITLE
tests: add test case for file_data depth inspection

### DIFF
--- a/tests/file-data-depth-inspection/test.rules
+++ b/tests/file-data-depth-inspection/test.rules
@@ -1,0 +1,1 @@
+alert tcp any any -> any 25 (msg:"VIRUS INBOUND bad file attachment"; flow:to_server,established; content:"content-disposition|3a| attachment|3b|"; nocase; content:".zip|22|"; nocase; within:128; file_data; content:".pdf.exe"; within:64; sid:13371339; rev:1;)

--- a/tests/file-data-depth-inspection/test.yaml
+++ b/tests/file-data-depth-inspection/test.yaml
@@ -1,0 +1,10 @@
+requires:
+    features:
+        - HAVE_LIBJANSSON
+
+checks:
+    - filter:
+        count: 1
+        match:
+            event_type: alert
+            alert.signature_id: 13371339


### PR DESCRIPTION
This is a test case which currently doesn't generate an alert although it should. PCAP is from https://redmine.openinfosecfoundation.org/issues/2395 as well as the rule but removed some unnecessary parts from the rule (like classification).