### PR TITLE
Bug fix 3201/v1

### DIFF
--- a/run.py
+++ b/run.py
@@ -32,14 +32,14 @@ import threading
 import shutil
 import string
 import argparse
-import yaml
+#import yaml
 import glob
 import re
 import json
 import unittest
 from collections import namedtuple
 
-import yaml
+#import yaml
 
 WIN32 = sys.platform == "win32"
 suricata_bin = "src\suricata.exe" if WIN32 else "./src/suricata"
@@ -284,12 +284,14 @@ class ShellCheck:
         try:
             if WIN32:
                 print("skipping shell check on windows")
-                return True;
+                return False;
             output = subprocess.check_output(self.config["args"], shell=True)
             if "expect" in self.config:
                 return str(self.config["expect"]) == output.decode().strip()
             return True
         except subprocess.CalledProcessError as err:
+            raise TestError(err)
+        else:
             raise TestError(err)
 
 class StatsCheck:

--- a/run.py
+++ b/run.py
@@ -32,14 +32,14 @@ import threading
 import shutil
 import string
 import argparse
-#import yaml
+import yaml
 import glob
 import re
 import json
 import unittest
 from collections import namedtuple
 
-#import yaml
+import yaml
 
 WIN32 = sys.platform == "win32"
 suricata_bin = "src\suricata.exe" if WIN32 else "./src/suricata"


### PR DESCRIPTION
Fix Bug #3201 

Description:
If a shell check fails without the TestError exception, it is counted as success. This is incorrect.

What I did:
 I set return to False in the try block and added an else block to raise TestError.