### PR TITLE
runner: unify requirements check between test-case and filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,12 @@ checks:
   # A verification filter that is run over the eve.json. Multiple
   # filters may exist and all must pass for the test to pass.
   - filter:
-      # Additional feature needed to run this specific filter
-      feature: HTTP2_DECOMPRESSION
+
+      # Requires that apply just to this check. Has all the same options
+      # as the test level requires above.
+      requires:
+        features:
+          - HTTP2_DECOMPRESSION
 
       # The number of records this filter should match.
       count: 1

--- a/run.py
+++ b/run.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 #
-# Copyright (C) 2017-2020 Open Information Security Foundation
+# Copyright (C) 2017-2021 Open Information Security Foundation
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
@@ -554,21 +554,6 @@ class TestRunner:
                     except:
                         raise UnsatisfiedRequirementError(
                             "requires script returned false")
-
-            elif key == "config":
-                for pattern, need_val in requires["config"].items():
-                    found = False
-                    for key, val in self.suricata_config.config.items():
-                        if re.match(pattern, key):
-                            print("%s -> %s" % (pattern, key))
-                            if str(need_val) != str(val):
-                                raise UnsatisfiedRequirementError(
-                                    "requires %s = %s" % (
-                                        key, need_val))
-                    print(found)
-                    if not found:
-                        raise UnsatisfiedRequirementError(
-                            "requires %s = %s" % (pattern, need_val))
 
             elif key == "pcap":
                 # Handle below...

--- a/tests/http2-bugfixes/test.yaml
+++ b/tests/http2-bugfixes/test.yaml
@@ -16,14 +16,16 @@ checks:
         event_type: anomaly
 # check gzip decompresser
   - filter:
-      feature: HTTP2_DECOMPRESSION
+      requires:
+        features: [HTTP2_DECOMPRESSION]
       count: 1
       match:
         event_type: fileinfo
         fileinfo.size: 639
 # check brotli decompresser
   - filter:
-      feature: HTTP2_DECOMPRESSION
+      requires:
+        features: [HTTP2_DECOMPRESSION]
       count: 1
       match:
         event_type: fileinfo


### PR DESCRIPTION
Re-use the test-case requirements check at the per-check level. This means there is parity between the features that can be used.

I converted one test to use the proper format, but the runner has been updated to handle the old way of specifying per-check requirements as well.
