### PR TITLE
createst: add midstream arg - v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,4 +171,6 @@ optional arguments:
   --eventtype-only      Create filter blocks based on event types only
   --allow-events [ALLOW_EVENTS]
                         Create filter blocks for the specified events
+  --strictcsums         Strictly validate checksum
+  --midstream           Allow midstream session pickups
 ```

--- a/createst.py
+++ b/createst.py
@@ -141,10 +141,29 @@ def write_to_file(data):
         sys.exit(1)
     with open(test_yaml_path, "w+") as fp:
         fp.write("# *** Add configuration here ***\n\n")
-        if not args["strictcsums"]:
-            fp.write("args:\n- -k none\n\n")
+        if check_set_args():
+            fp.write("args:\n")
+            if not args["strictcsums"]:
+                fp.write("- -k none\n")
+            if args["midstream"]:
+                fp.write("- --set stream.midstream=true\n")
+            fp.write("\n")
         fp.write(data)
 
+def check_set_args():
+    """
+    Check if the user wants midstream set to true and/or to have strict
+    checksums
+    """
+    features = ["strictcsums", "midstream"]
+    no_features = True
+    for item in features:
+        if args[item]:
+            if item != "strictcsums":
+                return True
+            no_features = False 
+        elif no_features:
+            return True
 
 def test_yaml_format(func):
     """
@@ -344,6 +363,8 @@ def parse_args():
                         help="Create filter blocks for the specified events")
     parser.add_argument("--strictcsums", default=None, action="store_true",
                         help="Stricly validate checksum")
+    parser.add_argument("--midstream", default=False, action="store_true",
+                        help="Allow midstream session pickups")
 
     # add arg to allow stdout only
     args = parser.parse_args()
@@ -385,6 +406,8 @@ def generate_eve():
 
     if not args["strictcsums"]:
         largs += ["-k", "none"]
+    if args["midstream"]:
+        largs += ["--set", "stream.midstream=true"]
     p = subprocess.Popen(
         largs, cwd=cwd, env=env,
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/createst.py
+++ b/createst.py
@@ -1,6 +1,6 @@
 #! /bin/python
 #
-# Copyright (C) 2019 Open Information Security Foundation
+# Copyright (C) 2019-2022 Open Information Security Foundation
 #
 # You can copy, redistribute or modify this Program under the terms of
 # the GNU General Public License version 2 as published by the Free
@@ -362,7 +362,7 @@ def parse_args():
     parser.add_argument("--allow-events", nargs="?", default=None,
                         help="Create filter blocks for the specified events")
     parser.add_argument("--strictcsums", default=None, action="store_true",
-                        help="Stricly validate checksum")
+                        help="Strictly validate checksum")
     parser.add_argument("--midstream", default=False, action="store_true",
                         help="Allow midstream session pickups")
 


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata-verify/pull/795

Changes from previous PR:
- make sure that `args` is only printed when we do have command line args to pass