### PR TITLE
rfb: adds a check for community_id field in a rfb event

### DIFF
--- a/tests/rfb-protocol-3.3/suricata.yaml
+++ b/tests/rfb-protocol-3.3/suricata.yaml
@@ -6,6 +6,7 @@ outputs:
       enabled: yes
       filetype: regular
       filename: eve.json
+      community-id: true
       types:
         - rfb
         - flow

--- a/tests/rfb-protocol-3.3/test.yaml
+++ b/tests/rfb-protocol-3.3/test.yaml
@@ -16,6 +16,12 @@ checks:
       count: 1
       match:
         event_type: rfb
+        community_id: 1:d6qHVLyvWEl4kfHAZiDmEtDyb2I=
+
+  - filter:
+      count: 1
+      match:
+        event_type: rfb
         rfb.server_protocol_version.major: "003"
         rfb.server_protocol_version.minor: "003"
         rfb.client_protocol_version.major: "003"


### PR DESCRIPTION
Should be good for master, and not for master6