### PR TITLE
createst: Create a default README with every test

### DIFF
--- a/createst.py
+++ b/createst.py
@@ -23,6 +23,7 @@ import logging
 import os
 import subprocess
 import sys
+import configparser
 from collections import defaultdict
 from shutil import copyfile
 
@@ -124,6 +125,28 @@ def create_directory(path):
     except OSError as e:
         logger.error(e)
         sys.exit(1)
+
+
+def create_readme():
+    """
+    Create a README.md file and write to it.
+    """
+    readme_path = os.path.join(test_dir, "README.md")
+    config_path = os.path.join( os.path.expanduser( '~' ), '.gitconfig')
+    config = configparser.ConfigParser()
+    config.read(config_path)
+    user_name = config['user']['name']
+    user_email = config['user']['email']
+    with open(readme_path, "w+") as fp:
+        fp.write("Description\n")
+        fp.write("===========\n")
+        fp.write("<TODO>\n\n")
+        fp.write("PCAP\n")
+        fp.write("====\n")
+        fp.write("<TODO>\n\n")
+        fp.write("Reported by\n")
+        fp.write("===========\n")
+        fp.write("%s <%s>\n" % (user_name, user_email))
 
 
 def write_to_file(data):
@@ -437,6 +460,7 @@ def main():
     init_global_params()
     create_directory(path=args["test-name"])
     create_directory(path=os.path.join(args["test-name"], "output"))
+    create_readme()
     generate_eve()
 
 


### PR DESCRIPTION
Feature: #5210

Description:
- Generate a default README.md file for tests created with createst.py

The content of the README:
```
Description
===========
<TODO>

PCAP
====
<TODO>

Reported by
===========
Marty Meerkat <marty@meerkatcommunity.org>
```
Link to the redmine ticket: https://redmine.openinfosecfoundation.org/issues/5210