### PR TITLE
Adds check about flow.age keyword

### DIFF
--- a/tests/bug-4663-03/test.rules
+++ b/tests/bug-4663-03/test.rules
@@ -1,2 +1,4 @@
 pass tcp any any -> any 22 (sid:2; gid:10000003; msg:"PASS SSH";)
 drop tcp any any -> any any (noalert; sid:1; rev:1; msg:"DROP all TCP";)
+
+alert icmp any any -> any any (msg:"Flow longer than 10 seconds"; flow.age:>10; flowbits: isnotset, longflow; flowbits: set, longflow; sid:3;)

--- a/tests/bug-4663-03/test.yaml
+++ b/tests/bug-4663-03/test.yaml
@@ -28,3 +28,8 @@ checks:
       match:
         event_type: flow
         flow.action: pass
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 3


### PR DESCRIPTION
Replaces #933 focusing on `min-version: 7`

Requires https://github.com/OISF/suricata/pull/7857