### PR TITLE
test: add test for checking sip alerts

### DIFF
--- a/tests/sip-inspection-id/README.md
+++ b/tests/sip-inspection-id/README.md
@@ -1,0 +1,1 @@
+The purpose of this test is to check that with OISF/suricata#4330 PR the correct numbers of alert related to SIP are logged.

--- a/tests/sip-inspection-id/test.rules
+++ b/tests/sip-inspection-id/test.rules
@@ -1,0 +1,1 @@
+alert sip any any -> any any (flow:to_server; sip.method; content:"REGISTER"; sid:1;)

--- a/tests/sip-inspection-id/test.yaml
+++ b/tests/sip-inspection-id/test.yaml
@@ -1,0 +1,20 @@
+requires:
+  features:
+    - HAVE_LIBJANSSON
+  min-version: 5.0.0
+
+args:
+  - -k none
+  - --set app-layer.protocols.sip.enabled=yes
+  - --set eve-log.types.sip.enabled=yes
+
+pcap: ../sip-method/sip.pcap
+
+checks:
+  - filter:
+      count: 18
+      match:
+        event_type: alert
+        src_ip: 192.168.1.2
+        dest_ip: 212.242.33.35
+        alert.signature_id: 1


### PR DESCRIPTION
The purpose of this test is to check that with OISF/suricata#4330 PR the
correct numbers of alert related to SIP are logged.