### PR TITLE
tests/bsize Add test cases for bsize

### DIFF
--- a/tests/detect-bsize-01/test.rules
+++ b/tests/detect-bsize-01/test.rules
@@ -1,0 +1,6 @@
+alert http any any -> any any (msg:"bsize test TEST"; http.uri; content:"abcdefgh123456"; bsize:2; sid:1; rev:1;)
+alert http any any -> any any (msg:"bsize test TEST"; http.uri; content:"abcdefgh123456"; bsize:>2; sid:2; rev:1;)
+alert http any any -> any any (msg:"bsize test TEST"; http.uri; content:"abcdefgh123456"; bsize:<13; sid:3; rev:1;)
+alert http any any -> any any (msg:"bsize test TEST"; http.uri; content:"abcdefgh123456"; bsize:>15; sid:4; rev:1;)
+alert http any any -> any any (msg:"bsize test TEST"; http.uri; content:"abcdefgh123456"; bsize:10<>15; sid:5; rev:1;)
+

--- a/tests/detect-bsize-01/test.yaml
+++ b/tests/detect-bsize-01/test.yaml
@@ -1,0 +1,25 @@
+requires:
+    min-version: 6.0.0
+    pcap: false
+
+args:
+    - --engine-analysis
+
+exit-code: 1
+
+checks:
+    - shell:
+        args: grep "SC_ERR_INVALID_SIGNATURE" suricata.log | wc -l | xargs
+        expect: 6
+
+    - shell:
+        args: grep "bsize match impossible.*content len 14 and bsize op '=' values lo=2; hi=0" suricata.log | wc -l | xargs
+        expect: 1
+
+    - shell:
+        args: grep "bsize match impossible.*content len 14 and bsize op '<' values lo=13; hi=0" suricata.log | wc -l | xargs
+        expect: 1
+
+    - shell:
+        args: grep "bsize match impossible.*content len 14 and bsize op '>' values lo=15; hi=0" suricata.log | wc -l | xargs
+        expect: 1


### PR DESCRIPTION
This commit adds several test cases for the `bsize` keyword.

[Suricata PR #4949](https://github.com/OISF/suricata/pull/4949)