### PR TITLE
Set minimum version to 6 in tests related with dcerpc iface,opnum fixes

### DIFF
--- a/tests/dcerpc/dcerpc-dce-iface-many/test.yaml
+++ b/tests/dcerpc/dcerpc-dce-iface-many/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 7
+  min-version: 6
 
 args:
 - -k none

--- a/tests/smb-dce_iface/test.yaml
+++ b/tests/smb-dce_iface/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 7
+  min-version: 6
 
 args:
 - -k none

--- a/tests/smb-dce_opnum/test.yaml
+++ b/tests/smb-dce_opnum/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 7
+  min-version: 6
 
 args:
 - -k none


### PR DESCRIPTION
Set minimum version 6 in tests related with the PR https://github.com/OISF/suricata/pull/6955.