### PR TITLE
tls: only one alert for an invalid handshake

### DIFF
--- a/tests/bug-1450-01/test.yaml
+++ b/tests/bug-1450-01/test.yaml
@@ -6,17 +6,17 @@ args:
 
 checks:
   - filter:
-      count: 2
+      count: 1
       match:
         event_type: alert
         alert.signature_id: 2230003
   - filter:
-      count: 2
+      count: 1
       match:
         event_type: alert
         alert.signature_id: 2230007
   - filter:
-      count: 2
+      count: 1
       match:
         event_type: alert
         alert.signature_id: 2230010


### PR DESCRIPTION
Instead of 2, when it happens and when the connection gets closed

cf https://github.com/OISF/suricata/pull/7076