### PR TITLE
createst: add midstream arg - v10

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ This needs to be run from a valid Suricata source directory.
 usage: createst.py [-h] [--output-path <output-path>] [--eventtype-only]
                    [--allow-events [ALLOW_EVENTS]] [--rules <rules-file>]
                    [--strictcsums] [--min-version <min-version>]
+                   [--midstream]
                    <test-name> <pcap-file>
 
 Create tests with a given PCAP. Execute the script from a valid Suricata source
@@ -186,6 +187,7 @@ optional arguments:
   --strictcsums         Strictly validate checksum
   --min-version <min-version>
                         Adds a global minimum required version
+  --midstream           Allow midstream session pickups
 ```
 
 ### Examples


### PR DESCRIPTION
Add optional argument '--midstream' to add that as an argument to test.yaml.
Default is still midstream false.

usage:
createst.py [--midstream]

before:
```
args:
- -k none
```
after:
```
args:
- -k none
- --set stream.midstream=true
```
Previous PR: https://github.com/OISF/suricata-verify/pull/987

Update from Last PR: rebased.