### PR TITLE
test-bad-hex-rule-1: add rule with incomplete hex

### DIFF
--- a/tests/test-bad-hex-rule-1/test.rules
+++ b/tests/test-bad-hex-rule-1/test.rules
@@ -1,1 +1,2 @@
 alert tcp any any -> any any (msg:"invalid hex test rule"; content:"|l0 01 01|"; sid:12345; rev:1;)
+alert tcp any any -> any any (msg:"invalid hex test rule"; content:"|22 2 22|"; sid:12346; rev:1;)

--- a/tests/test-bad-hex-rule-1/test.yaml
+++ b/tests/test-bad-hex-rule-1/test.yaml
@@ -21,3 +21,9 @@ checks:
       match:
         event_type: engine
         engine.error: "SC_ERR_NO_RULES_LOADED"
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "Incomplete hex code in content - |22 2 22|. Invalidating signature."


### PR DESCRIPTION
Add a rule with incomplete hex, for example "|22 2 22|" which
should result in a parse error.

Ticket #5201.