### PR TITLE
framework: new requires: lt-version (less than version)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -58,6 +58,7 @@ jobs:
       - run: cargo install --force cbindgen
       - run: echo "::add-path::$HOME/.cargo/bin"
       - uses: actions/checkout@v1
+      - run: python3 ./run.py --self-test
       - run: git clone https://github.com/OISF/suricata -b ${{ matrix.branch }}
       - run: git clone https://github.com/OISF/libhtp suricata/libhtp
       - name: Build Suricata

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -55,7 +55,7 @@ jobs:
                 software-properties-common \
                 zlib1g \
                 zlib1g-dev
-      - run: cargo install --force cbindgen
+      - run: cargo install --force --debug cbindgen
       - run: echo "::add-path::$HOME/.cargo/bin"
       - uses: actions/checkout@v1
       - run: python3 ./run.py --self-test

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ requires:
   # Require a minimum version of Suricata.
   min-version: 4.1.0
 
+  # Require that the Suricata version be less than a version.
+  lt-version: 6
+
   # Test is only for this version. For example, 4.0 would match any 4.0 
   # release, but 4.0.3 would only match 4.0.3.
   version: 4.0

--- a/run.py
+++ b/run.py
@@ -62,24 +62,24 @@ class SelfTest(unittest.TestCase):
 
         version = parse_suricata_version("4")
         self.assertEqual(
-            (4, None, None), (version.major, version.minor, version.patch))
+            (4, 0, 0), (version.major, version.minor, version.patch))
 
         version = parse_suricata_version("4.0.3")
         self.assertEqual(
             (4, 0, 3), (version.major, version.minor, version.patch))
 
     def test_version_equal(self):
-        self.assertTrue(version_equal("4", "4.0.3"))
-        self.assertTrue(version_equal("4.0", "4.0.3"))
-        self.assertTrue(version_equal("4.0.3", "4.0.3"))
+        self.assertTrue(Version().is_equal(SuricataVersion(5, 0, 0), SuricataVersion(5, 0, 0)))
+        self.assertTrue(Version().is_equal(SuricataVersion(5, 1, 0), SuricataVersion(5, None, None)))
+        self.assertFalse(Version().is_equal(SuricataVersion(4, 1, 0), SuricataVersion(5, None, None)))
 
-        self.assertTrue(version_equal("4.0.3", "4"))
-        self.assertTrue(version_equal("4.0.3", "4.0"))
-        self.assertTrue(version_equal("4.0.3", "4.0.3"))
-
-        self.assertFalse(version_equal("3", "4.0.3"))
-        self.assertFalse(version_equal("4.0", "4.1.3"))
-        self.assertFalse(version_equal("4.0.2", "4.0.3"))
+    def test_version_lt(self):
+        comp = Version()
+        self.assertTrue(comp.is_lt(SuricataVersion(5, 0, 3), SuricataVersion(6, None, None)))
+        self.assertTrue(comp.is_lt(SuricataVersion(6, 0, 0), SuricataVersion(6, 0, 1)))
+        self.assertTrue(comp.is_lt(SuricataVersion(6, 0, 0), SuricataVersion(6, 1, 1)))
+        self.assertFalse(comp.is_lt(SuricataVersion(6, 1, 2), SuricataVersion(6, 1, 1)))
+        self.assertTrue(comp.is_lt(SuricataVersion(6, 0, 0), SuricataVersion(7, 0, 0)))
 
 class TestError(Exception):
     pass
@@ -835,8 +835,13 @@ def main():
                         help="Outputs to custom directory")
     parser.add_argument("--valgrind", dest="valgrind", action="store_true",
                         help="Run tests in with valgrind")
+    parser.add_argument("--self-test", action="store_true",
+                        help="Run self tests")
     parser.add_argument("patterns", nargs="*", default=[])
     args = parser.parse_args()
+
+    if args.self_test:
+        return unittest.main(argv=[sys.argv[0]])
 
     TOPDIR = os.path.abspath(os.path.dirname(sys.argv[0]))
 

--- a/run.py
+++ b/run.py
@@ -181,6 +181,15 @@ class Version:
 
         return True
 
+    def is_lt(self, v1, v2):
+        """Return True if v1 is less than v2."""
+        if v1.major < v2.major:
+            return True
+        elif v1.minor < v2.minor:
+            return True
+        elif v1.patch < v2.patch:
+            return True
+        return False
 
 class SuricataConfig:
 
@@ -453,6 +462,12 @@ class TestRunner:
                         suri_version=suri_version, expr="gte"):
                     raise UnsatisfiedRequirementError(
                             "requires at least version {}".format(min_version))
+            elif key == "lt-version":
+                lt_version = requires["lt-version"]
+                if not is_version_compatible(version=lt_version,
+                        suri_version=suri_version, expr="lt"):
+                    raise UnsatisfiedRequirementError(
+                            "for version less than {}".format(lt_version))
             elif key == "version":
                 req_version = requires["version"]
                 if not is_version_compatible(version=req_version,

--- a/tests/filestore-ftp-active-mode/suricata.yaml
+++ b/tests/filestore-ftp-active-mode/suricata.yaml
@@ -1,6 +1,10 @@
 %YAML 1.1
 ---
 
+requires:
+  features:
+    - HAVE_NSS
+
 pcap-file:
     checksum-checks: no
 

--- a/tests/filestore-ftp-passive-mode/test.yaml
+++ b/tests/filestore-ftp-passive-mode/test.yaml
@@ -1,5 +1,7 @@
 requires:
   min-version: 4.1.0
+  features:
+    - HAVE_NSS
 
 checks:
   - shell:

--- a/tests/filestore-v1-stream-depth/test.yaml
+++ b/tests/filestore-v1-stream-depth/test.yaml
@@ -2,6 +2,7 @@ requires:
   features:
     - HAVE_LIBJANSSON
   min-version: 5.0.0
+  lt-version: 6
 
 args:
   - -k none


### PR DESCRIPTION
Implement a less than version requirement. Can be used prevent a test running on versions 6 and newer like required in https://github.com/OISF/suricata-verify/pull/195.

Other changes:
- Fix the self unit tests to run.
- Add a command line option to run the self unit tests.
- Run the self unit tests in GitHub CI on push
- Set a lt-version for filestore v1 tests.