### PR TITLE
runtime: report code errors as test errors - v2

### DIFF
--- a/run.py
+++ b/run.py
@@ -163,6 +163,8 @@ def handle_exceptions(func):
             if args and not args[0].quiet:
                 print("===> {}: Sub test #{}: SKIPPED : {}".format(kwargs["test_name"], kwargs["test_num"], ue))
             kwargs["count"]["skipped"] += 1
+        except Exception as err:
+            raise TestError("Internal runtime error: {}".format(err))
         else:
             if result:
               kwargs["count"]["success"] += 1

--- a/run.py
+++ b/run.py
@@ -378,10 +378,13 @@ class FileCompareCheck:
             return True;
         expected = os.path.join(self.directory, self.config["expected"])
         filename = self.config["filename"]
-        if filecmp.cmp(expected, filename):
-            return True
-        else:
-            raise TestError("%s %s \nFAILED: verification failed" % (expected, filename))
+        try:
+            if filecmp.cmp(expected, filename):
+                return True
+            else:
+                raise TestError("%s %s \nFAILED: verification failed" % (expected, filename))
+        except Exception as err:
+            raise TestError("file-compare check failed with exception: %s" % (err))
 
 class ShellCheck:
 


### PR DESCRIPTION
Fix the case where a file compare error fails silently due to a missing file,
and missing exception handling by locally handling exception in the file
compare class and turning those into test errors.

Additionally, wrap any exception during the checks in a test error so they can
be reported as test errors instead of lost.

Replaces https://github.com/OISF/suricata-verify/pull/623
Redmine ticket: https://redmine.openinfosecfoundation.org/issues/4899
