### PR TITLE
createst: add midstream arg - v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ requires:
   # Require that the Suricata version be less than a version.
   lt-version: 6
 
-  # Test is only for this version. For example, 4.0 would match any 4.0 
+  # Test is only for this version. For example, 4.0 would match any 4.0
   # release, but 4.0.3 would only match 4.0.3.
   version: 4.0
 
@@ -173,4 +173,6 @@ optional arguments:
                         Create filter blocks for the specified events
   --strictcsums         Strictly validate checksum
   --midstream           Allow midstream session pickups
+  --min-version <min-version>
+                        Adds a global minimum required version
 ```

--- a/README.md
+++ b/README.md
@@ -171,4 +171,6 @@ optional arguments:
   --eventtype-only      Create filter blocks based on event types only
   --allow-events [ALLOW_EVENTS]
                         Create filter blocks for the specified events
+  --strictcsums         Strictly validate checksum
+  --midstream           Allow midstream session pickups
 ```

--- a/createst.py
+++ b/createst.py
@@ -1,6 +1,6 @@
 #! /bin/python
 #
-# Copyright (C) 2019 Open Information Security Foundation
+# Copyright (C) 2019-2022 Open Information Security Foundation
 #
 # You can copy, redistribute or modify this Program under the terms of
 # the GNU General Public License version 2 as published by the Free
@@ -374,7 +374,7 @@ def parse_args():
     parser.add_argument("--allow-events", nargs="?", default=None,
                         help="Create filter blocks for the specified events")
     parser.add_argument("--strictcsums", default=None, action="store_true",
-                        help="Stricly validate checksum")
+                        help="Strictly validate checksum")
     parser.add_argument("--midstream", default=False, action="store_true",
                         help="Allow midstream session pickups")
     parser.add_argument("--min-version", default=None, metavar="<min-version>",


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata-verify/pull/821

Changes from previous PR:
- cleaner and more concise version of `check_set_args()` as @inashivb request