### PR TITLE
tests/content: Validate distance/within values

### DIFF
--- a/run.py
+++ b/run.py
@@ -219,7 +219,9 @@ class Version:
 
     def is_lt(self, v1, v2):
         """Return True if v1 is less than v2."""
-        if v1.major < v2.major:
+        if v1.major > v2.major:
+            return False
+        elif v1.major < v2.major:
             return True
         elif v1.minor < v2.minor:
             return True

--- a/tests/test-content-limits-1/suricata.yaml
+++ b/tests/test-content-limits-1/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: info
+  outputs:
+  - file:
+      enabled: yes
+      filename: eve.json
+      type: json

--- a/tests/test-content-limits-1/test.rules
+++ b/tests/test-content-limits-1/test.rules
@@ -1,0 +1,4 @@
+drop ip :: 0 <> :: 2 (msg:"Invalid within" ;content:" ";within:1048577;dsize:4; sid:1;)
+drop ip :: 0 <> :: 2 (msg:"Invalid within" ;content:" ";within:-1048577;dsize:4; sid:2;)
+drop ip :: 0 <> :: 2 (msg:"Invalid distance" ;content:" ";distance:1048577;dsize:4; sid:3;)
+drop ip :: 0 <> :: 2 (msg:"Invalid distance" ;content:" ";distance:-1048577;dsize:4; sid:4;)

--- a/tests/test-content-limits-1/test.yaml
+++ b/tests/test-content-limits-1/test.yaml
@@ -1,0 +1,50 @@
+requires:
+  min-version: 7
+
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
+checks:
+  # check that we have the following entries in eve.json
+  # match 1 specific rule load failure reason
+  - filter:
+      count: 2
+      match:
+        event_type: engine
+        engine.module: detect-within
+
+  - filter:
+      count: 2
+      match:
+        event_type: engine
+        engine.module: detect-distance
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "invalid value for distance: 1048577"
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "invalid value for distance: -1048577"
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "invalid value for within: 1048577"
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "invalid value for within: -1048577"
+
+  - filter:
+      count: 1
+      match:
+        event_type: engine
+        engine.message: "1 rule files specified, but no rules were loaded!"


### PR DESCRIPTION
This PR validates that the distance and within values for content matches are within the range supported by Suricata.

Issue: 5740

Changes
- Add test cases for distance and within
- Improve the version checking for 'lt' matches