### PR TITLE
tests: fix sip tests

### DIFF
--- a/tests/sip-method/test.yaml
+++ b/tests/sip-method/test.yaml
@@ -11,6 +11,6 @@ pcap: sip.pcap
 
 checks:
   - filter:
-      count: 36
+      count: 18
       match:
         event_type: alert

--- a/tests/sip-request-line/test.yaml
+++ b/tests/sip-request-line/test.yaml
@@ -11,6 +11,6 @@ pcap: ../sip-method/sip.pcap
 
 checks:
   - filter:
-      count: 36
+      count: 18
       match:
         event_type: alert

--- a/tests/sip-response-line/test.yaml
+++ b/tests/sip-response-line/test.yaml
@@ -11,6 +11,6 @@ pcap: ../sip-method/sip.pcap
 
 checks:
   - filter:
-      count: 5
+      count: 3
       match:
         event_type: alert

--- a/tests/sip-uri/test.yaml
+++ b/tests/sip-uri/test.yaml
@@ -11,6 +11,6 @@ pcap: ../sip-method/sip.pcap
 
 checks:
   - filter:
-      count: 36
+      count: 18
       match:
         event_type: alert


### PR DESCRIPTION
The correct numbers of alerts logged is not correct and OISF/suricata#4330
fixes this issue, so this commit fixes tests that are broken.

I removed the test added previously, because it's a duplicate of sip-method test.

Previous PR: #156 