### PR TITLE
dcerpc-iface-01: update alert count to also match response

### DIFF
--- a/tests/dcerpc/dcerpc-dce-iface-01/test.yaml
+++ b/tests/dcerpc/dcerpc-dce-iface-01/test.yaml
@@ -7,7 +7,7 @@ args:
 
 checks:
   - filter:
-      count: 1
+      count: 2
       match:
         event_type: alert
         alert.signature_id: 1


### PR DESCRIPTION
Update to the dcerpc-iface-01 test as required by https://github.com/OISF/suricata/pull/6511 since this fix makes dcerpc responses to also match with dce_iface, which is the intended behaviour.