### PR TITLE
mqtt: add suricata.yaml enabling MQTT for testing

### DIFF
--- a/tests/mqtt-events-invalid-qos/suricata.yaml
+++ b/tests/mqtt-events-invalid-qos/suricata.yaml
@@ -1,0 +1,17 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - mqtt
+        - alert
+        - anomaly
+
+app-layer:
+  protocols:
+    mqtt:
+      enabled: yes

--- a/tests/mqtt-events-missing-connect/suricata.yaml
+++ b/tests/mqtt-events-missing-connect/suricata.yaml
@@ -1,0 +1,17 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - mqtt
+        - alert
+        - anomaly
+
+app-layer:
+  protocols:
+    mqtt:
+      enabled: yes

--- a/tests/mqtt-events-unassigned-msgtype/suricata.yaml
+++ b/tests/mqtt-events-unassigned-msgtype/suricata.yaml
@@ -1,0 +1,17 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - mqtt
+        - alert
+        - anomaly
+
+app-layer:
+  protocols:
+    mqtt:
+      enabled: yes

--- a/tests/mqtt-events-unintroduced/suricata.yaml
+++ b/tests/mqtt-events-unintroduced/suricata.yaml
@@ -1,0 +1,17 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - mqtt
+        - alert
+        - anomaly
+
+app-layer:
+  protocols:
+    mqtt:
+      enabled: yes


### PR DESCRIPTION
This PR ensures that the MQTT app-layer parser is always enabled in the MQTT tests, See https://github.com/OISF/suricata/pull/6229#issuecomment-867926602