### PR TITLE
Make HTTP2 test work on version 6

### DIFF
--- a/tests/http2-bugfixes/test.yaml
+++ b/tests/http2-bugfixes/test.yaml
@@ -1,11 +1,11 @@
 requires:
   features:
     - HAVE_LIBJANSSON
-  min-version: 7.0.0
+  min-version: 6.0.0
 
 # disables checksum verification
 args:
-  - -k none
+  - -k none --set app-layer.protocols.http2.http1-rules=true
 
 checks:
 


### PR DESCRIPTION
Replaces #503 with using `app-layer.protocols.http2.http1-rules` for config