### PR TITLE
tests: showcase verdict & no action field in test - v1

### DIFF
--- a/tests/bug-4394-pdonly-drop/suricata.yaml
+++ b/tests/bug-4394-pdonly-drop/suricata.yaml
@@ -13,7 +13,8 @@ outputs:
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
       types:
-        - alert
+        - alert:
+            action: no
         - drop:
             flows: all
             alerts: true

--- a/tests/bug-4394-pdonly-drop/test.yaml
+++ b/tests/bug-4394-pdonly-drop/test.yaml
@@ -8,6 +8,7 @@ args:
 
 checks:
   - filter:
+      lt-version: 7
       count: 1
       match:
         event_type: alert
@@ -15,11 +16,28 @@ checks:
         alert.signature_id: 1
         pcap_cnt: 4
   - filter:
+      lt-version: 7
       count: 1
       match:
         event_type: alert
         alert.action: blocked
         alert.signature_id: 2
+        pcap_cnt: 4
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 1
+        verdict: reject
+        pcap_cnt: 4
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 2
+        verdict: reject
         pcap_cnt: 4
   - filter:
       count: 0
@@ -28,11 +46,20 @@ checks:
         alert.signature_id: 3
 
   - filter:
+      lt-version: 7
       count: 1
       match:
         event_type: drop
         alert.action: blocked
         alert.signature_id: 1
+        pcap_cnt: 4
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: drop
+        alert.signature_id: 1
+        verdict: reject
         pcap_cnt: 4
   - filter:
       count: 1


### PR DESCRIPTION
With the addition of the 'verdict' field and making the 'action' field optional, have at least one test that illustrates this.

Bug #5464

Describe changes:
- disable the action field for the test
- add version checks to version dependent checks
- add check for verdict or action according to Suricata version