### PR TITLE
tests: fix bad http host rule tests - v1

### DIFF
--- a/tests/test-bad-http-host-rule-1/test.yaml
+++ b/tests/test-bad-http-host-rule-1/test.yaml
@@ -1,6 +1,9 @@
 requires:
   min-version: 7.0.0
 
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
 checks:
   # check that we have the following entres in eve.json
   # match 1 specific rule load failure reason
@@ -8,8 +11,7 @@ checks:
       count: 1
       match:
         event_type: engine
-        engine.message: "rule 1111: A pattern with uppercase chararacters detected for http.host. The hostname buffer is normalized to lowercase, please specify a lowercase pattern."
-
+        engine.message: "rule 1111: A pattern with uppercase characters detected for http.host. The hostname buffer is normalized to lowercase, please specify a lowercase pattern."
   - filter:
       count: 1
       match:

--- a/tests/test-bad-http-host-rule-2/test.yaml
+++ b/tests/test-bad-http-host-rule-2/test.yaml
@@ -1,6 +1,9 @@
 requires:
   min-version: 7.0.0
 
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
+
 checks:
   # check that we have the following entres in eve.json
   # match 1 specific rule load failure reason


### PR DESCRIPTION
The test.yaml files were missing the command set to compare eve.json output and to run without a pcap file, therefore being simply skipped for lack of a pcap file.

Test 1 also had a typo in the expected message to be checked, making it fail.