### PR TITLE
Give test count as output not check count

### DIFF
--- a/run.py
+++ b/run.py
@@ -606,6 +606,10 @@ class TestRunner:
         count = StatsCheck(check, self.output).run()
         return count
 
+    def reset_count(self, dictionary):
+        for k in dictionary.keys():
+            dictionary[k] = 0
+
     def check(self):
         pdir = os.getcwd()
         os.chdir(self.output)
@@ -618,6 +622,7 @@ class TestRunner:
         try:
             self.pre_check()
             if "checks" in self.config:
+                self.reset_count(count)
                 for check_count, check in enumerate(self.config["checks"]):
                     for key in check:
                         if key in ["filter", "shell", "stats"]:
@@ -867,9 +872,12 @@ def main():
             cwd, dirpath, outdir, suricata_config, args.verbose)
         try:
             results = test_runner.run()
-            passed += results["success"]
-            failed += results["failure"]
-            skipped += results["skipped"]
+            if results["failure"] > 0:
+                failed += 1
+            elif results["skipped"] > 0:
+                skipped += 1
+            elif results["success"] > 0:
+                passed += 1
         except UnsatisfiedRequirementError as ue:
             print("SKIPPED: {}".format(ue))
             skipped += 1


### PR DESCRIPTION
With the current setup, after running suricata-verify, the output would
give stats about the passed, failed or skipped checks. However, it is
cleaner to get the total stats about tests only.

The priority order for the output is:
FAILED
SKIPPED
PASSED

i.e. if a check or sub-test has failed, the entire test will be counted
as failed in the final output. Similarly, if a check has been skipped,
the entire test will be counted as skipped in the final output.

Closes redmine ticket: https://redmine.openinfosecfoundation.org/issues/3172