### PR TITLE
Fixes mqtt unassgined test

### DIFF
--- a/tests/mqtt-events-unassigned-msgtype/test.yaml
+++ b/tests/mqtt-events-unassigned-msgtype/test.yaml
@@ -10,7 +10,7 @@ args:
 checks:
 
   - filter:
-      count: 2
+      count: 1
       match:
         event_type: alert
         alert.signature_id: 2226008


### PR DESCRIPTION
There is only one occurence of `mqtt.msgtype == 0`
So there should be only one alert

cc @satta 

needs https://github.com/OISF/suricata/pull/6662