### PR TITLE
Fixes http sticky server test with gaps

### DIFF
--- a/tests/http-sticky-server/test.yaml
+++ b/tests/http-sticky-server/test.yaml
@@ -5,7 +5,7 @@ requires:
 
 checks:
   - filter:
-      count: 28
+      count: 29
       match:
         event_type: alert
         alert.signature_id: 2


### PR DESCRIPTION
Needs https://github.com/OISF/suricata/pull/4951 and https://github.com/OISF/libhtp/pull/296

There should be 29 alerts and not only 28 (as you can count in the pcap with `grep -a Omniture http-sticky-server.pcap | wc -l`

The missed alert is at packet 8363 (cf Wireshark filter `tcp.port == 56401`), due to missing first request packet

