### PR TITLE
test/ipproto: Validate proto name/numbers

### DIFF
--- a/tests/detect-ip_proto-01/test.rules
+++ b/tests/detect-ip_proto-01/test.rules
@@ -1,0 +1,13 @@
+# Valid protocol names/numbers
+alert ip any any -> any any (msg:"Valid protoccol number"; ip_proto:2; sid:1;)
+alert ip any any -> any any (msg:"Valid protoccol name"; ip_proto:tcp; sid:2;)
+alert ip any any -> any any (msg:"Valid protoccol number"; ip_proto:0; sid:3;)
+alert ip any any -> any any (msg:"Valid protoccol number"; ip_proto:144; sid:4;)
+alert ip any any -> any any (msg:"Valid protoccol name"; ip_proto:TCP; sid:5;)
+
+# Invalid protocol names and/or numbers
+alert ip any any -> any any (msg:"Invalid protoccol number"; ip_proto:TcP; sid:20;)
+alert ip any any -> any any (msg:"Invalid protoccol number"; ip_proto:295; sid:22;)
+alert ip any any -> any any (msg:"Invalid protoccol name"; ip_proto:"not-a-protocol"; sid:23;)
+alert ip any any -> any any (msg:"Invalid protoccol number"; ip_proto:70000; sid:24;)
+alert ip any any -> any any (msg:"Invalid protoccol number"; ip_proto:-1; sid:25;)

--- a/tests/detect-ip_proto-01/test.yaml
+++ b/tests/detect-ip_proto-01/test.yaml
@@ -1,0 +1,17 @@
+requires:
+    min-version: 7
+    pcap: false
+
+args:
+    - --engine-analysis
+
+exit-code: 1
+
+checks:
+    - shell:
+        args: grep "SC_ERR_INVALID_SIGNATURE" suricata.log | wc -l | xargs
+        expect: 5
+
+    - shell:
+        args: grep "SC_ERR_INVALID_VALUE" suricata.log | wc -l | xargs
+        expect: 5


### PR DESCRIPTION
Tests for issue 5072

New test cases to validate protocol name/numbers with the `ip-proto` keyword.

This PR accompanies [Suricata PR 6991](https://github.com/OISF/suricata/pull/6991)