### PR TITLE
createst: add add-min-version option

### DIFF
--- a/createst.py
+++ b/createst.py
@@ -143,6 +143,8 @@ def write_to_file(data):
         fp.write("# *** Add configuration here ***\n\n")
         if not args["strictcsums"]:
             fp.write("args:\n- -k none\n\n")
+        if args["add_min_version"]:
+            fp.write("requires:\n   min-version: %s\n\n" % args["add_min_version"])
         fp.write(data)
 
 
@@ -344,6 +346,8 @@ def parse_args():
                         help="Create filter blocks for the specified events")
     parser.add_argument("--strictcsums", default=None, action="store_true",
                         help="Stricly validate checksum")
+    parser.add_argument("--add-min-version", default=None, metavar="<min-version>",
+                        help="Adds a global minimum required version")
 
     # add arg to allow stdout only
     args = parser.parse_args()


### PR DESCRIPTION
Current createst script generates only the filter blocks as per eve.json, extend its functionality to add a global minimum required version of Suricata as mentioned on command line.

The final generated test.yaml should have a min suricata version defined globally.

Link to redmine ticket: https://redmine.openinfosecfoundation.org/issues/4060

Usage : `createst.py mytest mypcap --add-min-version 5.0`

Before:
```
requires:
  features:
    - HAVE_LIBJANSSON

checks:
- filter:
    count: 1
    match:
      event_type: alert
      alert.signature_id: 4
```

After:
```
requires:
  features:
    - HAVE_LIBJANSSON
  min-version: 6.0.0

checks:
- filter:
    count: 1
    match:
      event_type: alert
      alert.signature_id: 4
```