### PR TITLE
GitHub ci jsonschema/v4

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -59,6 +59,7 @@ jobs:
                 libjansson-dev \
                 libpython2.7 \
                 libnss3-dev \
+                libssl-dev \
                 make \
                 parallel \
                 python3-distutils \
@@ -71,6 +72,10 @@ jobs:
       - run: cargo install --force --debug cbindgen
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v2
+      - name: Build jsonschema-rs-iter
+        working-directory: jsonschema-rs-iter
+        run: |
+          cargo install --path .
       - run: python3 ./run.py --self-test
       - run: git clone https://github.com/OISF/suricata -b ${{ matrix.branch }}
       - run: git clone https://github.com/OISF/libhtp suricata/libhtp
@@ -123,6 +128,7 @@ jobs:
                 libevent-devel \
                 libmaxminddb-devel \
                 libpcap-devel \
+                openssl-devel \
                 libtool \
                 lz4-devel \
                 make \
@@ -141,6 +147,10 @@ jobs:
       - run: cargo install --force --debug cbindgen
       - run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v2
+      - name: Build jsonschema-rs-iter
+        working-directory: jsonschema-rs-iter
+        run: |
+          cargo install --path .
       - run: python3 ./run.py --self-test
       - run: git clone https://github.com/OISF/suricata -b ${{ matrix.branch }}
       - run: git clone https://github.com/OISF/libhtp suricata/libhtp

--- a/jsonschema-rs-iter/Cargo.toml
+++ b/jsonschema-rs-iter/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "jsonschema-rs-iter"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+jsonschema = "0.13"
+structopt = {version = ">= 0.3"}
+serde_json = "1"

--- a/jsonschema-rs-iter/src/main.rs
+++ b/jsonschema-rs-iter/src/main.rs
@@ -1,0 +1,89 @@
+use std::{error::Error, fs, path::PathBuf, process};
+
+use jsonschema::JSONSchema;
+use structopt::StructOpt;
+
+type BoxErrorResult<T> = Result<T, Box<dyn Error>>;
+
+use std::fs::File;
+use std::io::BufReader;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "jsonschema")]
+struct Cli {
+    /// A path to a JSON instance (i.e. filename.json) to validate (may be specified multiple times).
+    #[structopt(short = "i", long = "instance")]
+    instances: Option<Vec<PathBuf>>,
+
+    /// The JSON Schema to validate with (i.e. schema.json).
+    #[structopt(parse(from_os_str), required_unless("version"))]
+    schema: Option<PathBuf>,
+
+    /// Show program's version number and exit.
+    #[structopt(short = "v", long = "version")]
+    version: bool,
+}
+
+pub fn main() -> BoxErrorResult<()> {
+    let config = Cli::from_args();
+
+    if config.version {
+        println!("Version: {}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
+    let mut success = true;
+    if let Some(schema) = config.schema {
+        if let Some(instances) = config.instances {
+            success = validate_instances(&instances, schema)?;
+        }
+    }
+
+    if !success {
+        process::exit(1);
+    }
+
+    Ok(())
+}
+
+fn validate_instances(instances: &[PathBuf], schema: PathBuf) -> BoxErrorResult<bool> {
+    let mut success = true;
+
+    let schema_json = fs::read_to_string(schema)?;
+    let schema_json = serde_json::from_str(&schema_json)?;
+    match JSONSchema::compile(&schema_json) {
+        Ok(schema) => {
+            for instance in instances {
+                let instance_path_name = instance.to_str().unwrap();
+                let file = File::open(instance_path_name)?;
+                let reader = BufReader::new(file);
+                let deserializer = serde_json::Deserializer::from_reader(reader);
+                let iterator = deserializer.into_iter::<serde_json::Value>();
+                let mut success_i = true;
+                for item in iterator {
+                    let instance_json = item?;
+                    let validation = schema.validate(&instance_json);
+                    match validation {
+                        Ok(_) => {}
+                        Err(errors) => {
+                            success = false;
+                            success_i = false;
+                            println!("{} - INVALID. Errors:", instance_path_name);
+                            for (i, e) in errors.enumerate() {
+                                println!("{}.{} {}", i + 1, e.instance_path, e);
+                            }
+                        }
+                    }
+                }
+                if success_i {
+                    println!("{} - VALID", instance_path_name);
+                }
+            }
+        }
+        Err(error) => {
+            println!("Schema is invalid. Error: {}", error);
+            success = false;
+        }
+    }
+    Ok(success)
+}

--- a/run.py
+++ b/run.py
@@ -933,7 +933,8 @@ def main():
     if args.self_test:
         return unittest.main(argv=[sys.argv[0]])
 
-    print("Warning: EVE files will not be valided: jsonschema module not found.")
+    if not VALIDATE_EVE:
+        print("Warning: EVE files will not be valided: jsonschema module not found.")
 
     TOPDIR = os.path.abspath(os.path.dirname(sys.argv[0]))
 

--- a/run.py
+++ b/run.py
@@ -46,8 +46,10 @@ import yaml
 
 # Check if we can validate EVE files against the schema.
 try:
-    import jsonschema
     VALIDATE_EVE = True
+    check_output = subprocess.run(["jsonschema-rs-iter", "-v"], capture_output=True)
+    if check_output.returncode != 0:
+        VALIDATE_EVE = False
 except:
     VALIDATE_EVE = False
 
@@ -934,7 +936,7 @@ def main():
         return unittest.main(argv=[sys.argv[0]])
 
     if not VALIDATE_EVE:
-        print("Warning: EVE files will not be valided: jsonschema module not found.")
+        print("Warning: EVE files will not be valided: jsonschema-rs-iter program not found.")
 
     TOPDIR = os.path.abspath(os.path.dirname(sys.argv[0]))
 

--- a/schema.json
+++ b/schema.json
@@ -1421,6 +1421,18 @@
                 "state": {
                     "type": "string"
                 },
+                "magic": {
+                    "type": "string"
+                },
+                "md5": {
+                    "type": "string"
+                },
+                "sha1": {
+                    "type": "string"
+                },
+                "sha256": {
+                    "type": "string"
+                },
                 "stored": {
                     "type": "boolean"
                 },
@@ -1428,6 +1440,9 @@
                     "type": "integer"
                 },
                 "tx_id": {
+                    "type": "integer"
+                },
+                "file_id": {
                     "type": "integer"
                 },
                 "gaps": {
@@ -1446,7 +1461,7 @@
                     }
                 }
             },
-            "additionalProperties": true
+            "additionalProperties": false
         }
     },
     "additionalProperties": true

--- a/schema.json
+++ b/schema.json
@@ -1272,6 +1272,57 @@
                 "status": {
                     "type": "integer"
                 },
+                "http_refer": {
+                    "type": "string"
+                },
+                "redirect": {
+                    "type": "string"
+                },
+                "xff": {
+                    "type": "string"
+                },
+                "http_port": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "request_headers": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            },
+                            "table_size_update": {
+                                "type": "integer"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "response_headers": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            },
+                            "table_size_update": {
+                                "type": "integer"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
                 "length": {
                     "type": "integer"
                 },
@@ -1291,10 +1342,70 @@
                             "type": "integer"
                         }
                     },
