### PR TITLE
tests: fix exception policy midstream tests - v1

### DIFF
--- a/tests/exception-policy-midstream-04/test.yaml
+++ b/tests/exception-policy-midstream-04/test.yaml
@@ -1,5 +1,6 @@
 args:
 - --simulate-ips
+- --set stream.midstream=true
 - --set stream.midstream-policy=pass-flow
 
 checks:
@@ -14,6 +15,6 @@ checks:
       event_type: flow
       flow.action: pass
 - filter:
-    count: 0
+    count: 1
     match:
       event_type: http

--- a/tests/exception-policy-midstream-05/README.md
+++ b/tests/exception-policy-midstream-05/README.md
@@ -6,8 +6,8 @@ stage.
 
 # Behavior
 
-We expect to have no alerts, but to see ``http`` events logged, as the flow will
-be inspected still.
+We expect to have no ``alert`` or ``http`` events logged, as the flow will
+be bypassed.
 
 # Pcap
 

--- a/tests/exception-policy-midstream-05/test.yaml
+++ b/tests/exception-policy-midstream-05/test.yaml
@@ -1,5 +1,6 @@
 args:
 - --simulate-ips
+- --set stream.midstrea=true
 - --set stream.midstream-policy=bypass
 
 checks:


### PR DESCRIPTION
From what I understand, the README file description for the 'bypass' (`midstream-05`) test was wrong, and the test for the 'pass-flow' (`midstream-04`) wasn't actually acting as expected due to not having midstream set to true...