### PR TITLE
createst: add midstream arg - v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ requires:
   # Require that the Suricata version be less than a version.
   lt-version: 6
 
-  # Test is only for this version. For example, 4.0 would match any 4.0 
+  # Test is only for this version. For example, 4.0 would match any 4.0
   # release, but 4.0.3 would only match 4.0.3.
   version: 4.0
 
@@ -173,4 +173,6 @@ optional arguments:
                         Create filter blocks for the specified events
   --strictcsums         Strictly validate checksum
   --midstream           Allow midstream session pickups
+  --min-version <min-version>
+                        Adds a global minimum required version
 ```

--- a/README.md
+++ b/README.md
@@ -171,4 +171,6 @@ optional arguments:
   --eventtype-only      Create filter blocks based on event types only
   --allow-events [ALLOW_EVENTS]
                         Create filter blocks for the specified events
+  --strictcsums         Strictly validate checksum
+  --midstream           Allow midstream session pickups
 ```

--- a/createst.py
+++ b/createst.py
@@ -141,12 +141,17 @@ def write_to_file(data):
         sys.exit(1)
     with open(test_yaml_path, "w+") as fp:
         fp.write("# *** Add configuration here ***\n\n")
-        if not args["strictcsums"]:
-            fp.write("args:\n- -k none\n\n")
         if check_requires():
             fp.write("requires:\n")
         if args["min_version"]:
             fp.write("   min-version: %s\n\n" % args["min_version"])
+        if check_set_args():
+            fp.write("args:\n")
+            if not args["strictcsums"]:
+                fp.write("- -k none\n")
+            if args["midstream"]:
+                fp.write("- --set stream.midstream=true\n")
+            fp.write("\n")
         fp.write(data)
 
 def check_requires():
@@ -154,6 +159,25 @@ def check_requires():
     for item in features:
         if args[item]:
             return True
+
+def check_set_args():
+    """
+    Check if the user wants midstream set to true and/or to have strict
+    checksums
+    """
+    if not args["strictcsums"]:
+        return True
+
+    user_args = ["midstream"]
+    for item in user_args:
+        if args[item]:
+            if item != "strictcsums":
+                return True
+    """
+    If we did not reach a non-strictcsems arg here, we have the special case:
+    strictcsums, and we don't need to set args.
+    """
+    return False
 
 def test_yaml_format(func):
     """
@@ -353,6 +377,8 @@ def parse_args():
                         help="Create filter blocks for the specified events")
     parser.add_argument("--strictcsums", default=None, action="store_true",
                         help="Stricly validate checksum")
+    parser.add_argument("--midstream", default=False, action="store_true",
+                        help="Allow midstream session pickups")
     parser.add_argument("--min-version", default=None, metavar="<min-version>",
                         help="Adds a global minimum required version")
 
@@ -396,6 +422,8 @@ def generate_eve():
 
     if not args["strictcsums"]:
         largs += ["-k", "none"]
+    if args["midstream"]:
+        largs += ["--set", "stream.midstream=true"]
     p = subprocess.Popen(
         largs, cwd=cwd, env=env,
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/createst.py
+++ b/createst.py
@@ -1,6 +1,6 @@
 #! /bin/python
 #
-# Copyright (C) 2019 Open Information Security Foundation
+# Copyright (C) 2019-2022 Open Information Security Foundation
 #
 # You can copy, redistribute or modify this Program under the terms of
 # the GNU General Public License version 2 as published by the Free
@@ -376,7 +376,7 @@ def parse_args():
     parser.add_argument("--allow-events", nargs="?", default=None,
                         help="Create filter blocks for the specified events")
     parser.add_argument("--strictcsums", default=None, action="store_true",
-                        help="Stricly validate checksum")
+                        help="Strictly validate checksum")
     parser.add_argument("--midstream", default=False, action="store_true",
                         help="Allow midstream session pickups")
     parser.add_argument("--min-version", default=None, metavar="<min-version>",


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata-verify/pull/851

Changes from previous PR:
- make `check_set_args()` more readable, and dictionary element's order irrelevant, again