### PR TITLE
tests: fix bad http host rule tests - v2

### DIFF
--- a/tests/test-bad-http-host-rule-1/test.yaml
+++ b/tests/test-bad-http-host-rule-1/test.yaml
@@ -1,5 +1,5 @@
-requires:
-  min-version: 7.0.0
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
 
 checks:
   # check that we have the following entres in eve.json
@@ -8,10 +8,16 @@ checks:
       count: 1
       match:
         event_type: engine
-        engine.message: "rule 1111: A pattern with uppercase chararacters detected for http.host. The hostname buffer is normalized to lowercase, please specify a lowercase pattern."
-
+        engine.message: "rule 1111: A pattern with uppercase characters detected for http.host. The hostname buffer is normalized to lowercase, please specify a lowercase pattern."
   - filter:
+      lt-version: 7
       count: 1
       match:
         event_type: engine
         engine.error: "SC_ERR_NO_RULES_LOADED"
+  - filter:
+      min-version: 7
+      count: 3
+      match:
+        event_type: engine
+        engine.module: detect

--- a/tests/test-bad-http-host-rule-2/test.yaml
+++ b/tests/test-bad-http-host-rule-2/test.yaml
@@ -1,5 +1,5 @@
-requires:
-  min-version: 7.0.0
+command: |
+  ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules
 
 checks:
   # check that we have the following entres in eve.json
@@ -11,7 +11,15 @@ checks:
         engine.message: "rule 123: http.host keyword specified along with \"nocase\". The hostname buffer is normalized to lowercase, specifying nocase is redundant."
 
   - filter:
+      lt-version: 7
       count: 1
       match:
         event_type: engine
         engine.error: "SC_ERR_NO_RULES_LOADED"
+  - filter:
+      min-version: 7
+      count: 3
+      match:
+        event_type: engine
+        engine.module: detect
+


### PR DESCRIPTION
The test.yaml files were missing the command set to compare eve.json output and to run without a pcap file, therefore being simply skipped for lack of a pcap file.

Test 1 also had a typo in the expected message to be checked, making it fail.

Previous PR: #1038 

Changes from previous PR:
- Make the tests compatible with new error message formats for Suricata 7, as per previous PR review (https://github.com/OISF/suricata-verify/pull/1038#pullrequestreview-1230144201)