### PR TITLE
test-bad-hex-rule-1: update output for Suricata 6.0.7

### DIFF
--- a/tests/test-bad-hex-rule-1/test.yaml
+++ b/tests/test-bad-hex-rule-1/test.yaml
@@ -1,8 +1,5 @@
 requires:
-  min-version: 5.0.0
-
-  features:
-    - HAVE_LIBJANSSON
+  min-version: 6.0.0
 
 command: |
   ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
@@ -23,7 +20,15 @@ checks:
         engine.error: "SC_ERR_NO_RULES_LOADED"
 
   - filter:
+      min-version: 7.0
       count: 1
       match:
         event_type: engine
         engine.message: "Incomplete hex code in content - |22 2 22|. Invalidating signature."
+
+  - filter:
+      lt-version: 7
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "Incomplete hex code in content - |22 2 22|. Invalidating signature. This will become an error in Suricata 7.0."


### PR DESCRIPTION
https://redmine.openinfosecfoundation.org/issues/5546
