### PR TITLE
tests: test midstream w midstream exception policy

### DIFF
--- a/tests/bug-2491-02/suricata.yaml
+++ b/tests/bug-2491-02/suricata.yaml
@@ -1,0 +1,22 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats
+

--- a/tests/bug-2491-02/test.yaml
+++ b/tests/bug-2491-02/test.yaml
@@ -4,6 +4,7 @@ requires:
 args:
 - --set stream.async-oneside=true
 - --set stream.midstream=true
+- --set stream.midstream-policy=drop-flow
 
 checks:
   - filter:


### PR DESCRIPTION
Related to
Bug #5765

Edit a test that needs midstream enabled to also have exception policy midstream set to drop-flow, to check that we're ignoring the exception policy in favour of the stream.midstream setting.

Test `bug-2491-02` should fail until suri pr is merged