### PR TITLE
createst: commandline param to specify required features

### DIFF
--- a/createst.py
+++ b/createst.py
@@ -344,6 +344,7 @@ def parse_args():
                         help="Create filter blocks for the specified events")
     parser.add_argument("--strictcsums", default=None, action="store_true",
                         help="Stricly validate checksum")
+    parser.add_argument("--features", type=str, action="store_true", required=True, help="Include features defined globally")
 
     # add arg to allow stdout only
     args = parser.parse_args()


### PR DESCRIPTION
It should be possible to define multiple features.

Link to redmine ticket: https://redmine.openinfosecfoundation.org/issues/4061

`createst.py mytest mypcap --features HAVE_LUA,HAVE_LIBJANSSON`

The final generated test.yaml should have features defined globally.

```
requires:
  features:
    - HAVE_LIBJANSSON
    - HAVE_LUA
  version: 6.0.0

checks:
- filter:
    count: 1
```