### PR TITLE
app-layer-template: only for version < 7

### DIFF
--- a/tests/app-layer-template-rust/test.yaml
+++ b/tests/app-layer-template-rust/test.yaml
@@ -1,5 +1,8 @@
 # *** Add configuration here ***
 
+requires:
+  lt-version: 7
+
 args:
 - -k none
 

--- a/tests/app-layer-template/test.yaml
+++ b/tests/app-layer-template/test.yaml
@@ -5,6 +5,7 @@ args:
 
 checks:
 - filter:
+    lt-version: 7
     count: 1
     match:
       dest_ip: 10.16.1.10
@@ -16,6 +17,19 @@ checks:
       src_port: 58352
       template.request: 12:Hello World!
       template.response: 3:Bye
+- filter:
+    min-version: 7
+    count: 1
+    match:
+      dest_ip: 10.16.1.10
+      dest_port: 7000
+      event_type: template
+      pcap_cnt: 7
+      proto: TCP
+      src_ip: 10.16.1.11
+      src_port: 58352
+      template.request: Hello World!
+      template.response: Bye
 - filter:
     count: 1
     match:


### PR DESCRIPTION
The C templates have been removed from 7.0.
