### PR TITLE
Pcre2 3194 v2

### DIFF
--- a/tests/detect-pcrexform-03/test.yaml
+++ b/tests/detect-pcrexform-03/test.yaml
@@ -1,4 +1,5 @@
 requires:
+  lt-version: 7
 
   files:
     - src/detect-transform-pcrexform.c

--- a/tests/threshold-config-validate-02/test.yaml
+++ b/tests/threshold-config-validate-02/test.yaml
@@ -7,7 +7,7 @@ command: |
 checks:
 
     - shell:
-        args: grep -e "pcre_exec parse error, ret -1, string this is not correct" suricata.log | wc -l | xargs
+        args: grep -e "SC_ERR_PCRE_MATCH" suricata.log | wc -l | xargs
         expect: 1
 
     - shell:


### PR DESCRIPTION
Modifies #480 with adapting the threshold-config-validate-02 test to work for both PCRE1 and PCRE2

cc @jlucovsky for the threshold.config test change

see https://github.com/OISF/suricata/pull/6138
