### PR TITLE
ttl: add tests for prefilter keyword for ipv6 packets

### DIFF
--- a/tests/detect-ttl-ipv6/README.md
+++ b/tests/detect-ttl-ipv6/README.md
@@ -1,0 +1,11 @@
+Description
+===========
+Tests the `prefilter` keyword for `ttl` for `ipv6` packets which is used to check for a specific IP time-to-live value in the header of a packet.
+
+PCAP
+====
+PCAP comes from an [existing IPV6 test](https://github.com/OISF/suricata-verify/blob/master/tests/ipv6-evasion/ipv6-covert-dstopts/covert_send6.pcap04-vnc-openwall-3.8.pcap)
+
+Redmine ticket
+==============
+https://redmine.openinfosecfoundation.org/issues/5800

--- a/tests/detect-ttl-ipv6/test.rules
+++ b/tests/detect-ttl-ipv6/test.rules
@@ -1,0 +1,3 @@
+alert ip any any -> any any (ttl:254; prefilter; sid:1;)
+alert ip any any -> any any (ttl:64; prefilter; sid:2;)
+alert ip any any -> any any (ttl:255; prefilter; sid:3;)

--- a/tests/detect-ttl-ipv6/test.yaml
+++ b/tests/detect-ttl-ipv6/test.yaml
@@ -1,0 +1,20 @@
+pcap: ../ipv6-evasion/ipv6-covert-dstopts/covert_send6.pcap
+
+checks:
+  - filter:
+      count: 18
+      match:
+        event_type: alert
+        alert.signature_id: 1
+
+  - filter:
+      count: 18
+      match:
+        event_type: alert
+        alert.signature_id: 2
+
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 3


### PR DESCRIPTION
Describe changes:

- Add tests for `prefilter` keyword for `ttl` in ipv6 packets.