### PR TITLE
test: set min version 6 in smb-dce_iface test

### DIFF
--- a/tests/smb-dce_iface/test.yaml
+++ b/tests/smb-dce_iface/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 7
+  min-version: 6
 
 args:
 - -k none


### PR DESCRIPTION
Change minimum version to 6 so it can be used after the PR https://github.com/OISF/suricata/pull/6951