### PR TITLE
(minor) readme: remove mention to pcapng file type - v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Or to run a single test:
 - Create a directory that is the name of the new test.
 
 - Copy a single pcap file into the test directory. It must end in
-  ".pcap" or ".pcapng".
+  ".pcap".
 
   This is enough for a basic test that will run Suricata over the pcap
   testing for a successful exit code.


### PR DESCRIPTION
Since we're not accepting this format, for now, better not to be misleading.

(as pointed out in https://github.com/OISF/suricata-verify/pull/1079#issuecomment-1408641293 )