### PR TITLE
runner: warn user when no test matches given args - v2

### DIFF
--- a/run.py
+++ b/run.py
@@ -1011,6 +1011,14 @@ def main():
     # Sort alphabetically.
     tests.sort()
 
+    # If we don't find any tests, let's let the user know and exit
+    if not tests:
+        if args.testdir:
+            print("Warning: Couldn't find any directory to match the pattern %s" % args.testdir)
+        else:
+            print("Warning: Couldn't find any tests to match the pattern %s" % args.patterns)
+        return 1
+
     if LINUX:
         run_mp(args.j, tests, dirpath, args, cwd, suricata_config)
     else:


### PR DESCRIPTION
It is easier to realize that a non-existing, or typoed name was given
if we warn the user about it.

Describe changes:
- a more compact check which now also handles extra non-mandatory flags better, as per @inashivb request

Previous PR: https://github.com/OISF/suricata-verify/pull/750

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/4944
