### PR TITLE
tests: require version 6 for dcerpc-dce-iface-many test

### DIFF
--- a/tests/dcerpc/dcerpc-dce-iface-many/test.yaml
+++ b/tests/dcerpc/dcerpc-dce-iface-many/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 7
+  min-version: 6
 
 args:
 - -k none


### PR DESCRIPTION
Update the test so it also can be applied to suricata version 6 after the fix in the PR https://github.com/OISF/suricata/pull/6949 is applied.