### PR TITLE
test: configuration file includes

### DIFF
--- a/tests/config-includes/overrides.yaml
+++ b/tests/config-includes/overrides.yaml
@@ -1,0 +1,11 @@
+%YAML 1.1
+---
+
+# This will override an existing variable.
+vars.address-groups.HOME_NET: "10.10.10.10/32"
+
+# This create a new variable under port-groups.
+vars.port-groups.FTP_PORTS: "[21,2121]"
+
+# And another custom var.
+vars.port-groups.DEV_SERVER_PORTS: "[3000,4200]"

--- a/tests/config-includes/suricata.yaml
+++ b/tests/config-includes/suricata.yaml
@@ -1,0 +1,11 @@
+%YAML 1.1
+---
+
+vars:
+  address-groups:
+    HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
+    EXTERNAL_NET: "!$HOME_NET"
+  port-groups:
+    HTTP_PORTS: "80"
+
+include: overrides.yaml

--- a/tests/config-includes/test.yaml
+++ b/tests/config-includes/test.yaml
@@ -1,0 +1,34 @@
+requires:
+  min-version: 7
+
+pcap: false
+
+args:
+  - --dump-config
+
+checks:
+  # Test for the overriden value of HOME_NET.
+  - shell:
+      args: grep 'vars.address-groups.HOME_NET = 10.10.10.10/32' stdout | wc -l
+      expect: 1
+
+  # Test there is no "HOME-NET".
+  - shell:
+      args: grep 'vars.address-groups.HOME-NET' stdout | wc -l
+      expect: 0
+    
+  # Test for new variable in include file.
+  - shell:
+      args: grep 'vars.port-groups.FTP_PORTS = \[21,2121\]' stdout | wc -l
+      expect: 1
+
+  # Make sure the new variable does not have a '-' in the variable name.
+  - shell:
+      args: grep 'FTP-PORTS' stdout | wc -l
+      expect: 0
+
+  # Test for another new variable in include file.
+  - shell:
+      args: grep 'vars.port-groups.DEV_SERVER_PORTS = \[3000,4200\]' stdout | wc -l
+      expect: 1
+      


### PR DESCRIPTION
Test configuration file includes that also include the new fully
qualified name overrides.

Pay attention to our "_" to "-" translation which should not happen for
variables.
