### PR TITLE
tests: mark 2 smb file tests as requiring rust

### DIFF
--- a/tests/filestore-filecontainer-smb/test.yaml
+++ b/tests/filestore-filecontainer-smb/test.yaml
@@ -2,6 +2,7 @@ requires:
   features:
     - HAVE_NSS
     - MAGIC
+    - HAVE_RUST
   files:
     - src/output-filestore.c
 

--- a/tests/smb-eicar-file/test.yaml
+++ b/tests/smb-eicar-file/test.yaml
@@ -1,6 +1,7 @@
 requires:
   features:
     - HAVE_LIBJANSSON
+    - HAVE_RUST
 
 # disables checksum verification
 args:


### PR DESCRIPTION
- filestore-container-smb
- smb-eicar-file