### PR TITLE
test/mqtt: add sid to mqtt-binary-message rule

### DIFF
--- a/tests/mqtt-binary-message/test.rules
+++ b/tests/mqtt-binary-message/test.rules
@@ -1,1 +1,1 @@
-alert mqtt any any -> any any (msg:"MQTT PUBLISH JPEG message"; mqtt.type:PUBLISH; mqtt.publish.message; content:"|FF D8 FF E0|"; startswith; fast_pattern;)
+alert mqtt any any -> any any (msg:"MQTT PUBLISH JPEG message"; mqtt.type:PUBLISH; mqtt.publish.message; content:"|FF D8 FF E0|"; startswith; fast_pattern; sid:1;)


### PR DESCRIPTION
mqtt-binary-message: add sid to rule in test.rules

After adding a fix to [bug-4491](https://redmine.openinfosecfoundation.org/issues/4491), suricata checks began to fail, because mqtt-binary-message test.rules' rule was missing sid field.