### PR TITLE
catch runtime errors; allow pcap to be false in main block - v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ pre-check: |
   # Some script to run before running checks.
   cp eve.json eve.json.bak
 
+# Provide a pcap filename. A falsey value like false or empty is equivalent to setting
+# "pcap: false" in the requires section.
+pcap: input.pcap
+
 checks:
 
   # A verification filter that is run over the eve.json. Multiple

--- a/run.py
+++ b/run.py
@@ -663,6 +663,9 @@ class TestRunner:
 
             open(os.path.join(self.output, "cmdline"), "w").write(cmdline)
 
+            if self.verbose:
+                print("Executing: {}".format(cmdline.strip()))
+
             p = subprocess.Popen(
                 args, shell=shell, cwd=self.directory, env=env,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/run.py
+++ b/run.py
@@ -308,7 +308,7 @@ def check_requires(requires, suricata_config: SuricataConfig):
                     raise UnsatisfiedRequirementError(
                         "requires script returned false")
         elif key == "pcap":
-            # Handle below...
+            # A valid requires argument, but not verified here.
             pass
         else:
             raise Exception("unknown requires types: %s" % (key))
@@ -583,6 +583,13 @@ class TestRunner:
                 pcap_required = requires["pcap"]
             else:
                 pcap_required = True
+
+            # As a pcap filename can be specified outside of the requires block, let
+            # setting this to false disable the requirement of a pcap as well.
+            if "pcap" in self.config and not self.config["pcap"]:
+                pcap_required = False
+                del(self.config["pcap"])
+
             if pcap_required and not "pcap" in self.config:
                 if not glob.glob(os.path.join(self.directory, "*.pcap")) + \
                    glob.glob(os.path.join(self.directory, "*.pcapng")):

--- a/run.py
+++ b/run.py
@@ -43,6 +43,7 @@ import threading
 import filecmp
 import subprocess
 import yaml
+import traceback
 
 VALIDATE_EVE = False
 WIN32 = sys.platform == "win32"
@@ -896,6 +897,15 @@ def run_test(dirpath, args, cwd, suricata_config):
         check_args_fail()
         with lock:
             count_dict["failed"] += 1
+    except Exception as err:
+        print("===> {}: FAILED: Unexpected exception: {}".format(os.path.basename(dirpath), err))
+        traceback.print_exc()
+
+        # Always terminate the runner on this type of error, as its an error in the framework.
+        with lock:
+            check_args['fail'] = 1
+            count_dict["failed"] += 1
+            raise TerminatePoolError()
 
 def run_mp(jobs, tests, dirpath, args, cwd, suricata_config):
     print("Number of concurrent jobs: %d" % jobs)


### PR DESCRIPTION
Setting `pcap: false` in the main block was causing a runtime error that was silently being ignored. Fix the runner to have a fatal error on runtime errors, but then also allow `pcap: false` in the main block, in addition to the requires as it makes sense to allow it here, given this is where you override the pcap filename to be used.