### PR TITLE
run.py: Add dir in the output

### DIFF
--- a/run.py
+++ b/run.py
@@ -694,7 +694,11 @@ class TestRunner:
 
         if not check_value["failure"] and not check_value["skipped"]:
             if not self.quiet:
-                print("===> %s: OK%s" % (os.path.basename(self.directory), " (%dx)" % count if count > 1 else ""))
+                if os.path.basename(os.path.dirname(self.directory)) != "tests":
+                    path_name = os.path.join(os.path.basename(os.path.dirname(self.directory)), self.name)
+                else:
+                    path_name = (os.path.basename(self.directory))
+                print("===> %s: OK%s" % (path_name, " (%dx)" % count if count > 1 else ""))
         elif not check_value["failure"]:
             if not self.quiet:
                 print("===> {}: OK (checks: {}, skipped: {})".format(os.path.basename(self.directory), sum(check_value.values()), check_value["skipped"]))


### PR DESCRIPTION
These changes were based on Blithe Brandon's PR #344
Task: #3144

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/3144

Description:
- Add dir as a visual indicator in the output

Before:
===> datasets-04-http-dns: OK
===> datasets-05-state: OK
===> datasets-state-isnotset: SKIPPED: requires feature HAVE_NSS
===> dce-gap-handling: OK
===> dce-logging: OK
===> dcerpc-dce-iface-01: OK
===> dcerpc-dce-iface-02: OK
===> dcerpc-dce-iface-03: OK
===> dcerpc-dce-iface-04: OK
===> dcerpc-dce-opnum: OK
===> dcerpc-dcepayload: OK
===> decode-chdlc-01: OK
===> decode-erspan-typeI-01: OK

After:
===> datasets-04-http-dns: OK
===> datasets-05-state: OK
===> datasets-state-isnotset: SKIPPED: requires feature HAVE_NSS
===> dcerpc/dce-gap-handling: OK
===> dcerpc/dce-logging: OK
===> dcerpc/dcerpc-dce-iface-01: OK
===> dcerpc/dcerpc-dce-iface-02: OK
===> dcerpc/dcerpc-dce-iface-03: OK
===> dcerpc/dcerpc-dce-iface-04: OK
===> dcerpc/dcerpc-dce-opnum: OK
===> dcerpc/dcerpc-dcepayload: OK
===> decode-chdlc-01: OK
===> decode-erspan-typeI-01: OK
