### PR TITLE
Validate eve.json output /v5

### DIFF
--- a/check-eve.py
+++ b/check-eve.py
@@ -1,0 +1,122 @@
+#! /usr/bin/env python3
+#
+# Copyright (C) 2021 Open Information Security Foundation
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import sys
+import os
+import os.path
+import argparse
+import json
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+
+def validate_json(args, dirpath, schema, isDirectory):
+    json_filename = dirpath
+    if isDirectory:
+        json_filename = os.path.join(dirpath, 'eve.json')
+        
+    testname = dirpath
+    if "suricata-verify" in dirpath:
+        testname = os.path.basename(os.path.dirname(dirpath))
+
+    status = "OK"
+    errors = []
+
+    with open(json_filename) as f:
+        for line in f:
+            obj = json.loads(line)
+            try:
+                validate(instance = obj, schema=schema)
+            except ValidationError as err:
+                status = "FAIL"
+                errors.append(err.message)
+    
+    if not args.quiet:
+        if status == "FAIL":
+            print("===> %s: FAIL " % testname)
+
+            for err in errors:
+                print(err)
+        elif args.verbose:
+            print("===> %s: OK " % testname)
+
+    return status
+        
+def main():
+    global args
+
+    parser = argparse.ArgumentParser(description="Validation schema")
+    parser.add_argument("-v", dest="verbose", action="store_true")
+    parser.add_argument("file", nargs="?", default=[])
+    parser.add_argument("-q", dest="quiet", action="store_true")
+    args = parser.parse_args()
+    TOPDIR = os.path.abspath(os.path.dirname(sys.argv[0]))
+    tdir = os.path.join(TOPDIR, "tests")
+
+    json_path = "{}/schema.json".format(TOPDIR)
+    schema = json.load(open(json_path))
+
+    checked = 0
+    passed = 0
+    failed = 0
+
+    isDirectory = True
+    argfile = args.file
+    
+    if argfile:
+        # if the argument is a single file
+        if os.path.isfile(argfile):
+            isDirectory = False
+            status = validate_json(args, argfile, schema, isDirectory)
+            checked += 1
+            if status == "OK":
+                passed += 1
+            else:
+                failed += 1
+
+        # if the argument is a directory
+        elif os.path.isdir(argfile):
+            tdir = argfile
+           
+    if isDirectory:
+        # os.walk for eve.json files and validate each one
+        for dirpath, dirnames, filenames in os.walk(tdir):
+            if 'eve.json' in filenames:
+                status = validate_json(args, dirpath, schema, isDirectory)
+                checked += 1
+                if status == "OK":
+                    passed += 1
+                else:
+                    failed += 1
+
+    if not args.quiet:
+        print("CHECKED: %d" % (checked))
+        print("PASSED:  %d" % (passed))
+        print("FAILED:  %d" % (failed))
+
+    if failed > 0:
+        return 1
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/run.py
+++ b/run.py
@@ -40,7 +40,7 @@ import unittest
 import multiprocessing as mp
 from collections import namedtuple
 import threading
-
+import subprocess
 import yaml
 
 WIN32 = sys.platform == "win32"
@@ -872,6 +872,9 @@ def run_test(dirpath, args, cwd, suricata_config):
         elif results["success"] > 0:
             with lock:
                 count_dict["passed"] += 1
+        check_output = subprocess.call(["../suricata-verify/check-eve.py", outdir, "-q"])
+        if check_output == 0:
+            raise TestError("Invalid JSON schema")
     except UnsatisfiedRequirementError as ue:
         print("===> {}: SKIPPED: {}".format(os.path.basename(dirpath), ue))
         with lock:

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,103 @@
+{
+    "type": "object",
+    "properties": {
+        "timestamp": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+[+\\-]\\d+$",
+            "optional": false
+        },
+        "flow_id": {
+            "type": "integer",
+            "optional": true
+        },
+        "pcap_cnt": {
+            "type": "integer",
+            "optional": true
+        },
+        "event_type": {
+            "type": "string",
+            "optional": false
+        },
+        "vlan": {
+            "type": "array",
+            "items": {
+                "type": "number"
+            }
+        },
+        "src_ip": {
+            "type": "string",
+            "optional": true
+        },
+        "src_port": {
+            "type": "integer",
+            "optional": true
+        },
+        "dest_ip": {
+            "type": "string",
+            "optional": true
+        },
+        "dest_port": {
+            "type": "integer",
+            "optional": true
+        },
+        "proto": {
+            "type": "string",
+            "optional": true
+        },
+        "http": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "hostname": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "http_user_agent": {
+                    "type": "string"
+                },
+                "http_content_type": {
+                    "type": "string"
+                },
+                "http_method": {
+                    "type": "string"
+                },
+                "protocol": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "integer"
+                },
+                "length": {
+                    "type": "integer"
+                }
+            }
+        },
+        "app_proto": {
+            "type": "string",
+            "optional": true
+        },
+        "fileinfo": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "filename": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string"
+                },
+                "stored": {
+                    "type": "boolean"
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "tx_id": {
+                    "type": "integer"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Validates eve.json output using JSON schema.

Link to redmine ticket: https://redmine.openinfosecfoundation.org/issues/1369

Changes from last PR : #440

- Added `--quiet `to suppress all output
- Resolved path errors
- Threw error in `run.py` if `check-eve.py` exited with error
- Broke commit into 3 