### PR TITLE
http: check that custom logging does not collide

### DIFF
--- a/tests/http2-range/suricata.yaml
+++ b/tests/http2-range/suricata.yaml
@@ -1,0 +1,25 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      types:
+        - files
+        - stats
+        - http:
+           custom: [Content-Range]
+  - file-store:
+      version: 2
+      enabled: yes
+      force-filestore: yes
+      stream-depth: 0
+
+app-layer:
+  protocols:
+    http:
+      enabled: yes
+      libhtp:
+        default-config:
+          personality: IDS
+          response-body-limit: 100kb

--- a/tests/http2-range/test.yaml
+++ b/tests/http2-range/test.yaml
@@ -16,6 +16,11 @@ checks:
         event_type: fileinfo
         fileinfo.size: 69
   - filter:
+      count: 1
+      match:
+        event_type: http
+        http.custom.content_range: "bytes 10-20/69"
+  - filter:
       count: 0
       match:
         event_type: anomaly


### PR DESCRIPTION
for content range header for instance

I do not know if this will be backported as this is a breaking change of something broken...