### PR TITLE
ci: test --outdir

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -85,6 +85,9 @@ jobs:
         run: python3 ../run.py --quiet
       - name: Running check-eve
         run: python3 ./check-eve.py
+      - name: Running suricata-verify with different output dir
+        working-directory: suricata
+        run: python3 ../run.py --quiet --fail --outdir /tmp/sv-output
 
   almalinux:
     name: AlmaLinux 8


### PR DESCRIPTION
Test --outdir in CI to prevent adding broken tests that mess up path handling