### PR TITLE
ssh-banner-only: update test.yaml checks - v1

### DIFF
--- a/tests/ssh-banner-only/test.rules
+++ b/tests/ssh-banner-only/test.rules
@@ -1,4 +1,4 @@
 alert ssh any any -> any any (ssh.software; content:"OpenSSH"; sid:1;)
 # broken?
-#alert ssh any any -> any any (ssh.softwareversion:OpenSSH_7.4; sid:2;)
+alert ssh any any -> any any (ssh.softwareversion:OpenSSH_7.4; sid:2;)
 alert ssh any any -> any any (ssh.proto; content:"2"; sid:3;)

--- a/tests/ssh-banner-only/test.yaml
+++ b/tests/ssh-banner-only/test.yaml
@@ -19,3 +19,13 @@ checks:
       match:
         event_type: alert
         alert.signature_id: 1
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 2
+  - filter:
+      count: 2
+      match:
+        event_type: alert
+        alert.signature_id: 3


### PR DESCRIPTION
While studying this test in order to review a PR, I've noticed that there were two rules, but only one (sid 1) being checked for in the `test.yaml`.  

Describe changes:
- Added filter for rule sid 3 which had done
- Uncommented rule sid 2 (will see if this triggers failures, and might rollback to leaving it commented out)