### PR TITLE
ssh-banner-only: update test.yaml checks - v2

### DIFF
--- a/tests/ssh-banner-only/test.rules
+++ b/tests/ssh-banner-only/test.rules
@@ -1,4 +1,4 @@
 alert ssh any any -> any any (ssh.software; content:"OpenSSH"; sid:1;)
-# broken?
-#alert ssh any any -> any any (ssh.softwareversion:OpenSSH_7.4; sid:2;)
+# ssh.softwareversion is deprecated in favor of ssh.software this is just to check if it still works
+alert ssh any any -> any any (ssh.softwareversion:OpenSSH_7.4; sid:2;)
 alert ssh any any -> any any (ssh.proto; content:"2"; sid:3;)

--- a/tests/ssh-banner-only/test.yaml
+++ b/tests/ssh-banner-only/test.yaml
@@ -19,3 +19,13 @@ checks:
       match:
         event_type: alert
         alert.signature_id: 1
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 2
+  - filter:
+      count: 2
+      match:
+        event_type: alert
+        alert.signature_id: 3


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata-verify/pull/662

Changes:
- Added a comment explaining that sid:2 uses a deprecated keyword. But left it there, as I figured it would be a good way to know that it's still working even if deprecated.