### PR TITLE
Remove unused warning/error codes in Suricata

### DIFF
--- a/tests/filestore-v2.8-stream-depth/test.yaml
+++ b/tests/filestore-v2.8-stream-depth/test.yaml
@@ -13,7 +13,7 @@ pcap: ../filestore-v2.7-stream-depth/input.pcap
 checks:
 
   - shell:
-      args: grep "SC_WARN_FILESTORE_CONFIG(331)] - file-store.stream-depth value 10000 has no effect since it's less than stream.reassembly.depth value" stdout | wc -l | xargs
+      args: grep "SC_WARN_FILESTORE_CONFIG([0-9]\+)] - file-store.stream-depth value 10000 has no effect since it's less than stream.reassembly.depth value" stdout | wc -l | xargs
       expect: 1
 
   - filter:


### PR DESCRIPTION
Required by https://github.com/OISF/suricata/pull/7642 (and not the other way around)