### PR TITLE
pcap-log: fix tests for issue 5374

### DIFF
--- a/tests/output-pcap-log-conditional-alert/test.yaml
+++ b/tests/output-pcap-log-conditional-alert/test.yaml
@@ -3,5 +3,5 @@ requires:
 
 checks:
   - file-compare:
-      filename: log.pcap.0
+      filename: log.pcap.1444144603
       expected: expected/log.pcap.1444144603

--- a/tests/output-pcap-log-conditional-tag-alert/test.yaml
+++ b/tests/output-pcap-log-conditional-tag-alert/test.yaml
@@ -3,5 +3,5 @@ requires:
 
 checks:
   - file-compare:
-      filename: log.pcap.0
+      filename: log.pcap.1444144603
       expected: expected/log.pcap.1444144603

--- a/tests/output-pcap-log/test.yaml
+++ b/tests/output-pcap-log/test.yaml
@@ -3,5 +3,5 @@ requires:
 
 checks:
   - file-compare:
-      filename: log.pcap.0
+      filename: log.pcap.1444144603
       expected: expected/log.pcap.1444144603


### PR DESCRIPTION
Suricata 7.0-dev will now use the time of the start packet for pcap logging when reading from a file like 6.0 did.

Issue: 5374

#1066 rebased