### PR TITLE
test: update smb-dce_opnum test to apply to version 6

### DIFF
--- a/tests/smb-dce_opnum/test.yaml
+++ b/tests/smb-dce_opnum/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 7
+  min-version: 6
 
 args:
 - -k none


### PR DESCRIPTION
Edit test to apply version 6 after https://github.com/OISF/suricata/pull/6950 is applied.