### PR TITLE
Strings safe environment and other fixes - v1

### DIFF
--- a/run.py
+++ b/run.py
@@ -610,6 +610,10 @@ class TestRunner:
 
         env = self.build_env()
 
+        safe_env = {}
+        for key in env:
+            safe_env[key] = str(env[key])
+
         if "count" in self.config:
             count = self.config["count"]
         else:
@@ -633,10 +637,10 @@ class TestRunner:
 
             if shell:
                 template = string.Template(args)
-                cmdline = template.substitute(env)
+                cmdline = template.substitute(safe_env)
             else:
                 for a in range(len(args)):
-                    args[a] = string.Template(args[a]).substitute(env)
+                    args[a] = string.Template(args[a]).substitute(safe_env)
                 cmdline = " ".join(args) + "\n"
 
             open(os.path.join(self.output, "cmdline"), "w").write(cmdline)

--- a/tests/datasets-06-state-long/test.yaml
+++ b/tests/datasets-06-state-long/test.yaml
@@ -11,5 +11,5 @@ args:
 checks:
   - shell:
       args: |
-        cat ../expected/state.csv | sort > expected.csv
+        cat ${TEST_DIR}/expected/state.csv | sort > expected.csv
         cat state.csv | sort | cmp - expected.csv

--- a/tests/datasets-06-state-long/test.yaml
+++ b/tests/datasets-06-state-long/test.yaml
@@ -1,7 +1,6 @@
 requires:
   features:
     - HAVE_LIBJANSSON
-    - NEEDS_PATH_FIXES
   files:
     - src/datasets.c
 

--- a/tests/datasets-state-isnotset/test.yaml
+++ b/tests/datasets-state-isnotset/test.yaml
@@ -4,7 +4,7 @@ requires:
     - HAVE_NSS
     - HAVE_LIBJANSSON
 
-pcap: false
+pcap: ../datasets-05-state/input.pcap
 
 args:
   - --data-dir=${OUTPUT_DIR}


### PR DESCRIPTION
Recently Windows and Mac tests started to fail due to string substituion in the arguments from the environment where some environment vars were not string friendly (they don't have to be strings, thats just how we most often use them). To fix this issue we first create a copy of the environment where are values are transformed to be string safe.

Additionally fix shell checks for out of tree output by passing the environment into the the shell check so the directories can be determined.