### PR TITLE
Createst add midstream arg - v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,4 +171,6 @@ optional arguments:
   --eventtype-only      Create filter blocks based on event types only
   --allow-events [ALLOW_EVENTS]
                         Create filter blocks for the specified events
+  --strictcsums         Strictly validate checksum
+  --midstream           Allow midstream session pickups
 ```

--- a/createst.py
+++ b/createst.py
@@ -142,7 +142,13 @@ def write_to_file(data):
     with open(test_yaml_path, "w+") as fp:
         fp.write("# *** Add configuration here ***\n\n")
         if not args["strictcsums"]:
-            fp.write("args:\n- -k none\n\n")
+            fp.write("args:\n- -k none\n")
+            if args["midstream"]:
+                fp.write("- --set stream.midstream=true\n")
+            fp.write("\n")
+        elif args["midstream"]:
+            fp.write("args:\n- --set stream.midstream=true\n\n")
+
         fp.write(data)
 
 
@@ -344,6 +350,8 @@ def parse_args():
                         help="Create filter blocks for the specified events")
     parser.add_argument("--strictcsums", default=None, action="store_true",
                         help="Stricly validate checksum")
+    parser.add_argument("--midstream", default=False, action="store_true",
+                        help="Allow midstream session pickups")
 
     # add arg to allow stdout only
     args = parser.parse_args()
@@ -385,6 +393,8 @@ def generate_eve():
 
     if not args["strictcsums"]:
         largs += ["-k", "none"]
+    if args["midstream"]:
+        largs += ["--set", "stream.midstream=true"]
     p = subprocess.Popen(
         largs, cwd=cwd, env=env,
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/createst.py
+++ b/createst.py
@@ -1,6 +1,6 @@
 #! /bin/python
 #
-# Copyright (C) 2019 Open Information Security Foundation
+# Copyright (C) 2019-2022 Open Information Security Foundation
 #
 # You can copy, redistribute or modify this Program under the terms of
 # the GNU General Public License version 2 as published by the Free
@@ -349,7 +349,7 @@ def parse_args():
     parser.add_argument("--allow-events", nargs="?", default=None,
                         help="Create filter blocks for the specified events")
     parser.add_argument("--strictcsums", default=None, action="store_true",
-                        help="Stricly validate checksum")
+                        help="Strictly validate checksum")
     parser.add_argument("--midstream", default=False, action="store_true",
                         help="Allow midstream session pickups")
 


### PR DESCRIPTION
As this seems to be quite a common option to use, it seemed that we could benefit from having
the possibility to set this via command-line argument. The default is still not to have it, but a user
can now add --midstream in case they want to have arg `--set stream.midstream=true` for a given 
s-v test.

Also: updated the Readme to include `strictsums` and `midstream` args. Typo fix, copyright update.