### PR TITLE
detect-dce-opnum/v3: add test

### DIFF
--- a/tests/dcerpc/dcerpc-dce-opnum/README.md
+++ b/tests/dcerpc/dcerpc-dce-opnum/README.md
@@ -1,0 +1,1 @@
+Tests the dce_opnum keyword

--- a/tests/dcerpc/dcerpc-dce-opnum/test.rules
+++ b/tests/dcerpc/dcerpc-dce-opnum/test.rules
@@ -1,1 +1,2 @@
-alert tcp any any -> any any (msg:"DCE Iface test";flow:established,to_server;dce_iface:afa8bd80-7d8a-11c9-bef4-08002b102989;dce_opnum:4;sid:1;)
+alert tcp any any -> any any (msg:"DCE Iface test";flow:established,to_server;dcerpc.iface:afa8bd80-7d8a-11c9-bef4-08002b102989;dcerpc.opnum:4;sid:1;)
+alert tcp any any -> any any (msg:"DCERPC"; dcerpc.opnum:4; sid:2;)

--- a/tests/dcerpc/dcerpc-dce-opnum/test.yaml
+++ b/tests/dcerpc/dcerpc-dce-opnum/test.yaml
@@ -10,3 +10,9 @@ checks:
       count: 1
       match:
         event_type: alert
+        alert.signature_id: 1
+  - filter:
+      count: 2
+      match:
+        event_type: alert
+        alert.signature_id: 2


### PR DESCRIPTION
Adds test for DetectDceOpnumTestParse01 - 02

Previous PR: #702

Link to redmine ticket: https://redmine.openinfosecfoundation.org/issues/4911

Corresponding Suricata PR: OISF/suricata#6910