### PR TITLE
snmp rdp alert metadata/v1

### DIFF
--- a/tests/rdp-protocol/suricata.yaml
+++ b/tests/rdp-protocol/suricata.yaml
@@ -7,6 +7,7 @@ outputs:
       filetype: regular
       filename: eve.json
       types:
+        - alert
         - rdp
         - flow
 

--- a/tests/rdp-protocol/test.rules
+++ b/tests/rdp-protocol/test.rules
@@ -1,0 +1,1 @@
+alert rdp any any -> any any (msg:"TEST RDP RULE"; sid:1; rev:1;)

--- a/tests/rdp-protocol/test.yaml
+++ b/tests/rdp-protocol/test.yaml
@@ -35,3 +35,11 @@ checks:
         rdp.channels[0]: "rdpdr"
         rdp.channels[1]: "cliprdr"
         rdp.channels[2]: "rdpsnd"
+  - filter:
+      count: 1
+      match:
+        event_type: "alert"
+        pcap_cnt: 5
+        rdp.tx_id: 0
+        rdp.event_type: "initial_request"
+        rdp.cookie: "A70067"

--- a/tests/snmp-v2c-get/test.rules
+++ b/tests/snmp-v2c-get/test.rules
@@ -1,0 +1,1 @@
+alert snmp any any -> any any (msg:"TEST SNMP ALERT"; sid:1; rev:1;)

--- a/tests/snmp-v2c-get/test.yaml
+++ b/tests/snmp-v2c-get/test.yaml
@@ -32,3 +32,12 @@ checks:
        snmp.community: "[R0_C@cti!]"
        snmp.version: 2
        snmp.vars: ["0.1"]
+ - filter:
+     count: 1
+     match:
+       event_type: alert
+       pcap_cnt: 7
+       snmp.version: 2
+       snmp.pdu_type: get_request
+       snmp.vars[0]: "1.3.6.1.2.1.31.1.1.1.6.1"
+       snmp.community: "[R0_C@cti!]"


### PR DESCRIPTION
- snmp-v2c-get: test snmp metadata in alert
- rdp-protocol: test rdp metadata in alert

Requires Suricata PR.
