### PR TITLE
runner: warn user when no test matches given args - v1

### DIFF
--- a/run.py
+++ b/run.py
@@ -1011,6 +1011,16 @@ def main():
     # Sort alphabetically.
     tests.sort()
 
+    # If we don't find any tests, let's let the user know and exit
+    if not tests:
+        if args.exact:
+            print("Couldn't find any tests to match the pattern %s" % args.patterns)
+        elif args.testdir:
+            print("Couldn't find any tests to match the pattern %s" % args.testdir)
+        else:
+            print("Couldn't find any tests to match given pattern %s" % sys.argv[1])
+        return 1
+
     if LINUX:
         run_mp(args.j, tests, dirpath, args, cwd, suricata_config)
     else:


### PR DESCRIPTION
It is easier to realize that a non-existing, or typoed name was given
if we warn the user about it.

(I really miss this one when writing and tests new s-v tests...)

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/4944