### PR TITLE
tests: add tests for issue 3515

### DIFF
--- a/tests/bug-3515/test.rules
+++ b/tests/bug-3515/test.rules
@@ -1,0 +1,1 @@
+alert tcp any any -> any any (msg:"Test rule"; sid:1;)

--- a/tests/bug-3515/test.yaml
+++ b/tests/bug-3515/test.yaml
@@ -1,0 +1,12 @@
+requires:
+  # No pcap required.
+  pcap: false
+  min-version: 6
+
+args:
+  - --engine-analysis --set decoder.erspan.typeI.enabled=true
+
+checks:
+    - shell:
+        args: grep "SC_WARN_ERSPAN_CONFIG" suricata.log | wc -l | xargs
+        expect: 1


### PR DESCRIPTION
Requires [Suricata PR#4861](https://github.com/OISF/suricata/pull/4861)

Ensure that warning is issued if a conf setting for ERSPAN Type I exists.