### PR TITLE
tests/ftp: add checks for too long alerts

### DIFF
--- a/tests/ftp/ftp-too-long-command/ftp-events.rules
+++ b/tests/ftp/ftp-too-long-command/ftp-events.rules
@@ -1,0 +1,6 @@
+# FTP app-layer event rules
+#
+# SID range start: 2232000
+
+alert ftp any any -> any any (msg:"SURICATA FTP Request command too long"; flow:to_server; app-layer-event:ftp.request_command_too_long; classtype:protocol-command-decode; sid:2232000; rev:1;)
+alert ftp any any -> any any (msg:"SURICATA FTP Response command too long"; flow:to_client; app-layer-event:ftp.response_command_too_long; classtype:protocol-command-decode; sid:2232001; rev:1;)

--- a/tests/ftp/ftp-too-long-command/test.yaml
+++ b/tests/ftp/ftp-too-long-command/test.yaml
@@ -18,3 +18,19 @@ checks:
         ftp.command_data: index.html
         ftp.command_truncated: false
         ftp.reply_truncated: false
+
+  # Look for anomaly event.
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: anomaly
+        anomaly.event: request_command_too_long
+
+  # Look for app-layer alert.
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 2232000

--- a/tests/ftp/ftp-too-long-response/ftp-events.rules
+++ b/tests/ftp/ftp-too-long-response/ftp-events.rules
@@ -1,0 +1,6 @@
+# FTP app-layer event rules
+#
+# SID range start: 2232000
+
+alert ftp any any -> any any (msg:"SURICATA FTP Request command too long"; flow:to_server; app-layer-event:ftp.request_command_too_long; classtype:protocol-command-decode; sid:2232000; rev:1;)
+alert ftp any any -> any any (msg:"SURICATA FTP Response command too long"; flow:to_client; app-layer-event:ftp.response_command_too_long; classtype:protocol-command-decode; sid:2232001; rev:1;)

--- a/tests/ftp/ftp-too-long-response/test.yaml
+++ b/tests/ftp/ftp-too-long-response/test.yaml
@@ -13,3 +13,20 @@ checks:
         event_type: ftp
         ftp.command: PASV
         ftp.reply_truncated: true
+
+  # Look for anomaly event.
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: anomaly
+        anomaly.event: response_command_too_long
+
+  # Look for app-layer alert.
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 2232001
+        


### PR DESCRIPTION
Related issue: 5235
