### PR TITLE
Opt 3973 /v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ checks:
       # A shell check that also tests the output of the command.
       args: cat fast.log | wc -l | xargs
       expect: 1
+
+  - file-compare:
+      # A check that compares two files
+      filename: datasets.csv
+      expected: expected/datasets.csv
 ```		
 
 ## Adding a new test the automated way: createst

--- a/tests/datasets-01/check.sh
+++ b/tests/datasets-01/check.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec cmp datasets.csv ${TEST_DIR}/expected/datasets.csv

--- a/tests/datasets-01/test.yaml
+++ b/tests/datasets-01/test.yaml
@@ -7,3 +7,8 @@ command: |
       --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR}         \
       -c "${SRCDIR}/suricata.yaml" -r ${TEST_DIR}/input.pcap -S ${TEST_DIR}/test.rules  \
       --data-dir="${OUTPUT_DIR}"
+
+checks:
+  - file-compare:
+      filename: datasets.csv
+      expected: expected/datasets.csv


### PR DESCRIPTION
Some tests use a check.sh script to run "cmp" on 2 files to check that they are the same. This could be converted to an internal check and become part of test.yaml.

Link to redmine ticket: https://redmine.openinfosecfoundation.org/issues/3973

Example test: output-tcp-data

Possible YAML syntax for test.yaml:
```
checks:
  - file-compare:
      filename: tcp-data.log
      expected: expected/tcp-data.log
```