### PR TITLE
createst: add midstream arg - v9

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ needs to be run from a valid Suricata source directory.
 ```
 usage: createst.py [-h] [--output-path <output-path>] [--eventtype-only]
                    [--allow-events [ALLOW_EVENTS]]
+                   [--midstream]
                    <test-name> <pcap-file>
 
 Create tests with a given PCAP. Execute the script from a valid Suricata source
@@ -175,4 +176,5 @@ optional arguments:
   --eventtype-only      Create filter blocks based on event types only
   --allow-events [ALLOW_EVENTS]
                         Create filter blocks for the specified events
+  --midstream           Allow midstream session pickups
 ```

--- a/createst.py
+++ b/createst.py
@@ -141,12 +141,19 @@ def write_to_file(data):
         sys.exit(1)
     with open(test_yaml_path, "w+") as fp:
         fp.write("# *** Add configuration here ***\n\n")
-        if not args["strictcsums"]:
-            fp.write("args:\n- -k none\n\n")
         if check_requires():
             fp.write("requires:\n")
         if args["min_version"]:
             fp.write("   min-version: %s\n\n" % args["min_version"])
+        suricata_args = []
+        if not args["strictcsums"]:
+            suricata_args.append("-k none")
+        if args["midstream"]:
+            suricata_args.append("--set stream.midstream=true")
+        if suricata_args:
+            fp.write("args:\n")
+            fp.write("\n".join(["- {}".format(a) for a in suricata_args]))
+            fp.write("\n\n")
         fp.write(data)
 
 def check_requires():
@@ -353,6 +360,8 @@ def parse_args():
                         help="Create filter blocks for the specified events")
     parser.add_argument("--strictcsums", default=None, action="store_true",
                         help="Stricly validate checksum")
+    parser.add_argument("--midstream", default=False, action="store_true",
+                        help="Allow midstream session pickups")
     parser.add_argument("--min-version", default=None, metavar="<min-version>",
                         help="Adds a global minimum required version")
 
@@ -396,6 +405,8 @@ def generate_eve():
 
     if not args["strictcsums"]:
         largs += ["-k", "none"]
+    if args["midstream"]:
+        largs += ["--set", "stream.midstream=true"]
     p = subprocess.Popen(
         largs, cwd=cwd, env=env,
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
Add optional argument '--midstream' to add that as an argument to test.yaml.
Default is still midstream false.

usage:
`createst.py [--midstream]`

before:
```
args:
- -k none
```

after:
```
args:
- -k none
- --set stream.midstream=true
```

Previous PR: #882 

Update from Last PR: rebased, adjusted README file to (hopefully) avoid merging conflicts.