### PR TITLE
nfs: Add detection rules for NFS3_READDIRPLUS v1

### DIFF
--- a/tests/nfs3-readdirplus/test.rules
+++ b/tests/nfs3-readdirplus/test.rules
@@ -1,0 +1,2 @@
+alert nfs any any -> any any (nfs_version:3; flow:to_server; nfs_procedure:17; sid:1;)
+alert nfs any any -> any any (flow:to_client; content:"|2e 2e|"; sid:2;)

--- a/tests/nfs3-readdirplus/test.yaml
+++ b/tests/nfs3-readdirplus/test.yaml
@@ -31,3 +31,15 @@ checks:
         rpc.auth_type: UNIX
         rpc.creds.uid: 1000
         rpc.creds.gid: 1000
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        app_proto: nfs
+        alert.signature_id: 1
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        app_proto: nfs
+        alert.signature_id: 2


### PR DESCRIPTION
Improve S-V test for `NFS3PROC_READDIRPLUS`

improve on https://github.com/OISF/suricata-verify/pull/699/commits/4ef8d937a21601b62ec0aa341d5296594e48b8a8
related to https://github.com/OISF/suricata/commit/4e2edd4