### PR TITLE
createst: commandline param to specify required features

### DIFF
--- a/createst.py
+++ b/createst.py
@@ -143,8 +143,8 @@ def write_to_file(data):
         fp.write("# *** Add configuration here ***\n\n")
         if not args["strictcsums"]:
             fp.write("args:\n- -k none\n\n")
-		if args["features"]:
-			fp.write("requires:\n  features: %s\n\n" % args["features"])
+        if args["features"]:
+            fp.write("requires:\n features: %s\n\n" % args["features"])
         fp.write(data)
 
 
@@ -345,9 +345,9 @@ def parse_args():
     parser.add_argument("--allow-events", nargs="?", default=None,
                         help="Create filter blocks for the specified events")
     parser.add_argument("--strictcsums", default=None, action="store_true",
-                        help="Stricly validate checksum")
-	parser.add_argument("--features", default=None, action="store_true", required=True, metavar="<features>",
-                        help="Includes features defined globally")
+                        help="Stricly validate checksum") 
+    parser.add_argument("--features", default=None, action="store_true", required=True, mdtavar="<features>", 
+                        help="Includes features defined globally" )
 
     # add arg to allow stdout only
     args = parser.parse_args()

--- a/createst.py
+++ b/createst.py
@@ -143,6 +143,8 @@ def write_to_file(data):
         fp.write("# *** Add configuration here ***\n\n")
         if not args["strictcsums"]:
             fp.write("args:\n- -k none\n\n")
+		if args["features"]:
+			fp.write("requires:\n  features: %s\n\n" % args["features"])
         fp.write(data)
 
 
@@ -344,6 +346,8 @@ def parse_args():
                         help="Create filter blocks for the specified events")
     parser.add_argument("--strictcsums", default=None, action="store_true",
                         help="Stricly validate checksum")
+	parser.add_argument("--features", default=None, action="store_true", required=True, metavar="<features>",
+                        help="Includes features defined globally")
 
     # add arg to allow stdout only
     args = parser.parse_args()

--- a/createst.py
+++ b/createst.py
@@ -346,7 +346,7 @@ def parse_args():
                         help="Create filter blocks for the specified events")
     parser.add_argument("--strictcsums", default=None, action="store_true",
                         help="Stricly validate checksum") 
-    parser.add_argument("--features", default=None, action="store_true", required=True, mdtavar="<features>", 
+    parser.add_argument("--features", default=None, action="store_true", required=True, metavar="<features>",
                         help="Includes features defined globally" )
 
     # add arg to allow stdout only


### PR DESCRIPTION
It should be possible to define multiple features.

Link to redmine ticket: https://redmine.openinfosecfoundation.org/issues/4061

createst.py mytest mypcap --features HAVE_LUA,HAVE_LIBJANSSON

The final generated test.yaml should have features defined globally.

```
requires:
  features:
    - HAVE_LIBJANSSON
    - HAVE_LUA
  version: 6.0.0

checks:
- filter:
    count: 1
```