-                    "additionalProperties": true
+                    "additionalProperties": false
+                },
+                "http2": {
+                    "type": "object",
+                    "properties": {
+                        "stream_id": {
+                            "type": "integer"
+                        },
+                        "request": {
+                            "type": "object",
+                            "properties": {
+                                "settings": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "settings_id": {
+                                                "type": "string"
+                                            },
+                                            "settings_value": {
+                                                "type": "integer"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "priority": {
+                                    "type": "integer"
+                                },
+                                "error_code": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "response": {
+                            "type": "object",
+                            "properties": {
+                                "settings": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "settings_id": {
+                                                "type": "string"
+                                            },
+                                            "settings_value": {
+                                                "type": "integer"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "error_code": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "additionalProperties": false
                 }
             },
-            "additionalProperties": true
+            "additionalProperties": false
         },
         "app_proto": {
             "type": "string",

--- a/schema.json
+++ b/schema.json
@@ -48,6 +48,18 @@
             "type": "integer",
             "optional": true
         },
+        "icmp_code": {
+            "type": "integer"
+        },
+        "icmp_type": {
+            "type": "integer"
+        },
+        "response_icmp_code": {
+            "type": "integer"
+        },
+        "response_icmp_type": {
+            "type": "integer"
+        },
         "flow": {
             "type": "object",
             "optional": true,
@@ -1583,7 +1595,2880 @@
                 }
             },
             "additionalProperties": false
+        },
+        "dns": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "rrname": {
+                    "type": "string"
+                },
+                "rrtype": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "answer": {
+                    "type": "object",
+                    "properties": {
+                        "version": {
+                            "type": "integer"
+                        },
+                        "id": {
+                            "type": "integer"
+                        },
+                        "flags": {
+                            "type": "string"
+                        },
+                        "qr": {
+                            "type": "boolean"
+                        },
+                        "rd": {
+                            "type": "boolean"
+                        },
+                        "ra": {
+                            "type": "boolean"
+                        },
+                        "rrname": {
+                            "type": "string"
+                        },
+                        "rrtype": {
+                            "type": "string"
+                        },
+                        "rcode": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "authorities": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "optional": true,
+                        "properties": {
+                            "rrname": {
+                                "type": "string"
+                            },
+                            "rrtype": {
+                                "type": "string"
+                            },
+                            "ttl": {
+                                "type": "integer"
+                            },
+                            "soa": {
+                                "type": "object",
+                                "optional": true,
+                                "properties": {
+                                    "minimum": {
+                                        "type": "integer"
+                                    },
+                                    "mname": {
+                                        "type": "string"
+                                    },
+                                    "refresh": {
+                                        "type": "integer"
+                                    },
+                                    "retry": {
+                                        "type": "integer"
+                                    },
+                                    "rname": {
+                                        "type": "string"
+                                    },
+                                    "serial": {
+                                        "type": "integer"
+                                    },
+                                    "expire": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            "rdata": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "ra": {
+                    "type": "boolean"
+                },
+                "rd": {
+                    "type": "boolean"
+                },
+                "aa": {
+                    "type": "boolean"
+                },
+                "answers": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "optional": true,
+                        "properties": {
+                            "rrname": {
+                                "type": "string"
+                            },
+                            "rrtype": {
+                                "type": "string"
+                            },
+                            "ttl": {
+                                "type": "integer"
+                            },
+                            "srv": {
+                                "type": "object",
+                                "optional": true,
+                                "properties": {
+                                    "port": {
+                                        "type": "integer"
+                                    },
+                                    "priority": {
+                                        "type": "integer"
+                                    },
+                                    "weight": {
+                                        "type": "integer"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            "rdata": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "flags": {
+                    "type": "string"
+                },
+                "grouped": {
+                    "type": "object",
+                    "optional": true,
+                    "properties": {
+                        "PTR": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "TXT": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "CNAME": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "MX": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "NULL": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "AAAA": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "SRV": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "optional": true,
+                                "properties": {
+                                    "port": {
+                                        "type": "integer"
+                                    },
+                                    "priority": {
+                                        "type": "integer"
+                                    },
+                                    "weight": {
+                                        "type": "integer"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                },
+                                "additionalProperties": false
+                            }
+                        },
+                        "A": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "qr": {
+                    "type": "boolean"
+                },
+                "rcode": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "integer"
+                },
+                "query": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "optional": true,
+                        "properties": {
+                            "rrname": {
+                                "type": "string"
+                            },
+                            "rrtype": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            },
+                            "id": {
+                                "type": "integer"
+                            },
+                            "tx_id": {
+                                "type": "integer"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "tx_id": {
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false
+        },
+        "drop": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "ack": {
+                    "type": "boolean"
+                },
+                "icmp_id": {
+                    "type": "integer"
+                },
+                "icmp_seq": {
+                    "type": "integer"
+                },
+                "ipid": {
+                    "type": "integer"
+                },
+                "len": {
+                    "type": "integer"
+                },
+                "tos": {
+                    "type": "integer"
+                },
+                "ttl": {
+                    "type": "integer"
+                },
+                "psh": {
+                    "type": "boolean"
+                },
+                "rst": {
+                    "type": "boolean"
+                },
+                "urg": {
+                    "type": "boolean"
+                },
+                "syn": {
+                    "type": "boolean"
+                },
+                "tcpack": {
+                    "type": "integer"
+                },
+                "tcpres": {
+                    "type": "integer"
+                },
+                "tcpseq": {
+                    "type": "integer"
+                },
+                "tcpurgp": {
+                    "type": "integer"
+                },
+                "tcpwin": {
+                    "type": "integer"
+                },
+                "fin": {
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
+        },
+        "alert": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "action": {
+                    "type": "string"
+                },
+                "severity": {
+                    "type": "integer"
+                },
+                "signature": {
+                    "type": "string"
+                },
+                "signature_id": {
+                    "type": "integer"
+                },
+                "gid": {
+                    "type": "integer"
+                },
+                "rev": {
+                    "type": "integer"
+                },
+                "source": {
+                    "type": "object",
+                    "properties": {
+                        "ip": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "rule": {
+                    "type": "string"
+                },
+                "target": {
+                    "type": "object",
+                    "properties": {
+                        "ip": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "metadata": {
+                    "type": "object",
+                    "properties": {
+                        "created_at": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "tag": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "affected_product": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "attack_target": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "deployment": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "signature_severity": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "updated_at": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "category": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "anomaly": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "event": {
+                    "type": "string"
+                },
+                "layer": {
+                    "type": "string"
+                },
+                "app_proto": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "app_proto_orig": {
+            "type": "string"
+        },
+        "log_level": {
+            "type": "string"
+        },
+        "app_proto_tc": {
+            "type": "string"
+        },
+        "app_proto_ts": {
+            "type": "string"
+        },
+        "app_proto_expected": {
+            "type": "string"
+        },
+        "community_id": {
+            "type": "string"
+        },
+        "engine": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "error_code": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "ether": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "dest_mac": {
+                    "type": "string"
+                },
+                "src_mac": {
+                    "type": "string"
+                },
+                "dest_macs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "src_macs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "metadata": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "flowbits": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "flowvars": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            },
+                            "gid": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": true
+                    }
+                },
+                "pktvars": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "username": {
+                                "type": "string"
+                            },
+                            "uid": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "flowints": {
+                    "type": "object",
+                    "additionalProperties": true
+                }
+            },
+            "additionalProperties": false
+        },
+        "mqtt": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "publish": {
+                    "type": "object",
+                    "properties": {
+                        "dup": {
+                            "type": "boolean"
+                        },
+                        "retain": {
+                            "type": "boolean"
+                        },
+                        "qos": {
+                            "type": "integer"
+                        },
+                        "message_id": {
+                            "type": "integer"
+                        },
+                        "skipped_length": {
+                            "type": "integer"
+                        },
+                        "truncated": {
+                            "type": "boolean"
+                        },
+                        "message": {
+                            "type": "string"
+                        },
+                        "topic": {
+                            "type": "string"
+                        },
+                        "properties": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "connect": {
+                    "type": "object",
+                    "properties": {
+                        "dup": {
+                            "type": "boolean"
+                        },
+                        "retain": {
+                            "type": "boolean"
+                        },
+                        "qos": {
+                            "type": "integer"
+                        },
+                        "password": {
+                            "type": "string"
+                        },
+                        "protocol_string": {
+                            "type": "string"
+                        },
+                        "username": {
+                            "type": "string"
+                        },
+                        "client_id": {
+                            "type": "string"
+                        },
+                        "flags": {
+                            "type": "object",
+                            "properties": {
+                                "clean_session": {
+                                    "type": "boolean"
+                                },
+                                "password": {
+                                    "type": "boolean"
+                                },
+                                "username": {
+                                    "type": "boolean"
+                                },
+                                "will": {
+                                    "type": "boolean"
+                                },
+                                "will_retain": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "protocol_version": {
+                            "type": "integer"
+                        },
+                        "will": {
+                            "type": "object",
+                            "properties": {
+                                "message": {
+                                    "type": "string"
+                                },
+                                "topic": {
+                                    "type": "string"
+                                },
+                                "properties": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "properties": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "pingreq": {
+                    "type": "object",
+                    "properties": {
+                        "dup": {
+                            "type": "boolean"
+                        },
+                        "retain": {
+                            "type": "boolean"
+                        },
+                        "qos": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "pingresp": {
+                    "type": "object",
+                    "properties": {
+                        "dup": {
+                            "type": "boolean"
+                        },
+                        "retain": {
+                            "type": "boolean"
+                        },
+                        "qos": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "connack": {
+                    "type": "object",
+                    "properties": {
+                        "dup": {
+                            "type": "boolean"
+                        },
+                        "retain": {
+                            "type": "boolean"
+                        },
+                        "qos": {
+                            "type": "integer"
+                        },
+                        "return_code": {
+                            "type": "integer"
+                        },
+                        "session_present": {
+                            "type": "boolean"
+                        },
+                        "properties": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "unsuback": {
+                    "type": "object",
+                    "properties": {
+                        "dup": {
+                            "type": "boolean"
+                        },
+                        "retain": {
+                            "type": "boolean"
+                        },
+                        "qos": {
+                            "type": "integer"
+                        },
+                        "message_id": {
+                            "type": "integer"
+                        },
+                        "reason_codes": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "unsubscribe": {
+                    "type": "object",
+                    "properties": {
+                        "dup": {
+                            "type": "boolean"
+                        },
+                        "retain": {
+                            "type": "boolean"
+                        },
+                        "qos": {
+                            "type": "integer"
+                        },
+                        "message_id": {
+                            "type": "integer"
+                        },
+                        "topics": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "suback": {
+                    "type": "object",
+                    "properties": {
+                        "dup": {
+                            "type": "boolean"
+                        },
+                        "retain": {
+                            "type": "boolean"
+                        },
+                        "qos": {
+                            "type": "integer"
+                        },
+                        "message_id": {
+                            "type": "integer"
+                        },
+                        "qos_granted": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "subscribe": {
+                    "type": "object",
+                    "properties": {
+                        "dup": {
+                            "type": "boolean"
+                        },
+                        "retain": {
+                            "type": "boolean"
+                        },
+                        "qos": {
+                            "type": "integer"
+                        },
+                        "message_id": {
+                            "type": "integer"
+                        },
+                        "topics": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "qos": {
+                                        "type": "integer"
+                                    },
+                                    "topic": {
+                                        "type": "string"
+                                    }
+                                },
+                                "additionalProperties": false
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "puback": {
+                    "type": "object",
+                    "properties": {
+                        "dup": {
+                            "type": "boolean"
+                        },
+                        "retain": {
+                            "type": "boolean"
+                        },
+                        "qos": {
+                            "type": "integer"
+                        },
+                        "message_id": {
+                            "type": "integer"
+                        },
+                        "reason_code": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "pubcomp": {
+                    "type": "object",
+                    "properties": {
+                        "dup": {
+                            "type": "boolean"
+                        },
+                        "retain": {
+                            "type": "boolean"
+                        },
+                        "qos": {
+                            "type": "integer"
+                        },
+                        "message_id": {
+                            "type": "integer"
+                        },
+                        "reason_code": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "pubrec": {
+                    "type": "object",
+                    "properties": {
+                        "dup": {
+                            "type": "boolean"
+                        },
+                        "retain": {
+                            "type": "boolean"
+                        },
+                        "qos": {
+                            "type": "integer"
+                        },
+                        "message_id": {
+                            "type": "integer"
+                        },
+                        "reason_code": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "pubrel": {
+                    "type": "object",
+                    "properties": {
+                        "dup": {
+                            "type": "boolean"
+                        },
+                        "retain": {
+                            "type": "boolean"
+                        },
+                        "qos": {
+                            "type": "integer"
+                        },
+                        "message_id": {
+                            "type": "integer"
+                        },
+                        "reason_code": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "disconnect": {
+                    "type": "object",
+                    "properties": {
+                        "reason_code": {
+                            "type": "integer"
+                        },
+                        "dup": {
+                            "type": "boolean"
+                        },
+                        "retain": {
+                            "type": "boolean"
+                        },
+                        "qos": {
+                            "type": "integer"
+                        },
+                        "properties": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "ftp_data": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "command": {
+                    "type": "string"
+                },
+                "filename": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "xff": {
+            "type": "string"
+        },
+        "command": {
+            "type": "string"
+        },
+        "filename": {
+            "type": "string"
+        },
+        "parent_id": {
+            "type": "integer"
+        },
+        "packet": {
+            "type": "string"
+        },
+        "spi": {
+            "type": "integer"
+        },
+        "files": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "optional": true,
+                "properties": {
+                    "filename": {
+                        "type": "string"
+                    },
+                    "md5": {
+                        "type": "string"
+                    },
+                    "sha1": {
+                        "type": "string"
+                    },
+                    "sha256": {
+                        "type": "string"
+                    },
+                    "start": {
+                        "type": "integer"
+                    },
+                    "end": {
+                        "type": "integer"
+                    },
+                    "gaps": {
+                        "type": "boolean"
+                    },
+                    "sid": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "size": {
+                        "type": "integer"
+                    },
+                    "stored": {
+                        "type": "boolean"
+                    },
+                    "tx_id": {
+                        "type": "integer"
+                    },
+                    "state": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "netflow": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "age": {
+                    "type": "integer"
+                },
+                "bytes": {
+                    "type": "integer"
+                },
+                "end": {
+                    "type": "string"
+                },
+                "max_ttl": {
+                    "type": "integer"
+                },
+                "min_ttl": {
+                    "type": "integer"
+                },
+                "pkts": {
+                    "type": "integer"
+                },
+                "start": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "packet_info": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "linktype": {
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false
+        },
+        "tunnel": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "src_ip": {
+                    "type": "string"
+                },
+                "src_port": {
+                    "type": "integer"
+                },
+                "dest_ip": {
+                    "type": "string"
+                },
+                "dest_port": {
+                    "type": "integer"
+                },
+                "proto": {
+                    "type": "string"
+                },
+                "depth": {
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false
+        },
+        "traffic": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "id": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "label": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "dcerpc": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "request": {
+                    "type": "string"
+                },
+                "interfaces": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "uuid": {
+                                "type": "string"
+                            },
+                            "version": {
+                                "type": "string"
+                            },
+                            "ack_result": {
+                                "type": "integer"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "response": {
+                    "type": "string"
+                },
+                "call_id": {
+                    "type": "integer"
+                },
+                "req": {
+                    "type": "object",
+                    "optional": true,
+                    "properties": {
+                        "frag_cnt": {
+                            "type": "integer"
+                        },
+                        "opnum": {
+                            "type": "integer"
+                        },
+                        "stub_data_size": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "res": {
+                    "type": "object",
+                    "optional": true,
+                    "properties": {
+                        "frag_cnt": {
+                            "type": "integer"
+                        },
+                        "stub_data_size": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "rpc_version": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "krb5": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "msg_type": {
+                    "type": "string"
+                },
+                "failed_request": {
+                    "type": "string"
+                },
+                "error_code": {
+                    "type": "string"
+                },
+                "cname": {
+                    "type": "string"
+                },
+                "realm": {
+                    "type": "string"
+                },
+                "sname": {
+                    "type": "string"
+                },
+                "encryption": {
+                    "type": "string"
+                },
+                "weak_encryption": {
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
+        },
+        "rfb": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "screen_shared": {
+                    "type": "boolean"
+                },
+                "authentication": {
+                    "type": "object",
+                    "properties": {
+                        "security_type": {
+                            "type": "integer"
+                        },
+                        "vnc": {
+                            "type": "object",
+                            "properties": {
+                                "challenge": {
+                                    "type": "string"
+                                },
+                                "response": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+
+                        "security_result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "framebuffer": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "pixel_format": {
+                            "type": "object",
+                            "properties": {
+                                "bits_per_pixel": {
+                                    "type": "integer"
+                                },
+                                "depth": {
+                                    "type": "integer"
+                                },
+                                "big_endian": {
+                                    "type": "boolean"
+                                },
+                                "true_color": {
+                                    "type": "boolean"
+                                },
+                                "red_max": {
+                                    "type": "integer"
+                                },
+                                "green_max": {
+                                    "type": "integer"
+                                },
+                                "blue_max": {
+                                    "type": "integer"
+                                },
+                                "red_shift": {
+                                    "type": "integer"
+                                },
+                                "green_shift": {
+                                    "type": "integer"
+                                },
+                                "blue_shift": {
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "width": {
+                            "type": "integer"
+                        },
+                        "height": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "server_protocol_version": {
+                    "type": "object",
+                    "properties": {
+                        "major": {
+                            "type": "string"
+                        },
+                        "minor": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "client_protocol_version": {
+                    "type": "object",
+                    "properties": {
+                        "major": {
+                            "type": "string"
+                        },
+                        "minor": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "rdp": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "tx_id": {
+                    "type": "integer"
+                },
+                "cookie": {
+                    "type": "string"
+                },
+                "channels": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "client": {
+                    "type": "object",
+                    "properties": {
+                        "version": {
+                            "type": "string"
+                        },
+                        "desktop_width": {
+                            "type": "integer"
+                        },
+                        "desktop_height": {
+                            "type": "integer"
+                        },
+                        "color_depth": {
+                            "type": "integer"
+                        },
+                        "keyboard_layout": {
+                            "type": "string"
+                        },
+                        "build": {
+                            "type": "string"
+                        },
+                        "client_name": {
+                            "type": "string"
+                        },
+                        "keyboard_type": {
+                            "type": "string"
+                        },
+                        "function_keys": {
+                            "type": "integer"
+                        },
+                        "product_id": {
+                            "type": "integer"
+                        },
+                        "capabilities": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "event_type": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "email": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "status": {
+                    "type": "string"
+                },
+                "subject_md5": {
+                    "type": "string"
+                },
+                "body_md5": {
+                    "type": "string"
+                },
+                "attachment": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "to": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "from": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "dhcp": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "client_mac": {
+                    "type": "string"
+                },
+                "assigned_ip": {
+                    "type": "string"
+                },
+                "client_id": {
+                    "type": "string"
+                },
+                "client_ip": {
+                    "type": "string"
+                },
+                "dhcp_type": {
+                    "type": "string"
+                },
+                "lease_time": {
+                    "type": "integer"
+                },
+                "next_server_ip": {
+                    "type": "string"
+                },
+                "rebinding_time": {
+                    "type": "integer"
+                },
+                "relay_ip": {
+                    "type": "string"
+                },
+                "renewal_time": {
+                    "type": "integer"
+                },
+                "routers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "subnet_mask": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "dns_servers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "hostname": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "http2": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "http_method": {
+                    "type": "string"
+                },
+                "http_user_agent": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "length": {
+                    "type": "integer"
+                },
+                "request_headers": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            },
+                            "table_size_update": {
+                                "type": "integer"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "response_headers": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            },
+                            "table_size_update": {
+                                "type": "integer"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "http2": {
+                    "type": "object",
+                    "properties": {
+                        "stream_id": {
+                            "type": "integer"
+                        },
+                        "request": {
+                            "type": "object",
+                            "properties": {
+                                "priority": {
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "response": {
+                            "type": "object",
+                            "properties": {
+                                "error_code": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "status": {
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false
+        },
+        "modbus": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "request": {
+                    "type": "object",
+                    "properties": {
+                        "transaction_id": {
+                            "type": "integer"
+                        },
+                        "protocol_id": {
+                            "type": "integer"
+                        },
+                        "unit_id": {
+                            "type": "integer"
+                        },
+                        "function_raw": {
+                            "type": "integer"
+                        },
+                        "function_code": {
+                            "type": "string"
+                        },
+                        "error_flags": {
+                            "type": "string"
+                        },
+                        "access_type": {
+                            "type": "string"
+                        },
+                        "data": {
+                            "type": "string"
+                        },
+                        "read": {
+                            "type": "object",
+                            "properties": {
+                                "address": {
+                                    "type": "integer"
+                                },
+                                "quantity": {
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "write": {
+                            "type": "object",
+                            "properties": {
+                                "address": {
+                                    "type": "integer"
+                                },
+                                "data": {
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "diagnostic": {
+                            "type": "object",
+                            "properties": {
+                                "raw": {
+                                    "type": "integer"
+                                },
+                                "code": {
+                                    "type": "string"
+                                },
+                                "data": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "mei": {
+                            "type": "object",
+                            "properties": {
+                                "raw": {
+                                    "type": "integer"
+                                },
+                                "code": {
+                                    "type": "string"
+                                },
+                                "data": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "category": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "response": {
+                    "type": "object",
+                    "properties": {
+                        "transaction_id": {
+                            "type": "integer"
+                        },
+                        "protocol_id": {
+                            "type": "integer"
+                        },
+                        "unit_id": {
+                            "type": "integer"
+                        },
+                        "access_type": {
+                            "type": "string"
+                        },
+                        "category": {
+                            "type": "string"
+                        },
+                        "error_flags": {
+                            "type": "string"
+                        },
+                        "function_raw": {
+                            "type": "integer"
+                        },
+                        "function_code": {
+                            "type": "string"
+                        },
+                        "read": {
+                            "type": "object",
+                            "properties": {
+                                "data": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "write": {
+                            "type": "object",
+                            "properties": {
+                                "address": {
+                                    "type": "integer"
+                                },
+                                "data": {
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "diagnostic": {
+                            "type": "object",
+                            "properties": {
+                                "raw": {
+                                    "type": "integer"
+                                },
+                                "code": {
+                                    "type": "string"
+                                },
+                                "data": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "exception": {
+                            "type": "object",
+                            "properties": {
+                                "raw": {
+                                    "type": "integer"
+                                },
+                                "code": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "data": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "ike": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "init_spi": {
+                    "type": "string"
+                },
+                "resp_spi": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "payload": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "alg_auth_raw": {
+                    "type": "integer"
+                },
+                "alg_auth": {
+                    "type": "string"
+                },
+                "alg_dh_raw": {
+                    "type": "integer"
+                },
+                "alg_dh": {
+                    "type": "string"
+                },
+                "alg_enc_raw": {
+                    "type": "integer"
+                },
+                "alg_enc": {
+                    "type": "string"
+                },
+                "alg_hash_raw": {
+                    "type": "integer"
+                },
+                "alg_hash": {
+                    "type": "string"
+                },
+                "sa_key_length_raw": {
+                    "type": "integer"
+                },
+                "sa_key_length": {
+                    "type": "string"
+                },
+                "sa_life_duration_raw": {
+                    "type": "integer"
+                },
+                "sa_life_duration": {
+                    "type": "string"
+                },
+                "sa_life_type_raw": {
+                    "type": "integer"
+                },
+                "sa_life_type": {
+                    "type": "string"
+                },
+                "exchange_type_verbose": {
+                    "type": "string"
+                },
+                "message_id": {
+                    "type": "integer"
+                },
+                "exchange_type": {
+                    "type": "integer"
+                },
+                "ikev1": {
+                    "type": "object",
+                    "properties": {
+                        "doi": {
+                            "type": "integer"
+                        },
+                        "client": {
+                            "type": "object",
+                            "properties": {
+                                "proposals": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "alg_auth_raw": {
+                                                "type": "integer"
+                                            },
+                                            "alg_auth": {
+                                                "type": "string"
+                                            },
+                                            "alg_dh_raw": {
+                                                "type": "integer"
+                                            },
+                                            "alg_dh": {
+                                                "type": "string"
+                                            },
+                                            "alg_enc_raw": {
+                                                "type": "integer"
+                                            },
+                                            "alg_enc": {
+                                                "type": "string"
+                                            },
+                                            "alg_hash_raw": {
+                                                "type": "integer"
+                                            },
+                                            "alg_hash": {
+                                                "type": "string"
+                                            },
+                                            "sa_key_length_raw": {
+                                                "type": "integer"
+                                            },
+                                            "sa_key_length": {
+                                                "type": "string"
+                                            },
+                                            "sa_life_duration_raw": {
+                                                "type": "integer"
+                                            },
+                                            "sa_life_duration": {
+                                                "type": "string"
+                                            },
+                                            "sa_life_type_raw": {
+                                                "type": "integer"
+                                            },
+                                            "sa_life_type": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "nonce_payload": {
+                                    "type": "string"
+                                },
+                                "nonce_payload_length": {
+                                    "type": "integer"
+                                },
+                                "key_exchange_payload": {
+                                    "type": "string"
+                                },
+                                "key_exchange_payload_length": {
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "server": {
+                            "type": "object",
+                            "properties": {
+                                "nonce_payload": {
+                                    "type": "string"
+                                },
+                                "nonce_payload_length": {
+                                    "type": "integer"
+                                },
+                                "key_exchange_payload": {
+                                    "type": "string"
+                                },
+                                "key_exchange_payload_length": {
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "vendor_ids": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "encrypted_payloads": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ikev2": {
+                    "type": "object",
+                    "properties": {
+                        "notify": {
+                            "type": "array"
+                        },
+                        "errors": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "version_major": {
+                    "type": "integer"
+                },
+                "version_minor": {
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false
+        },
+        "dnp3": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "application": {
+                    "type": "object",
+                    "properties": {
+                        "complete": {
+                            "type": "boolean"
+                        },
+                        "objects": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "count": {
+                                        "type": "integer"
+                                    },
+                                    "group": {
+                                        "type": "integer"
+                                    },
+                                    "prefix_code": {
+                                        "type": "integer"
+                                    },
+                                    "qualifier": {
+                                        "type": "integer"
+                                    },
+                                    "range_code": {
+                                        "type": "integer"
+                                    },
+                                    "start": {
+                                        "type": "integer"
+                                    },
+                                    "stop": {
+                                        "type": "integer"
+                                    },
+                                    "variation": {
+                                        "type": "integer"
+                                    },
+                                    "points": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                        }
+                                    }
+                                },
+                                "additionalProperties": false
+                            }
+                        },
+                        "control": {
+                            "type": "object",
+                            "properties": {
+                                "fir": {
+                                    "type": "boolean"
+                                },
+                                "fin": {
+                                    "type": "boolean"
+                                },
+                                "con": {
+                                    "type": "boolean"
+                                },
+                                "uns": {
+                                    "type": "boolean"
+                                },
+                                "sequence": {
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "function_code": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "control": {
+                    "type": "object",
+                    "properties": {
+                        "dir": {
+                            "type": "boolean"
+                        },
+                        "pri": {
+                            "type": "boolean"
+                        },
+                        "fcb": {
+                            "type": "boolean"
+                        },
+                        "fcv": {
+                            "type": "boolean"
+                        },
+                        "function_code": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "src": {
+                    "type": "integer"
+                },
+                "dst": {
+                    "type": "integer"
+                },
+                "iin": {
+                    "type": "object",
+                    "properties": {
+                        "indicators": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "request": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "object",
+                            "properties": {
+                                "complete": {
+                                    "type": "boolean"
+                                },
+                                "objects": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "count": {
+                                                "type": "integer"
+                                            },
+                                            "group": {
+                                                "type": "integer"
+                                            },
+                                            "prefix_code": {
+                                                "type": "integer"
+                                            },
+                                            "qualifier": {
+                                                "type": "integer"
+                                            },
+                                            "range_code": {
+                                                "type": "integer"
+                                            },
+                                            "start": {
+                                                "type": "integer"
+                                            },
+                                            "stop": {
+                                                "type": "integer"
+                                            },
+                                            "variation": {
+                                                "type": "integer"
+                                            },
+                                            "points": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "additionalProperties": true
+                                                }
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "control": {
+                                    "type": "object",
+                                    "properties": {
+                                        "fir": {
+                                            "type": "boolean"
+                                        },
+                                        "fin": {
+                                            "type": "boolean"
+                                        },
+                                        "con": {
+                                            "type": "boolean"
+                                        },
+                                        "uns": {
+                                            "type": "boolean"
+                                        },
+                                        "sequence": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "function_code": {
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "control": {
+                            "type": "object",
+                            "properties": {
+                                "dir": {
+                                    "type": "boolean"
+                                },
+                                "pri": {
+                                    "type": "boolean"
+                                },
+                                "fcb": {
+                                    "type": "boolean"
+                                },
+                                "fcv": {
+                                    "type": "boolean"
+                                },
+                                "function_code": {
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "src": {
+                            "type": "integer"
+                        },
+                        "dst": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "response": {
+                    "properties": {
+                        "iin": {
+                            "type": "object",
+                            "properties": {
+                                "indicators": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "application": {
+                            "type": "object",
+                            "properties": {
+                                "complete": {
+                                    "type": "boolean"
+                                },
+                                "objects": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "count": {
+                                                "type": "integer"
+                                            },
+                                            "group": {
+                                                "type": "integer"
+                                            },
+                                            "prefix_code": {
+                                                "type": "integer"
+                                            },
+                                            "qualifier": {
+                                                "type": "integer"
+                                            },
+                                            "range_code": {
+                                                "type": "integer"
+                                            },
+                                            "start": {
+                                                "type": "integer"
+                                            },
+                                            "stop": {
+                                                "type": "integer"
+                                            },
+                                            "variation": {
+                                                "type": "integer"
+                                            },
+                                            "points": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "additionalProperties": true
+                                                }
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "control": {
+                                    "type": "object",
+                                    "properties": {
+                                        "fir": {
+                                            "type": "boolean"
+                                        },
+                                        "fin": {
+                                            "type": "boolean"
+                                        },
+                                        "con": {
+                                            "type": "boolean"
+                                        },
+                                        "uns": {
+                                            "type": "boolean"
+                                        },
+                                        "sequence": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "function_code": {
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "control": {
+                            "type": "object",
+                            "properties": {
+                                "dir": {
+                                    "type": "boolean"
+                                },
+                                "pri": {
+                                    "type": "boolean"
+                                },
+                                "fcb": {
+                                    "type": "boolean"
+                                },
+                                "fcv": {
+                                    "type": "boolean"
+                                },
+                                "function_code": {
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "src": {
+                            "type": "integer"
+                        },
+                        "dst": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "type": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "nfs": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "filename": {
+                    "type": "string"
+                },
+                "procedure": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "integer"
+                },
+                "hhash": {
+                    "type": "string"
+                },
+                "rename": {
+                    "type": "object",
+                    "optional": true,
+                    "properties": {
+                        "from": {
+                            "type": "string"
+                        },
+                        "to": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "read": {
+                    "type": "object",
+                    "optional": true,
+                    "properties": {
+                        "first": {
+                            "type": "boolean"
+                        },
+                        "chunks": {
+                            "type": "integer"
+                        },
+                        "last_xid": {
+                            "type": "integer"
+                        },
+                        "last": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "write": {
+                    "type": "object",
+                    "optional": true,
+                    "properties": {
+                        "first": {
+                            "type": "boolean"
+                        },
+                        "chunks": {
+                            "type": "integer"
+                        },
+                        "last_xid": {
+                            "type": "integer"
+                        },
+                        "last": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "file_tx": {
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
+        },
+        "ftp": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "command": {
+                    "type": "string"
+                },
+                "completion_code": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "reply": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "reply_received": {
+                    "type": "string"
+                },
+                "mode": {
+                    "type": "string"
+                },
+                "dynamic_port": {
+                    "type": "integer"
+                },
+                "command_data": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "payload": {
+            "type": "string"
+        },
+        "payload_printable": {
+            "type": "string"
+        },
+        "stream": {
+            "type": "integer"
+        },
+        "rpc": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "auth_type": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "creds": {
+                    "type": "object",
+                    "optional": true,
+                    "properties": {
+                        "gid": {
+                            "type": "integer"
+                        },
+                        "machine_name": {
+                            "type": "string"
+                        },
+                        "uid": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "xid": {
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false
+        },
+        "sip": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "method": {
+                    "type": "string"
+                },
+                "uri": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "code": {
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "response_line": {
+                    "type": "string"
+                },
+                "request_line": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "smb": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "command": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "status_code": {
+                    "type": "string"
+                },
+                "tree_id": {
+                    "type": "integer"
+                },
+                "session_id": {
+                    "type": "integer"
+                },
+                "filename": {
+                    "type": "string"
+                },
+                "fuid": {
+                    "type": "string"
+                },
+                "share": {
+                    "type": "string"
+                },
+                "access": {
+                    "type": "string"
+                },
+                "function": {
+                    "type": "string"
+                },
+                "function": {
+                    "type": "string"
+                },
+                "ntlmssp": {
+                    "type": "object",
+                    "optional": true,
+                    "properties": {
+                        "domain": {
+                            "type": "string"
+                        },
+                        "user": {
+                            "type": "string"
+                        },
+                        "host": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "kerberos": {
+                    "type": "object",
+                    "optional": true,
+                    "properties": {
+                        "realm": {
+                            "type": "string"
+                        },
+                        "snames": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "share_type": {
+                    "type": "string"
+                },
+                "service": {
+                    "type": "object",
+                    "optional": true,
+                    "properties": {
+                        "request": {
+                            "type": "string"
+                        },
+                        "response": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "named_pipe": {
+                    "type": "string"
+                },
+                "accessed": {
+                    "type": "integer"
+                },
+                "changed": {
+                    "type": "integer"
+                },
+                "created": {
+                    "type": "integer"
+                },
+                "modified": {
+                    "type": "integer"
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "disposition": {
+                    "type": "string"
+                },
+                "directory": {
+                    "type": "string"
+                },
+                "client_dialects": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "client_guid": {
+                    "type": "string"
+                },
+                "server_guid": {
+                    "type": "string"
+                },
+                "request": {
+                    "type": "object",
+                    "optional": true,
+                    "properties": {
+                        "native_lm": {
+                            "type": "string"
+                        },
+                        "native_os": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "response": {
+                    "type": "object",
+                    "optional": true,
+                    "properties": {
+                        "native_lm": {
+                            "type": "string"
+                        },
+                        "native_os": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "dcerpc": {
+                    "type": "object",
+                    "optional": true,
+                    "properties": {
+                        "opnum": {
+                            "type": "integer"
+                        },
+                        "interfaces": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "optional": true,
+                                "properties": {
+                                    "ack_reason": {
+                                        "type": "integer"
+                                    },
+                                    "ack_result": {
+                                        "type": "integer"
+                                    },
+                                    "uuid": {
+                                        "type": "string"
+                                    },
+                                    "version": {
+                                        "type": "string"
+                                    }
+                                },
+                                "additionalProperties": false
+                            }
+                        },
+                        "req": {
+                            "type": "object",
+                            "optional": true,
+                            "properties": {
+                                "frag_cnt": {
+                                    "type": "integer"
+                                },
+                                "stub_data_size": {
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "res": {
+                            "type": "object",
+                            "optional": true,
+                            "properties": {
+                                "frag_cnt": {
+                                    "type": "integer"
+                                },
+                                "stub_data_size": {
+                                    "type": "integer"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
+                        "request": {
+                            "type": "string"
+                        },
+                        "response": {
+                            "type": "string"
+                        },
+                        "call_id": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "dialect": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "smtp": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "helo": {
+                    "type": "string"
+                },
+                "mail_from": {
+                    "type": "string"
+                },
+                "rcpt_to": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "snmp": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "community": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "integer"
+                },
+                "pdu_type": {
+                    "type": "string"
+                },
+                "usm": {
+                    "type": "string"
+                },
+                "vars": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "template": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "request": {
+                    "type": "string"
+                },
+                "response": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "tftp": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "file": {
+                    "type": "string"
+                },
+                "mode": {
+                    "type": "string"
+                },
+                "packet": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "tls": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "session_resumed": {
+                    "type": "boolean"
+                },
+                "sni": {
+                    "type": "string"
+                },
+                "issuerdn": {
+                    "type": "string"
+                },
+                "subject": {
+                    "type": "string"
+                },
+                "fingerprint": {
+                    "type": "string"
+                },
+                "notafter": {
+                    "type": "string"
+                },
+                "notbefore": {
+                    "type": "string"
+                },
+                "serial": {
+                    "type": "string"
+                },
+                "from_proto": {
+                    "type": "string"
+                },
+                "ja3": {
+                    "type": "object",
+                    "optional": true,
+                    "properties": {
+                        "hash": {
+                            "type": "string"
+                        },
+                        "string": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ja3s": {
+                    "type": "object",
+                    "optional": true,
+                    "properties": {
+                        "hash": {
+                            "type": "string"
+                        },
+                        "string": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "version": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "ssh": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "client": {
+                    "type": "object",
+                    "properties": {
+                        "proto_version": {
+                            "type": "string"
+                        },
+                        "software_version": {
+                            "type": "string"
+                        },
+                        "hassh": {
+                            "type": "object",
+                            "properties": {
+                                "hash": {
+                                    "type": "string"
+                                },
+                                "string": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "server": {
+                    "type": "object",
+                    "properties": {
+                        "proto_version": {
+                            "type": "string"
+                        },
+                        "software_version": {
+                            "type": "string"
+                        },
+                        "hassh": {
+                            "type": "object",
+                            "properties": {
+                                "hash": {
+                                    "type": "string"
+                                },
+                                "string": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
         }
     },
-    "additionalProperties": true
+    "additionalProperties": false
 }

--- a/schema.json
+++ b/schema.json
@@ -79,11 +79,17 @@
                 "start": {
                     "type": "string"
                 },
+                "action": {
+                    "type": "string"
+                },
+                "bypass": {
+                    "type": "string"
+                },
                 "reason": {
                     "type": "string"
                 }
             },
-            "additionalProperties": true
+            "additionalProperties": false
         },
         "tcp": {
             "type": "object",
@@ -110,11 +116,23 @@
                 "fin": {
                     "type": "boolean"
                 },
+                "cwr": {
+                    "type": "boolean"
+                },
+                "ecn": {
+                    "type": "boolean"
+                },
+                "rst": {
+                    "type": "boolean"
+                },
+                "urg": {
+                    "type": "boolean"
+                },
                 "ack": {
                     "type": "boolean"
                 }
             },
-            "additionalProperties": true
+            "additionalProperties": false
         },
         "stats": {
             "type": "object",

--- a/schema.json
+++ b/schema.json
@@ -99,5 +99,6 @@
                 }
             }
         }
-    }
+    },
+    "additionalProperties": false
 }

--- a/schema.json
+++ b/schema.json
@@ -303,7 +303,8 @@
                                         "frag_ignored": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "icmpv4": {
                                     "type": "object",
@@ -323,7 +324,8 @@
                                         "ipv4_unknown_ver": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "icmpv6": {
                                     "type": "object",
@@ -352,7 +354,8 @@
                                         "experimentation_type": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "ipv6": {
                                     "type": "object",
@@ -450,7 +453,8 @@
                                         "ipv6_in_ipv6_wrong_version": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "tcp": {
                                     "type": "object",
@@ -470,7 +474,8 @@
                                         "opt_duplicate": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "udp": {
                                     "type": "object",
@@ -484,7 +489,8 @@
                                         "hlen_invalid": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "sll": {
                                     "type": "object",
@@ -492,7 +498,8 @@
                                         "pkt_too_small": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "ethernet": {
                                     "type": "object",
@@ -500,7 +507,8 @@
                                         "pkt_too_small": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "ppp": {
                                     "type": "object",
@@ -523,7 +531,8 @@
                                         "unsup_proto": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "pppoe": {
                                     "type": "object",
@@ -537,7 +546,8 @@
                                         "malformed_tags": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "gre": {
                                     "type": "object",
@@ -587,7 +597,8 @@
                                         "version1_hdr_too_big": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "vlan": {
                                     "type": "object",
@@ -601,7 +612,8 @@
                                         "too_many_layers": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "ieee8021ah": {
                                     "type": "object",
@@ -609,7 +621,8 @@
                                         "header_too_small": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "vntag": {
                                     "type": "object",
@@ -620,7 +633,8 @@
                                         "unknown_type": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "ipraw": {
                                     "type": "object",
@@ -628,7 +642,8 @@
                                         "invalid_ip_version": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "ltnull": {
                                     "type": "object",
@@ -639,7 +654,8 @@
                                         "unsupported_type": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "sctp": {
                                     "type": "object",
@@ -647,7 +663,8 @@
                                         "pkt_too_small": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "esp": {
                                     "type": "object",
@@ -655,7 +672,8 @@
                                         "pkt_too_small": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "mpls": {
                                     "type": "object",
@@ -678,7 +696,8 @@
                                         "unknown_payload_type": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "vxlan": {
                                     "type": "object",
@@ -686,7 +705,8 @@
                                         "unknown_payload_type": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "geneve": {
                                     "type": "object",
@@ -694,7 +714,8 @@
                                         "unknown_payload_type": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "erspan": {
                                     "type": "object",
@@ -708,7 +729,8 @@
                                         "too_many_vlan_layers": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "dce": {
                                     "type": "object",
@@ -716,7 +738,8 @@
                                         "pkt_too_small": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "chdlc": {
                                     "type": "object",
@@ -724,7 +747,8 @@
                                         "pkt_too_small": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "nsh": {
                                     "type": "object",
@@ -747,14 +771,17 @@
                                         "unknown_payload": {
                                             "type": "integer"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "too_many_layers": {
                             "type": "integer"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "flow": {
                     "type": "object",
@@ -819,7 +846,8 @@
                                 "flows_injected": {
                                     "type": "integer"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "mgr": {
                             "type": "object",
@@ -860,7 +888,8 @@
                                 "flows_evicted_needs_work": {
                                     "type": "integer"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "spare": {
                             "type": "integer"
@@ -874,7 +903,8 @@
                         "memuse": {
                             "type": "integer"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "defrag": {
                     "type": "object",
@@ -891,7 +921,8 @@
                                 "timeouts": {
                                     "type": "integer"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "ipv6": {
                             "type": "object",
@@ -905,12 +936,14 @@
                                 "timeouts": {
                                     "type": "integer"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "max_frag_hits": {
                             "type": "integer"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "flow_bypassed": {
                     "type": "object",
@@ -936,7 +969,8 @@
                         "bytes": {
                             "type": "integer"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "tcp": {
                     "type": "object",
@@ -1004,7 +1038,8 @@
                         "reassembly_memuse": {
                             "type": "integer"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "detect": {
                     "type": "object",
@@ -1026,13 +1061,15 @@
                                     "rules_failed": {
                                         "type": "integer"
                                     }
-                                }
+                                },
+                                "additionalProperties": false
                             }]
                         },
                         "alert": {
                             "type": "integer"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "app_layer": {
                     "type": "object",
@@ -1082,6 +1119,18 @@
                                 "ike": {
                                     "type": "integer"
                                 },
+                                "ikev2": {
+                                    "type": "integer"
+                                },
+                                "dnp3": {
+                                    "type": "integer"
+                                },
+                                "enip": {
+                                    "type": "integer"
+                                },
+                                "modbus": {
+                                    "type": "integer"
+                                },
                                 "krb5_tcp": {
                                     "type": "integer"
                                 },
@@ -1124,7 +1173,8 @@
                                 "failed_udp": {
                                     "type": "integer"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "tx": {
                             "type": "object",
@@ -1171,6 +1221,18 @@
                                 "ike": {
                                     "type": "integer"
                                 },
+                                "ikev2": {
+                                    "type": "integer"
+                                },
+                                "dnp3": {
+                                    "type": "integer"
+                                },
+                                "enip": {
+                                    "type": "integer"
+                                },
+                                "modbus": {
+                                    "type": "integer"
+                                },
                                 "krb5_tcp": {
                                     "type": "integer"
                                 },
@@ -1207,12 +1269,14 @@
                                 "krb5_udp": {
                                     "type": "integer"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "expectations": {
                             "type": "integer"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "http": {
                     "type": "object",
@@ -1223,7 +1287,8 @@
                         "memcap": {
                             "type": "integer"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "ftp": {
                     "type": "object",
@@ -1234,18 +1299,74 @@
                         "memcap": {
                             "type": "integer"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "file_store": {
                     "type": "object",
                     "properties": {
                         "open_files": {
                             "type": "integer"
+                        },
+                        "fs_errors": {
+                            "type": "integer"
+                        },
+                        "open_files_max_hit": {
+                            "type": "integer"
                         }
-                    }
+                    },
+                    "additionalProperties": false
+                },
+                "flow_mgr": {
+                    "type": "object",
+                    "properties": {
+                        "closed_pruned": {
+                            "type": "integer"
+                        },
+                        "new_pruned": {
+                            "type": "integer"
+                        },
+                        "est_pruned": {
+                            "type": "integer"
+                        },
+                        "bypassed_pruned": {
+                            "type": "integer"
+                        },
+                        "flows_checked": {
+                            "type": "integer"
+                        },
+                        "flows_notimeout": {
+                            "type": "integer"
+                        },
+                        "flows_timeout": {
+                            "type": "integer"
+                        },
+                        "flows_timeout_inuse": {
+                            "type": "integer"
+                        },
+                        "flows_removed": {
+                            "type": "integer"
+                        },
+                        "rows_checked": {
+                            "type": "integer"
+                        },
+                        "rows_skipped": {
+                            "type": "integer"
+                        },
+                        "rows_empty": {
+                            "type": "integer"
+                        },
+                        "rows_busy": {
+                            "type": "integer"
+                        },
+                        "rows_maxlen": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
                 }
             },
-            "additionalProperties": true
+            "additionalProperties": false
         },
         "http": {
             "type": "object",

--- a/schema.json
+++ b/schema.json
@@ -2689,6 +2689,12 @@
             "type": "object",
             "optional": true,
             "properties": {
+                "activityuuid": {
+                    "type": "string"
+                },
+                "seqnum": {
+                    "type": "integer"
+                },
                 "request": {
                     "type": "string"
                 },

--- a/schema.json
+++ b/schema.json
@@ -83,7 +83,7 @@
                     "type": "string"
                 }
             },
-            "additionalProperties": false
+            "additionalProperties": true
         },
         "tcp": {
             "type": "object",
@@ -114,7 +114,7 @@
                     "type": "boolean"
                 }
             },
-            "additionalProperties": false
+            "additionalProperties": true
         },
         "stats": {
             "type": "object",
@@ -122,8 +122,1112 @@
             "properties": {
                 "uptime": {
                     "type": "integer"
+                },
+                "decoder": {
+                    "type": "object",
+                    "properties": {
+                        "pkts": {
+                            "type": "integer"
+                        },
+                        "bytes": {
+                            "type": "integer"
+                        },
+                        "invalid": {
+                            "type": "integer"
+                        },
+                        "ipv4": {
+                            "type": "integer"
+                        },
+                        "ipv6": {
+                            "type": "integer"
+                        },
+                        "ethernet": {
+                            "type": "integer"
+                        },
+                        "chdlc": {
+                            "type": "integer"
+                        },
+                        "raw": {
+                            "type": "integer"
+                        },
+                        "null": {
+                            "type": "integer"
+                        },
+                        "sll": {
+                            "type": "integer"
+                        },
+                        "tcp": {
+                            "type": "integer"
+                        },
+                        "udp": {
+                            "type": "integer"
+                        },
+                        "sctp": {
+                            "type": "integer"
+                        },
+                        "esp": {
+                            "type": "integer"
+                        },
+                        "icmpv4": {
+                            "type": "integer"
+                        },
+                        "icmpv6": {
+                            "type": "integer"
+                        },
+                        "ppp": {
+                            "type": "integer"
+                        },
+                        "pppoe": {
+                            "type": "integer"
+                        },
+                        "geneve": {
+                            "type": "integer"
+                        },
+                        "gre": {
+                            "type": "integer"
+                        },
+                        "vlan": {
+                            "type": "integer"
+                        },
+                        "vlan_qinq": {
+                            "type": "integer"
+                        },
+                        "vxlan": {
+                            "type": "integer"
+                        },
+                        "vntag": {
+                            "type": "integer"
+                        },
+                        "ieee8021ah": {
+                            "type": "integer"
+                        },
+                        "teredo": {
+                            "type": "integer"
+                        },
+                        "ipv4_in_ipv6": {
+                            "type": "integer"
+                        },
+                        "ipv6_in_ipv6": {
+                            "type": "integer"
+                        },
+                        "mpls": {
+                            "type": "integer"
+                        },
+                        "avg_pkt_size": {
+                            "type": "integer"
+                        },
+                        "max_pkt_size": {
+                            "type": "integer"
+                        },
+                        "max_mac_addrs_src": {
+                            "type": "integer"
+                        },
+                        "max_mac_addrs_dst": {
+                            "type": "integer"
+                        },
+                        "erspan": {
+                            "type": "integer"
+                        },
+                        "nsh": {
+                            "type": "integer"
+                        },
+                        "event": {
+                            "type": "object",
+                            "properties": {
+                                "ipv4": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "hlen_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "iplen_smaller_than_hlen": {
+                                            "type": "integer"
+                                        },
+                                        "trunc_pkt": {
+                                            "type": "integer"
+                                        },
+                                        "opt_invalid": {
+                                            "type": "integer"
+                                        },
+                                        "opt_invalid_len": {
+                                            "type": "integer"
+                                        },
+                                        "opt_malformed": {
+                                            "type": "integer"
+                                        },
+                                        "opt_pad_required": {
+                                            "type": "integer"
+                                        },
+                                        "opt_eol_required": {
+                                            "type": "integer"
+                                        },
+                                        "opt_duplicate": {
+                                            "type": "integer"
+                                        },
+                                        "opt_unknown": {
+                                            "type": "integer"
+                                        },
+                                        "wrong_ip_version": {
+                                            "type": "integer"
+                                        },
+                                        "icmpv6": {
+                                            "type": "integer"
+                                        },
+                                        "frag_pkt_too_large": {
+                                            "type": "integer"
+                                        },
+                                        "frag_overlap": {
+                                            "type": "integer"
+                                        },
+                                        "frag_ignored": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "icmpv4": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "unknown_type": {
+                                            "type": "integer"
+                                        },
+                                        "unknown_code": {
+                                            "type": "integer"
+                                        },
+                                        "ipv4_trunc_pkt": {
+                                            "type": "integer"
+                                        },
+                                        "ipv4_unknown_ver": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "icmpv6": {
+                                    "type": "object",
+                                    "properties": {
+                                        "unknown_type": {
+                                            "type": "integer"
+                                        },
+                                        "unknown_code": {
+                                            "type": "integer"
+                                        },
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "ipv6_unknown_version": {
+                                            "type": "integer"
+                                        },
+                                        "ipv6_trunc_pkt": {
+                                            "type": "integer"
+                                        },
+                                        "mld_message_with_invalid_hl": {
+                                            "type": "integer"
+                                        },
+                                        "unassigned_type": {
+                                            "type": "integer"
+                                        },
+                                        "experimentation_type": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "ipv6": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "trunc_pkt": {
+                                            "type": "integer"
+                                        },
+                                        "trunc_exthdr": {
+                                            "type": "integer"
+                                        },
+                                        "exthdr_dupl_fh": {
+                                            "type": "integer"
+                                        },
+                                        "exthdr_useless_fh": {
+                                            "type": "integer"
+                                        },
+                                        "exthdr_dupl_rh": {
+                                            "type": "integer"
+                                        },
+                                        "exthdr_dupl_hh": {
+                                            "type": "integer"
+                                        },
+                                        "exthdr_dupl_dh": {
+                                            "type": "integer"
+                                        },
+                                        "exthdr_dupl_ah": {
+                                            "type": "integer"
+                                        },
+                                        "exthdr_dupl_eh": {
+                                            "type": "integer"
+                                        },
+                                        "exthdr_invalid_optlen": {
+                                            "type": "integer"
+                                        },
+                                        "wrong_ip_version": {
+                                            "type": "integer"
+                                        },
+                                        "exthdr_ah_res_not_null": {
+                                            "type": "integer"
+                                        },
+                                        "hopopts_unknown_opt": {
+                                            "type": "integer"
+                                        },
+                                        "hopopts_only_padding": {
+                                            "type": "integer"
+                                        },
+                                        "dstopts_unknown_opt": {
+                                            "type": "integer"
+                                        },
+                                        "dstopts_only_padding": {
+                                            "type": "integer"
+                                        },
+                                        "rh_type_0": {
+                                            "type": "integer"
+                                        },
+                                        "zero_len_padn": {
+                                            "type": "integer"
+                                        },
+                                        "fh_non_zero_reserved_field": {
+                                            "type": "integer"
+                                        },
+                                        "data_after_none_header": {
+                                            "type": "integer"
+                                        },
+                                        "unknown_next_header": {
+                                            "type": "integer"
+                                        },
+                                        "icmpv4": {
+                                            "type": "integer"
+                                        },
+                                        "frag_pkt_too_large": {
+                                            "type": "integer"
+                                        },
+                                        "frag_overlap": {
+                                            "type": "integer"
+                                        },
+                                        "frag_invalid_length": {
+                                            "type": "integer"
+                                        },
+                                        "frag_ignored": {
+                                            "type": "integer"
+                                        },
+                                        "ipv4_in_ipv6_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "ipv4_in_ipv6_wrong_version": {
+                                            "type": "integer"
+                                        },
+                                        "ipv6_in_ipv6_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "ipv6_in_ipv6_wrong_version": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "tcp": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "hlen_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "invalid_optlen": {
+                                            "type": "integer"
+                                        },
+                                        "opt_invalid_len": {
+                                            "type": "integer"
+                                        },
+                                        "opt_duplicate": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "udp": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "hlen_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "hlen_invalid": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "sll": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "ethernet": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "ppp": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "vju_pkt_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "ip4_pkt_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "ip6_pkt_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "wrong_type": {
+                                            "type": "integer"
+                                        },
+                                        "unsup_proto": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "pppoe": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "wrong_code": {
+                                            "type": "integer"
+                                        },
+                                        "malformed_tags": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "gre": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "wrong_version": {
+                                            "type": "integer"
+                                        },
+                                        "version0_recur": {
+                                            "type": "integer"
+                                        },
+                                        "version0_flags": {
+                                            "type": "integer"
+                                        },
+                                        "version0_hdr_too_big": {
+                                            "type": "integer"
+                                        },
+                                        "version0_malformed_sre_hdr": {
+                                            "type": "integer"
+                                        },
+                                        "version1_chksum": {
+                                            "type": "integer"
+                                        },
+                                        "version1_route": {
+                                            "type": "integer"
+                                        },
+                                        "version1_ssr": {
+                                            "type": "integer"
+                                        },
+                                        "version1_recur": {
+                                            "type": "integer"
+                                        },
+                                        "version1_flags": {
+                                            "type": "integer"
+                                        },
+                                        "version1_no_key": {
+                                            "type": "integer"
+                                        },
+                                        "version1_wrong_protocol": {
+                                            "type": "integer"
+                                        },
+                                        "version1_malformed_sre_hdr": {
+                                            "type": "integer"
+                                        },
+                                        "version1_hdr_too_big": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "vlan": {
+                                    "type": "object",
+                                    "properties": {
+                                        "header_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "unknown_type": {
+                                            "type": "integer"
+                                        },
+                                        "too_many_layers": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "ieee8021ah": {
+                                    "type": "object",
+                                    "properties": {
+                                        "header_too_small": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "vntag": {
+                                    "type": "object",
+                                    "properties": {
+                                        "header_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "unknown_type": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "ipraw": {
+                                    "type": "object",
+                                    "properties": {
+                                        "invalid_ip_version": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "ltnull": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "unsupported_type": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "sctp": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "esp": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "mpls": {
+                                    "type": "object",
+                                    "properties": {
+                                        "header_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "bad_label_router_alert": {
+                                            "type": "integer"
+                                        },
+                                        "bad_label_implicit_null": {
+                                            "type": "integer"
+                                        },
+                                        "bad_label_reserved": {
+                                            "type": "integer"
+                                        },
+                                        "unknown_payload_type": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "vxlan": {
+                                    "type": "object",
+                                    "properties": {
+                                        "unknown_payload_type": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "geneve": {
+                                    "type": "object",
+                                    "properties": {
+                                        "unknown_payload_type": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "erspan": {
+                                    "type": "object",
+                                    "properties": {
+                                        "header_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "unsupported_version": {
+                                            "type": "integer"
+                                        },
+                                        "too_many_vlan_layers": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "dce": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "chdlc": {
+                                    "type": "object",
+                                    "properties": {
+                                        "pkt_too_small": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "nsh": {
+                                    "type": "object",
+                                    "properties": {
+                                        "header_too_small": {
+                                            "type": "integer"
+                                        },
+                                        "unsupported_version": {
+                                            "type": "integer"
+                                        },
+                                        "bad_header_length": {
+                                            "type": "integer"
+                                        },
+                                        "reserved_type": {
+                                            "type": "integer"
+                                        },
+                                        "unsupported_type": {
+                                            "type": "integer"
+                                        },
+                                        "unknown_payload": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "too_many_layers": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "flow": {
+                    "type": "object",
+                    "properties": {
+                        "memcap": {
+                            "type": "integer"
+                        },
+                        "tcp": {
+                            "type": "integer"
+                        },
+                        "udp": {
+                            "type": "integer"
+                        },
+                        "icmpv4": {
+                            "type": "integer"
+                        },
+                        "icmpv6": {
+                            "type": "integer"
+                        },
+                        "tcp_reuse": {
+                            "type": "integer"
+                        },
+                        "get_used": {
+                            "type": "integer"
+                        },
+                        "get_used_eval": {
+                            "type": "integer"
+                        },
+                        "get_used_eval_reject": {
+                            "type": "integer"
+                        },
+                        "get_used_eval_busy": {
+                            "type": "integer"
+                        },
+                        "get_used_failed": {
+                            "type": "integer"
+                        },
+                        "wrk": {
+                            "type": "object",
+                            "properties": {
+                                "spare_sync_avg": {
+                                    "type": "integer"
+                                },
+                                "spare_sync": {
+                                    "type": "integer"
+                                },
+                                "spare_sync_incomplete": {
+                                    "type": "integer"
+                                },
+                                "spare_sync_empty": {
+                                    "type": "integer"
+                                },
+                                "flows_evicted_needs_work": {
+                                    "type": "integer"
+                                },
+                                "flows_evicted_pkt_inject": {
+                                    "type": "integer"
+                                },
+                                "flows_evicted": {
+                                    "type": "integer"
+                                },
+                                "flows_injected": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "mgr": {
+                            "type": "object",
+                            "properties": {
+                                "full_hash_pass": {
+                                    "type": "integer"
+                                },
+                                "closed_pruned": {
+                                    "type": "integer"
+                                },
+                                "new_pruned": {
+                                    "type": "integer"
+                                },
+                                "est_pruned": {
+                                    "type": "integer"
+                                },
+                                "bypassed_pruned": {
+                                    "type": "integer"
+                                },
+                                "rows_maxlen": {
+                                    "type": "integer"
+                                },
+                                "flows_checked": {
+                                    "type": "integer"
+                                },
+                                "flows_notimeout": {
+                                    "type": "integer"
+                                },
+                                "flows_timeout": {
+                                    "type": "integer"
+                                },
+                                "flows_timeout_inuse": {
+                                    "type": "integer"
+                                },
+                                "flows_evicted": {
+                                    "type": "integer"
+                                },
+                                "flows_evicted_needs_work": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "spare": {
+                            "type": "integer"
+                        },
+                        "emerg_mode_entered": {
+                            "type": "integer"
+                        },
+                        "emerg_mode_over": {
+                            "type": "integer"
+                        },
+                        "memuse": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "defrag": {
+                    "type": "object",
+                    "properties": {
+                        "ipv4": {
+                            "type": "object",
+                            "properties": {
+                                "fragments": {
+                                    "type": "integer"
+                                },
+                                "reassembled": {
+                                    "type": "integer"
+                                },
+                                "timeouts": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "ipv6": {
+                            "type": "object",
+                            "properties": {
+                                "fragments": {
+                                    "type": "integer"
+                                },
+                                "reassembled": {
+                                    "type": "integer"
+                                },
+                                "timeouts": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "max_frag_hits": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "flow_bypassed": {
+                    "type": "object",
+                    "properties": {
+                        "local_pkts": {
+                            "type": "integer"
+                        },
+                        "local_bytes": {
+                            "type": "integer"
+                        },
+                        "local_capture_pkts": {
+                            "type": "integer"
+                        },
+                        "local_capture_bytes": {
+                            "type": "integer"
+                        },
+                        "closed": {
+                            "type": "integer"
+                        },
+                        "pkts": {
+                            "type": "integer"
+                        },
+                        "bytes": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "tcp": {
+                    "type": "object",
+                    "properties": {
+                        "sessions": {
+                            "type": "integer"
+                        },
+                        "ssn_memcap_drop": {
+                            "type": "integer"
+                        },
+                        "pseudo": {
+                            "type": "integer"
+                        },
+                        "pseudo_failed": {
+                            "type": "integer"
+                        },
+                        "invalid_checksum": {
+                            "type": "integer"
+                        },
+                        "no_flow": {
+                            "type": "integer"
+                        },
+                        "syn": {
+                            "type": "integer"
+                        },
+                        "synack": {
+                            "type": "integer"
+                        },
+                        "rst": {
+                            "type": "integer"
+                        },
+                        "midstream_pickups": {
+                            "type": "integer"
+                        },
+                        "pkt_on_wrong_thread": {
+                            "type": "integer"
+                        },
+                        "segment_memcap_drop": {
+                            "type": "integer"
+                        },
+                        "stream_depth_reached": {
+                            "type": "integer"
+                        },
+                        "reassembly_gap": {
+                            "type": "integer"
+                        },
+                        "overlap": {
+                            "type": "integer"
+                        },
+                        "overlap_diff_data": {
+                            "type": "integer"
+                        },
+                        "insert_data_normal_fail": {
+                            "type": "integer"
+                        },
+                        "insert_data_overlap_fail": {
+                            "type": "integer"
+                        },
+                        "insert_list_fail": {
+                            "type": "integer"
+                        },
+                        "memuse": {
+                            "type": "integer"
+                        },
+                        "reassembly_memuse": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "detect": {
+                    "type": "object",
+                    "properties": {
+                        "engines": {
+                            "type": "array",
+                            "items": [{
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer"
+                                    },
+                                    "last_reload": {
+                                        "type": "string"
+                                    },
+                                    "rules_loaded": {
+                                        "type": "integer"
+                                    },
+                                    "rules_failed": {
+                                        "type": "integer"
+                                    }
+                                }
+                            }]
+                        },
+                        "alert": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "app_layer": {
+                    "type": "object",
+                    "properties": {
+                        "flow": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "integer"
+                                },
+                                "ftp": {
+                                    "type": "integer"
+                                },
+                                "smtp": {
+                                    "type": "integer"
+                                },
+                                "tls": {
+                                    "type": "integer"
+                                },
+                                "ssh": {
+                                    "type": "integer"
+                                },
+                                "imap": {
+                                    "type": "integer"
+                                },
+                                "smb": {
+                                    "type": "integer"
+                                },
+                                "dcerpc_tcp": {
+                                    "type": "integer"
+                                },
+                                "dns_tcp": {
+                                    "type": "integer"
+                                },
+                                "nfs_tcp": {
+                                    "type": "integer"
+                                },
+                                "ntp": {
+                                    "type": "integer"
+                                },
+                                "ftp-data": {
+                                    "type": "integer"
+                                },
+                                "tftp": {
+                                    "type": "integer"
+                                },
+                                "ike": {
+                                    "type": "integer"
+                                },
+                                "krb5_tcp": {
+                                    "type": "integer"
+                                },
+                                "dhcp": {
+                                    "type": "integer"
+                                },
+                                "snmp": {
+                                    "type": "integer"
+                                },
+                                "sip": {
+                                    "type": "integer"
+                                },
+                                "rfb": {
+                                    "type": "integer"
+                                },
+                                "mqtt": {
+                                    "type": "integer"
+                                },
+                                "rdp": {
+                                    "type": "integer"
+                                },
+                                "http2": {
+                                    "type": "integer"
+                                },
+                                "failed_tcp": {
+                                    "type": "integer"
+                                },
+                                "dcerpc_udp": {
+                                    "type": "integer"
+                                },
+                                "dns_udp": {
+                                    "type": "integer"
+                                },
+                                "nfs_udp": {
+                                    "type": "integer"
+                                },
+                                "krb5_udp": {
+                                    "type": "integer"
+                                },
+                                "failed_udp": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "tx": {
+                            "type": "object",
+                            "properties": {
+                                "http": {
+                                    "type": "integer"
+                                },
+                                "ftp": {
+                                    "type": "integer"
+                                },
+                                "smtp": {
+                                    "type": "integer"
+                                },
+                                "tls": {
+                                    "type": "integer"
+                                },
+                                "ssh": {
+                                    "type": "integer"
+                                },
+                                "imap": {
+                                    "type": "integer"
+                                },
+                                "smb": {
+                                    "type": "integer"
+                                },
+                                "dcerpc_tcp": {
+                                    "type": "integer"
+                                },
+                                "dns_tcp": {
+                                    "type": "integer"
+                                },
+                                "nfs_tcp": {
+                                    "type": "integer"
+                                },
+                                "ntp": {
+                                    "type": "integer"
+                                },
+                                "ftp-data": {
+                                    "type": "integer"
+                                },
+                                "tftp": {
+                                    "type": "integer"
+                                },
+                                "ike": {
+                                    "type": "integer"
+                                },
+                                "krb5_tcp": {
+                                    "type": "integer"
+                                },
+                                "dhcp": {
+                                    "type": "integer"
+                                },
+                                "snmp": {
+                                    "type": "integer"
+                                },
+                                "sip": {
+                                    "type": "integer"
+                                },
+                                "rfb": {
+                                    "type": "integer"
+                                },
+                                "mqtt": {
+                                    "type": "integer"
+                                },
+                                "rdp": {
+                                    "type": "integer"
+                                },
+                                "http2": {
+                                    "type": "integer"
+                                },
+                                "dcerpc_udp": {
+                                    "type": "integer"
+                                },
+                                "dns_udp": {
+                                    "type": "integer"
+                                },
+                                "nfs_udp": {
+                                    "type": "integer"
+                                },
+                                "krb5_udp": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "expectations": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "http": {
+                    "type": "object",
+                    "properties": {
+                        "memuse": {
+                            "type": "integer"
+                        },
+                        "memcap": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "ftp": {
+                    "type": "object",
+                    "properties": {
+                        "memuse": {
+                            "type": "integer"
+                        },
+                        "memcap": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "file_store": {
+                    "type": "object",
+                    "properties": {
+                        "open_files": {
+                            "type": "integer"
+                        }
+                    }
                 }
-            }
+            },
+            "additionalProperties": true
         },
         "http": {
             "type": "object",
@@ -169,10 +1273,10 @@
                             "type": "integer"
                         }
                     },
-                    "additionalProperties": false
+                    "additionalProperties": true
                 }
             },
-            "additionalProperties": false
+            "additionalProperties": true
         },
         "app_proto": {
             "type": "string",
@@ -213,8 +1317,8 @@
                     }
                 }
             },
-            "additionalProperties": false
+            "additionalProperties": true
         }
     },
-    "additionalProperties": false
+    "additionalProperties": true
 }

--- a/schema.json
+++ b/schema.json
@@ -44,6 +44,87 @@
             "type": "string",
             "optional": true
         },
+        "tx_id": {
+            "type": "integer",
+            "optional": true
+        },
+        "flow": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "pkts_toserver": {
+                    "type": "integer"
+                },
+                "pkts_toclient": {
+                    "type": "integer"
+                },
+                "alerted": {
+                    "type": "boolean"
+                },
+                "bytes_toserver": {
+                    "type": "integer"
+                },
+                "bytes_toclient": {
+                    "type": "integer"
+                },
+                "age": {
+                    "type": "integer"
+                },
+                "end": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string"
+                },
+                "start": {
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "tcp": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "tcp_flags": {
+                    "type": "string"
+                },
+                "tcp_flags_ts": {
+                    "type": "string"
+                },
+                "syn": {
+                    "type": "boolean"
+                },
+                "psh": {
+                    "type": "boolean"
+                },
+                "state": {
+                    "type": "string"
+                },
+                "tcp_flags_tc": {
+                    "type": "string"
+                },
+                "fin": {
+                    "type": "boolean"
+                },
+                "ack": {
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
+        },
+        "stats": {
+            "type": "object",
+            "optional": true,
+            "properties": {
+                "uptime": {
+                    "type": "integer"
+                }
+            }
+        },
         "http": {
             "type": "object",
             "optional": true,
@@ -71,8 +152,27 @@
                 },
                 "length": {
                     "type": "integer"
+                },
+                "content_range": {
+                    "type": "object",
+                    "properties": {
+                        "raw": {
+                            "type": "string"
+                        },
+                        "start": {
+                            "type": "integer"
+                        },
+                        "end": {
+                            "type": "integer"
+                        },
+                        "size": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "app_proto": {
             "type": "string",
@@ -96,8 +196,24 @@
                 },
                 "tx_id": {
                     "type": "integer"
+                },
+                "gaps": {
+                    "type": "boolean"
+                },
+                "start": {
+                    "type": "integer"
+                },
+                "end": {
+                    "type": "integer"
+                },
+                "sid": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
                 }
-            }
+            },
+            "additionalProperties": false
         }
     },
     "additionalProperties": false


### PR DESCRIPTION
cc @jasonish 

- extends the schema
- use the rust utility as it is faster than python

The schema should then be extended with turning `"additionalProperties": true` to false in only one remaining place (the base object)

Replaces #585 