### PR TITLE
tls: add test for tls keywords v2

### DIFF
--- a/tests/tls-issuerdn/README
+++ b/tests/tls-issuerdn/README
@@ -1,0 +1,13 @@
+Description
+===========
+Tests the `tls.issuerdn` legacy keyword
+Tests the `tls.cert_issuer` new keyword
+Both represent TLS/SSL certificate IssuerDN field
+
+PCAP
+====
+PCAP comes from an [existing TLS test](https://github.com/OISF/suricata-verify/blob/master/tests/tls/tls.pcap)
+
+Redmine ticket
+==============
+https://redmine.openinfosecfoundation.org/issues/5544

--- a/tests/tls-issuerdn/test.yaml
+++ b/tests/tls-issuerdn/test.yaml
@@ -1,0 +1,25 @@
+pcap: ../tls/tls.pcap
+
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+checks:
+  - filter:
+      count: 4
+      match:
+        event_type: tls
+        tls.issuerdn: C=FR, ST=IDF, L=Paris, O=Stamus, CN=SELKS
+        
+  - filter:
+      count: 4
+      match:
+        event_type: alert
+        alert.signature_id: 1
+
+  - filter:
+      count: 4
+      match:
+        event_type: alert
+        alert.signature_id: 2
+

--- a/tests/tls-issuerdn/tls.rules
+++ b/tests/tls-issuerdn/tls.rules
@@ -1,0 +1,6 @@
+//tests tls legacy keyword tls.issuerdn
+alert tls any any -> any any (msg:"TLS issuerDN keyword"; tls.issuerdn:"C=FR, ST=IDF, L=Paris, O=Stamus, CN=SELKS"; sid:1; rev:1;)
+
+//tests new tls keyword tls.cert_issuer
+alert tls any any -> any any (msg:"TLS issuerDN keyword"; tls.cert_issuer; content:"C=FR, ST=IDF, L=Paris, O=Stamus, CN=SELKS"; sid:2; rev:1;)
+

--- a/tests/tls-subject/README
+++ b/tests/tls-subject/README
@@ -1,0 +1,13 @@
+Description
+===========
+Tests the `tls.subject` legacy keyword.
+Tests the `tls.cert_subject` new keyword.
+Both represents TLS/SSL certificate Subject field.
+
+PCAP
+====
+PCAP comes from an [existing TLS test](https://github.com/OISF/suricata-verify/blob/master/tests/tls/tls.pcap)
+
+Redmine ticket
+==============
+https://redmine.openinfosecfoundation.org/issues/5544

--- a/tests/tls-subject/test.yaml
+++ b/tests/tls-subject/test.yaml
@@ -1,0 +1,24 @@
+pcap: ../tls/tls.pcap
+
+requires:
+  features:
+    - HAVE_LIBJANSSON
+
+checks:
+  - filter:
+      count: 4
+      match:
+        event_type: tls
+        tls.subject: C=FR, ST=IDF, L=Paris, O=Stamus, CN=SELKS
+        
+  - filter:
+      count: 4
+      match:
+        event_type: alert
+        alert.signature_id: 1
+        
+  - filter:
+      count: 4
+      match:
+        event_type: alert
+        alert.signature_id: 2

--- a/tests/tls-subject/tls.rules
+++ b/tests/tls-subject/tls.rules
@@ -1,0 +1,5 @@
+//tests tls legacy keyword tls.subject
+alert tls any any -> any any (msg:"TLS subject keyword"; tls.subject:"C=FR, ST=IDF, L=Paris, O=Stamus, CN=SELKS"; sid:1; rev:1;)
+
+//tests tls new keyword tls.cert_subject
+alert tls any any -> any any (msg:"TLS issuerDN keyword"; tls.cert_subject; content:"C=FR, ST=IDF, L=Paris, O=Stamus, CN=SELKS"; sid:2; rev:1;)


### PR DESCRIPTION
Previous PR : #1074 
Describe Changes:

- Update `test.yaml`
- Update `README` file.
- Add tests for new keywords `tls.cert_subject` `tls.cert_issuer`
- Update commit message