### PR TITLE
filestore-stream-depth: fix test for 6.0.x

### DIFF
--- a/tests/filestore-v2.7-stream-depth/test.yaml
+++ b/tests/filestore-v2.7-stream-depth/test.yaml
@@ -12,7 +12,7 @@ checks:
 
   - filter:
       requires:
-        version: 7
+        min-version: 6
       count: 1
       match:
         event_type: fileinfo
@@ -21,7 +21,7 @@ checks:
         fileinfo.size: 99400
   - filter:
       requires:
-        lt-version: 7
+        lt-version: 6
       count: 1
       match:
         event_type: fileinfo


### PR DESCRIPTION
Goes w Suricata PR: 