### PR TITLE
detect-modbus/v2: add tests to modbus

### DIFF
--- a/tests/modbus/test.rules
+++ b/tests/modbus/test.rules
@@ -3,3 +3,5 @@ alert modbus any any -> any any (msg:"Modbus function word test"; modbus: functi
 alert modbus any any -> any any (msg:"Modbus access test"; modbus: access read; sid:3; rev:1;)
 alert modbus any any -> any any (msg:"Modbus unit test"; modbus: unit 10; sid:4; rev:1;)
 alert modbus any any -> any any (msg:"Modbus full test"; modbus: unit >9, access read coils, address 0<>2; sid:5; rev:1;)
+alert modbus any any -> any any (msg:"Modbus access write test"; modbus: access write; sid:6;)
+alert modbus any any -> any any (msg:"Testing modbus code function"; modbus: function 8; sid:7;)

--- a/tests/modbus/test.yaml
+++ b/tests/modbus/test.yaml
@@ -56,3 +56,13 @@ checks:
       match:
         event_type: alert
         alert.signature_id: 5
+  - filter:
+      count: 3
+      match:
+        event_type: alert
+        alert.signature_id: 6
+  - filter:
+      count: 8
+      match:
+        event_type: alert
+        alert.signature_id: 7


### PR DESCRIPTION
Add tests for DetectModbusTestAccess and DetectModbusTestFunction

Link to redmine ticket: #4911

Previous PR: #636 