### PR TITLE
Task 3144/v1 Add dir as a visual indicator in the output

### DIFF
--- a/run.py
+++ b/run.py
@@ -536,7 +536,8 @@ class TestRunner:
 
     def run(self):
 
-        sys.stdout.write("===> %s: " % os.path.basename(self.directory))
+        directory_and_name = os.path.join(os.path.basename(os.path.dirname(self.directory)), self.name)
+        sys.stdout.write("===> %s: " % directory_and_name)
         sys.stdout.flush()
 
         if not self.force:

--- a/run.py
+++ b/run.py
@@ -535,9 +535,8 @@ class TestRunner:
                     raise UnsatisfiedRequirementError("No pcap file found")
 
     def run(self):
-
-        directory_and_name = os.path.join(os.path.basename(os.path.dirname(self.directory)), self.name)
-        sys.stdout.write("===> %s: " % directory_and_name)
+        directory_and_name = os.path.join(os.path.basename(os.path.dirname(self.directory)), self.name)
+        sys.stdout.write("===> %s: " % directory_and_name)
         sys.stdout.flush()
 
         if not self.force:


### PR DESCRIPTION
Add dir as a visual indicator in the output
The output of `suricata-verify` should be `$dirname/$testname` and not just `$testname`.
https://redmine.openinfosecfoundation.org/issues/3144

Previous output sample:
===> datasets-04-http-dns: OK
===> datasets-05-state: OK
===> datasets-state-isnotset: SKIPPED: requires feature HAVE_NSS
===> dce-gap-handling: OK
===> dce-logging: OK
===> dcerpc-dce-iface-01: OK
===> dcerpc-dce-iface-02: OK
===> dcerpc-dce-iface-03: OK
===> dcerpc-dce-iface-04: OK
===> dcerpc-dce-opnum: OK
===> dcerpc-dcepayload: OK
===> decode-chdlc-01: OK
===> decode-erspan-typeI-01: OK

After commit:
===> tests/datasets-04-http-dns: OK
===> tests/datasets-05-state: OK
===> tests/datasets-state-isnotset: SKIPPED: requires feature HAVE_NSS
===> dcerpc/dce-gap-handling: OK
===> dcerpc/dce-logging: OK
===> dcerpc/dcerpc-dce-iface-01: OK
===> dcerpc/dcerpc-dce-iface-02: OK
===> dcerpc/dcerpc-dce-iface-03: OK
===> dcerpc/dcerpc-dce-iface-04: OK
===> dcerpc/dcerpc-dce-opnum: OK
===> dcerpc/dcerpc-dcepayload: OK
===> tests/decode-chdlc-01: OK
===> tests/decode-erspan-typeI-01: OK
