### PR TITLE
createst: add the add-version param to specify Suricata version

### DIFF
--- a/createst.py
+++ b/createst.py
@@ -147,10 +147,12 @@ def write_to_file(data):
             fp.write("requires:\n")
         if args["min_version"]:
             fp.write("   min-version: %s\n\n" % args["min_version"])
+        if args["add_version"]:
+            fp.write("   version: %s\n\n" % args["add_version"])
         fp.write(data)
 
 def check_requires():
-    features = ["min_version"]
+    features = ["min_version", "add_version"]
     for item in features:
         if args[item]:
             return True
@@ -355,6 +357,8 @@ def parse_args():
                         help="Stricly validate checksum")
     parser.add_argument("--min-version", default=None, metavar="<min-version>",
                         help="Adds a global minimum required version")
+    parser.add_argument("--add-version", default=None, metavar="<add-version>",
+                        help="Adds a global suricata version")
 
     # add arg to allow stdout only
     args = parser.parse_args()


### PR DESCRIPTION
Feature #4059

Current createst script generates only the filter blocks as per eve.json, extend its functionality to add a global Suricata version as mentioned on command line.

Expectation:
``createst.py mytest mypcap --add-version 6.0.0``
```
requires:
  version: 6.0.0

checks:
- filter:
    count: 1
```

Link to the redmine ticket: https://redmine.openinfosecfoundation.org/issues/4059 
