### PR TITLE
pcrexform: test becomes obsolete in version 7

### DIFF
--- a/tests/detect-pcrexform-03/test.yaml
+++ b/tests/detect-pcrexform-03/test.yaml
@@ -1,4 +1,5 @@
 requires:
+  lt-version: 7
 
   files:
     - src/detect-transform-pcrexform.c


### PR DESCRIPTION
converted to a unit test failing to load the signature