### PR TITLE
readme: update createst explanation, add examples - v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,13 +147,13 @@ checks:
 
 ## Adding a new test the automated way: createst
 
-Script to create a test directory with test.yaml for a given PCAP. This
-needs to be run from a valid Suricata source directory.
+Createst is a script to create a test directory with test.yaml for a given PCAP.
+This needs to be run from a valid Suricata source directory.
 
 ### Usage
 ```
 usage: createst.py [-h] [--output-path <output-path>] [--eventtype-only]
-                   [--allow-events [ALLOW_EVENTS]]
+                   [--allow-events [ALLOW_EVENTS]] [--rules <rules-file>]
                    <test-name> <pcap-file>
 
 Create tests with a given PCAP. Execute the script from a valid Suricata source
@@ -165,10 +165,47 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --rules <rules-path>
+                        Path to rules' file (optional)
   --output-path <output-path>
                         Path to the folder where generated test.yaml should be
                         put
   --eventtype-only      Create filter blocks based on event types only
+                        This means the subfields of the event in the eve log
+                        will not be added to the test.yaml file
   --allow-events [ALLOW_EVENTS]
                         Create filter blocks for the specified events
+                        events must be comma-separated only
+                        This means that just the events listed will be checked
+                        against in the test
+  --strictcsums         Stricly validate checksum
+  --min-version <min-version>
+                        Adds a global minimum required version
 ```
+
+### Examples
+
+The only mandatory arguments for ``createst.py`` are the test name and the pcap
+file. These examples show how some of the optional arguments can be used.
+
+#### Example 1
+
+Create a Suricata-verify test named ``test-02`` that runs over a pcap file called
+``input.pcap`` and that requires strict checksums, filters only on the event-types
+and uses no Suricata rules:
+```
+../suricata-verify/createst.py --strictcsums --eventtype-only test-02 input.pcap
+```
+
+### Example 2
+
+Create a Suricata-verify test named ``test-01`` that runs over a pcap file called
+``input.pcap``, only checks for ``http``, ``alert`` and ``flow`` events, and
+uses a rule's file located in another test in the same suricata-verify folder.
+It also doesn't require strict checksums and will run only for versions 6 and
+newer:
+```
+../suricata-verify/createst.py --min-version 6 --allow-events http,alert,flow \
+--rules ../suricata-verify/tests/no-payload-output/test.rules test-01 input.pcap
+```
+


### PR DESCRIPTION
Added some optional arguments for `createst.py` that were missing, and also two explained
examples of its usage, to make it easier to visualize how to use the different possible arguments.

Didn't update copyright years because there's another PR that has that.