### PR TITLE
tests: bug-3490 requires a min-version

### DIFF
--- a/tests/bug-3490/test.yaml
+++ b/tests/bug-3490/test.yaml
@@ -1,4 +1,6 @@
 requires:
+  min-version: 6.0.0
+
   # No pcap required.
   pcap: false
 


### PR DESCRIPTION
The test-case for bug-3490 only applies to Suricata versions 6.0 and later.

REQUIRED for https://github.com/OISF/suricata/pull/4619