### PR TITLE
ttl: add tests for prefilter keyword v1

### DIFF
--- a/tests/detect-ttl/README.md
+++ b/tests/detect-ttl/README.md
@@ -1,0 +1,11 @@
+Description
+===========
+Tests the `prefilter` keyword for `ttl` which is used to check for a specific IP time-to-live value in the header of a packet.
+
+PCAP
+====
+PCAP comes from an [existing RFB test](https://github.com/OISF/suricata-verify/blob/master/tests/rfb-protocol-3.8/04-vnc-openwall-3.8.pcap)
+
+Redmine ticket
+==============
+https://redmine.openinfosecfoundation.org/issues/5800

--- a/tests/detect-ttl/test.rules
+++ b/tests/detect-ttl/test.rules
@@ -1,0 +1,1 @@
+alert ip any any -> any any (ttl:128; prefilter; sid:1;)

--- a/tests/detect-ttl/test.yaml
+++ b/tests/detect-ttl/test.yaml
@@ -1,0 +1,8 @@
+pcap: ../rfb-protocol-3.8/04-vnc-openwall-3.8.pcap
+
+checks:
+  - filter:
+      count: 3866
+      match:
+        event_type: alert
+        alert.signature_id: 1


### PR DESCRIPTION
Describe changes:

- Add tests for `prefilter` keyword for `ttl`.