### PR TITLE
Backports/60x/ssl incomplete/v2

### DIFF
--- a/tests/bug-1450-01/test.yaml
+++ b/tests/bug-1450-01/test.yaml
@@ -17,16 +17,4 @@ checks:
       match:
         event_type: alert
         alert.signature_id: 2230004
-  - filter:
-      lt-version: 7.0.0
-      count: 2
-      match:
-        event_type: alert
-        alert.signature_id: 2230007
-  - filter:
-      lt-version: 7.0.0
-      count: 2
-      match:
-        event_type: alert
-        alert.signature_id: 2230010
 

--- a/tests/bug-1450-02/test.yaml
+++ b/tests/bug-1450-02/test.yaml
@@ -11,7 +11,14 @@ checks:
         event_type: alert
         alert.signature_id: 2230003
   - filter:
+      lt-version: 7
       count: 1
       match:
         event_type: alert
         alert.signature_id: 2230007
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 2230004

--- a/tests/bug-1450-02/test.yaml
+++ b/tests/bug-1450-02/test.yaml
@@ -11,21 +11,7 @@ checks:
         event_type: alert
         alert.signature_id: 2230003
   - filter:
-      min-version: 7.0.0
       count: 1
       match:
         event_type: alert
         alert.signature_id: 2230007
-  - filter:
-      lt-version: 7.0.0
-      count: 1
-      match:
-        event_type: alert
-        alert.signature_id: 2230007
-  - filter:
-      lt-version: 7.0.0
-      count: 1
-      match:
-        event_type: alert
-        alert.signature_id: 2230010
-

--- a/tests/bug-1450-03/test.yaml
+++ b/tests/bug-1450-03/test.yaml
@@ -15,10 +15,3 @@ checks:
       match:
         event_type: alert
         alert.signature_id: 2230007
-  - filter:
-      lt-version: 7.0.0
-      count: 1
-      match:
-        event_type: alert
-        alert.signature_id: 2230010
-

--- a/tests/bug-1450-05/test.yaml
+++ b/tests/bug-1450-05/test.yaml
@@ -15,4 +15,4 @@ checks:
       count: 1
       match:
         event_type: alert
-        alert.signature_id: 2230007
+        alert.signature_id: 2230004


### PR DESCRIPTION
TLS test updates for nom7 in master and ssl-incomplete backports to 6.