### PR TITLE
http-sha256-drop-02: don't use flow_id in test

### DIFF
--- a/tests/bug-78-http-uri/test.yaml
+++ b/tests/bug-78-http-uri/test.yaml
@@ -22,6 +22,10 @@ checks:
         pkts_toclient: 2
         pkts_toserver: 4
         start: 2009-10-16T16:44:16.083524+0000
+        src_ip: 192.168.2.3
+        src_port: 37010
+        dest_ip: 208.69.36.231
+        dest_port: 80
       http:
         hostname: www.google.com
         http_content_type: text/html

--- a/tests/bug-78-uricontent/test.yaml
+++ b/tests/bug-78-uricontent/test.yaml
@@ -22,6 +22,10 @@ checks:
         pkts_toclient: 2
         pkts_toserver: 4
         start: 2009-10-16T16:44:16.083524+0000
+        src_ip: 192.168.2.3
+        src_port: 37010
+        dest_ip: 208.69.36.231
+        dest_port: 80
       http:
         hostname: www.google.com
         http_content_type: text/html

--- a/tests/http-sha256-drop-02/test.yaml
+++ b/tests/http-sha256-drop-02/test.yaml
@@ -27,10 +27,15 @@ checks:
         alert.signature_id: 2
         pcap_cnt: 103
   - filter:
-      count: 8
+      count: 3
       match:
         event_type: drop
-        flow_id: 746850855319537
+        src_port: 35824
+  - filter:
+      count: 4
+      match:
+        event_type: drop
+        dest_port: 35824
   - filter:
       count: 1
       match:
@@ -44,7 +49,12 @@ checks:
         alert.signature_id: 3
         pcap_cnt: 135
   - filter:
+      count: 1
+      match:
+        event_type: drop
+        src_port: 35820
+  - filter:
       count: 7
       match:
         event_type: drop
-        flow_id: 948787333709074
+        dest_port: 35820


### PR DESCRIPTION
flow_id has no reason to be fix from a user perspective so we
should not use it in test but use information from the flow
itself.