### PR TITLE
tests: Skip obsoleted standalone output test on 6+

### DIFF
--- a/tests/dns-json-log/test.yaml
+++ b/tests/dns-json-log/test.yaml
@@ -1,3 +1,4 @@
 requires:
+  lt-version: 6
   features:
     - HAVE_LIBJANSSON


### PR DESCRIPTION
This commit restricts the test case to versions less than 6. It's been
deprecated in 6.0+