### PR TITLE
tests: Update versions to accommodate dsize/bsize validation backport

### DIFF
--- a/run.py
+++ b/run.py
@@ -219,7 +219,9 @@ class Version:
 
     def is_lt(self, v1, v2):
         """Return True if v1 is less than v2."""
-        if v1.major < v2.major:
+        if v1.major > v2.major:
+            return False
+        elif v1.major < v2.major:
             return True
         elif v1.minor < v2.minor:
             return True

--- a/tests/test-bad-content-dsize-rule-1/test.yaml
+++ b/tests/test-bad-content-dsize-rule-1/test.yaml
@@ -1,6 +1,6 @@
 requires:
   min-version: 5.0.0
-  lt-version: 7
+  lt-version: 6.0.10
 
   features:
     - HAVE_LIBJANSSON

--- a/tests/test-bad-content-dsize-rule-2/test.yaml
+++ b/tests/test-bad-content-dsize-rule-2/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  version: 7
+  min-version: 6.0.10
 
 command: |
   ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules

--- a/tests/test-bad-content-dsize-rule-3/test.yaml
+++ b/tests/test-bad-content-dsize-rule-3/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  version: 7
+  min-version: 6.0.10
 
 command: |
   ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/etc/classification.config" --set reference-config-file="${SRCDIR}/etc/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules

--- a/tests/test-bad-dsize-offset-rule-1/test.yaml
+++ b/tests/test-bad-dsize-offset-rule-1/test.yaml
@@ -1,6 +1,6 @@
 requires:
   min-version: 5.0.0
-  lt-version: 7
+  lt-version: 6.0.10
 
   features:
     - HAVE_LIBJANSSON

--- a/tests/test-bad-dsize-offset-rule-2/test.yaml
+++ b/tests/test-bad-dsize-offset-rule-2/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  version: 7
+  min-version: 6.0.10
 
 command: |
   ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules

--- a/tests/test-bad-dsize-range-offset-rule-1/test.yaml
+++ b/tests/test-bad-dsize-range-offset-rule-1/test.yaml
@@ -1,6 +1,6 @@
 requires:
   min-version: 5.0.0
-  lt-version: 7
+  lt-version: 6.0.10
 
   features:
     - HAVE_LIBJANSSON

--- a/tests/test-bad-dsize-range-offset-rule-2/test.yaml
+++ b/tests/test-bad-dsize-range-offset-rule-2/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 7
+  min-version: 6.0.10
 
 command: |
   ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules

--- a/tests/test-bad-dsize-range-rule-1/test.yaml
+++ b/tests/test-bad-dsize-range-rule-1/test.yaml
@@ -1,6 +1,6 @@
 requires:
   min-version: 5.0.0
-  lt-version: 7
+  lt-version: 6.0.10
 
   features:
     - HAVE_LIBJANSSON


### PR DESCRIPTION
This PR updates the versions associated with tests that depend on the new/old bsize/dsize validation. The backport (issue 4317) of the dsize/bsize validation logic to 6.0.x requires tests with different behavior to be version-filtered.