### PR TITLE
tests: file_data depth inspection should keep working with other rules

### DIFF
--- a/tests/file-data-depth-inspection/test.rules
+++ b/tests/file-data-depth-inspection/test.rules
@@ -1,1 +1,4 @@
+# should match:
 alert tcp any any -> any 25 (msg:"VIRUS INBOUND bad file attachment"; flow:to_server,established; content:"content-disposition|3a| attachment|3b|"; nocase; content:".zip|22|"; nocase; within:128; file_data; content:".pdf.exe"; within:64; sid:13371339; rev:1;)
+# should match:
+alert tcp any any -> any any (msg:"ATTACK-RESPONSES directory listing"; flow:established; content:"Volume Serial Number"; sid:13371338; rev:1;)

--- a/tests/file-data-depth-inspection/test.yaml
+++ b/tests/file-data-depth-inspection/test.yaml
@@ -8,3 +8,8 @@ checks:
         match:
             event_type: alert
             alert.signature_id: 13371339
+    - filter:
+        count: 1
+        match:
+            event_type: alert
+            alert.signature_id: 13371338


### PR DESCRIPTION
see https://redmine.openinfosecfoundation.org/issues/3190