### PR TITLE
Fixes/windows/v7

### DIFF
--- a/run.py
+++ b/run.py
@@ -91,7 +91,7 @@ SuricataVersion = namedtuple(
     "SuricataVersion", ["major", "minor", "patch"])
 
 def parse_suricata_version(buf):
-    m = re.search("(\d+)\.?(\d+)?\.?(\d+)?.*", str(buf).strip())
+    m = re.search("(?:Suricata version |^)(\d+)\.?(\d+)?\.?(\d+)?.*", str(buf).strip())
     if m:
         major = int(m.group(1)) if m.group(1) else 0
         minor = int(m.group(2)) if m.group(2) else 0

--- a/run.py
+++ b/run.py
@@ -409,6 +409,8 @@ class TestRunner:
         for skip in self.config["skip"]:
 
             if "uid" in skip:
+                if WIN32:
+                    raise UnsatisfiedRequirementError("uid based skip not supported on Windows")
                 if os.getuid() == skip["uid"]:
                     if "msg" in skip:
                         msg = skip["msg"]


### PR DESCRIPTION
Windows (related) fixes. Skip tests using 'uid' requirement. Improve version checks to deal with unexpected leading data.