### PR TITLE
Http2 keywords v3

### DIFF
--- a/tests/http2-basic/test.rules
+++ b/tests/http2-basic/test.rules
@@ -2,3 +2,9 @@ alert http2 any any -> any any (http2.header; content:"agent: nghttp2"; sid:1; r
 alert http2 any any -> any any (http2.frametype:GOAWAY; sid:2; rev:1;)
 alert http2 any any -> any any (http2.settings:SETTINGS_HEADER_TABLE_SIZE>1000; sid:3; rev:1;)
 alert http2 any any -> any any (http2.window:34634; sid:4; rev:1;)
+
+alert http any any -> any any (http.uri; content:"/doc/manual/html/index.html"; sid:10;)
+alert http1 any any -> any any (http.uri; content:"/doc/manual/html/index.html"; sid:11;)
+alert http2 any any -> any any (http.uri; content:"/doc/manual/html/index.html"; sid:12;)
+alert tcp any any -> any any (http.uri; content:"/doc/manual/html/index.html"; sid:13;)
+alert ip any any -> any any (http.uri; content:"/doc/manual/html/index.html"; sid:14;)

--- a/tests/http2-basic/test.yaml
+++ b/tests/http2-basic/test.yaml
@@ -69,3 +69,29 @@ checks:
       match:
         event_type: alert
         alert.signature_id: 4
+  # HTTP generic keywords with HTTP2 traffic
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 10
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+        alert.signature_id: 11
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 12
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 13
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 14

--- a/tests/http2-upgrade/test.rules
+++ b/tests/http2-upgrade/test.rules
@@ -1,3 +1,5 @@
 alert http1 any any -> any any (http.uri; content:"/robots.txt"; sid:10;)
 alert http2 any any -> any any (http.uri; content:"/robots.txt"; sid:11;)
 alert http any any -> any any (http.uri; content:"/robots.txt"; sid:12;)
+
+alert http2 any any -> any any (http.user_agent; content:"curl"; sid:20;)

--- a/tests/http2-upgrade/test.rules
+++ b/tests/http2-upgrade/test.rules
@@ -1,0 +1,3 @@
+alert http1 any any -> any any (http.uri; content:"/robots.txt"; sid:10;)
+alert http2 any any -> any any (http.uri; content:"/robots.txt"; sid:11;)
+alert http any any -> any any (http.uri; content:"/robots.txt"; sid:12;)

--- a/tests/http2-upgrade/test.yaml
+++ b/tests/http2-upgrade/test.yaml
@@ -66,3 +66,8 @@ checks:
       match:
         event_type: alert
         alert.signature_id: 12
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 20

--- a/tests/http2-upgrade/test.yaml
+++ b/tests/http2-upgrade/test.yaml
@@ -50,3 +50,19 @@ checks:
         http.http_method: "GET"
         http.url: "/humans.txt"
         http.status: 404
+# checks for http.uti keyword : 1 for HTTP1, 1 for mimicked HTTP2 response, so 2 for whole HTTP
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 10
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 11
+  - filter:
+      count: 2
+      match:
+        event_type: alert
+        alert.signature_id: 12


### PR DESCRIPTION
Replaces #382 with added check for `http.user_agent` keyword

needs next version of OISF/suricata#5660