### PR TITLE
smb-eicar-file: check files array

### DIFF
--- a/tests/smb-eicar-file/test.yaml
+++ b/tests/smb-eicar-file/test.yaml
@@ -13,3 +13,12 @@ checks:
       match:
         event_type: alert
         alert.signature_id: 1
+
+  # Check for something in the files array, which is an array of
+  # fileinfo objects.
+  - filter:
+      min-version: 6.0.0
+      count: 1
+      match:
+        event_type: alert
+        files[0].filename: "\\eicar"


### PR DESCRIPTION
Add a check for the files array to make sure it exists
and has a filename.

Only applicable to v6.0.0+.

Requires: https://github.com/OISF/suricata/pull/5419