### PR TITLE
6.0.x fixes/v1

### DIFF
--- a/tests/issue-3703/test.yaml
+++ b/tests/issue-3703/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 7
+  min-version: 6
   features:
     - HAVE_NSS
     - MAGIC

--- a/tests/krb5-probing/test.yaml
+++ b/tests/krb5-probing/test.yaml
@@ -2,7 +2,7 @@ requires:
   features:
     - HAVE_LIBJANSSON
     - RUST
-  min-version: 7
+  min-version: 6
 
 args:
   - -k none

--- a/tests/smb-eicar-overlap/test.yaml
+++ b/tests/smb-eicar-overlap/test.yaml
@@ -1,7 +1,7 @@
 requires:
   features:
     - HAVE_LIBJANSSON
-  min-version: 7
+  min-version: 6
 
 # disables checksum verification
 args:

--- a/tests/smb-eicar-padding/test.yaml
+++ b/tests/smb-eicar-padding/test.yaml
@@ -1,7 +1,7 @@
 requires:
   features:
     - HAVE_LIBJANSSON
-  min-version: 7
+  min-version: 6
 
 # disables checksum verification
 args:


### PR DESCRIPTION
Set min-version to 6 for commits already backported and merged.
Corresponding issues:
https://redmine.openinfosecfoundation.org/issues/2809
https://redmine.openinfosecfoundation.org/issues/3703
https://redmine.openinfosecfoundation.org/issues/3475