### PR TITLE
createst: add exclude-fields option

### DIFF
--- a/createst.py
+++ b/createst.py
@@ -189,6 +189,8 @@ def get_manipulated_list():
     mentioned in `skip_fields` variable.
     """
     eve_path = os.path.join(test_dir, "output", "eve.json")
+    exclude_fields = args["exclude_fields"].strip().split(",") if args["exclude_fields"] else []
+    skip_fields.extend(exclude_fields)
     allow_events = args["allow_events"].strip().split(",") if args["allow_events"] else []
     with open(eve_path, "r") as fp:
         content = fp.read()
@@ -344,6 +346,8 @@ def parse_args():
                         help="Create filter blocks for the specified events")
     parser.add_argument("--strictcsums", default=None, action="store_true",
                         help="Stricly validate checksum")
+    parser.add_argument("--exclude-fields", nargs="?", default=None,
+                        help="Exclude specified fields from filter block")
 
     # add arg to allow stdout only
     args = parser.parse_args()


### PR DESCRIPTION
Adds the --exclude-fields option to exclude specified fields from the filter blocks.

Link to redmine ticket: https://redmine.openinfosecfoundation.org/issues/4062

`createst.py mytest mypcap --exclude-fields dest_port, src_port`

Before : 
```
requires:
  min-version: 5.0.0
  features:
    - HAVE_LIBJANSSON

args:
 - -k none

checks:
- filter:
    count: 1
    match:
      alert:
        action: allowed
        category: access to a potentially vulnerable web application
        gid: 1
        rev: 1
        severity: 2
        signature: no1
        signature_id: 9000000
      app_proto: http
      dest_ip: 10.100.0.8
      dest_port: 44270
      event_type: alert
      http:
        hostname: www.abcdefghij.com
        http_content_type: text/html
        http_method: GET
        http_refer: http://www.abcdefghij.com/abdeltat/login
        http_user_agent: Mozilla/5.0 (X11; U; Linux i686; fr; rv:1.9.0.6) Gecko/2009011912
          Firefox/3.0.6
        length: 1483
        protocol: HTTP/1.1
        status: 401
        url: /publication/pub.home/home.html
      pcap_cnt: 14
      proto: TCP
      src_ip: 162.2.41.200
      src_port: 80
```

After : 
```
requires:
  min-version: 5.0.0
  features:
    - HAVE_LIBJANSSON

args:
 - -k none

checks:
- filter:
    count: 1
    match:
      alert:
        action: allowed
        category: access to a potentially vulnerable web application
        gid: 1
        rev: 1
        severity: 2
        signature: no1
        signature_id: 9000000
      app_proto: http
      dest_ip: 10.100.0.8
      event_type: alert
      http:
        hostname: www.abcdefghij.com
        http_content_type: text/html
        http_method: GET
        http_refer: http://www.abcdefghij.com/abdeltat/login
        http_user_agent: Mozilla/5.0 (X11; U; Linux i686; fr; rv:1.9.0.6) Gecko/2009011912
          Firefox/3.0.6
        length: 1483
        protocol: HTTP/1.1
        status: 401
        url: /publication/pub.home/home.html
      pcap_cnt: 14
      proto: TCP
      src_ip: 162.2.41.200
```

