### PR TITLE
log: Updates needed since Suri stops if logs fail to open at startup

### DIFF
--- a/tests/bug-5198/test.yaml
+++ b/tests/bug-5198/test.yaml
@@ -11,4 +11,4 @@ setup:
 args:
     - --set outputs.1.eve-log.filename=noperms/eve.json --set outputs.1.eve-log.threaded=true
 
-exit-code: 0
+exit-code: 1

--- a/tests/output-eve-anomaly-04/test.yaml
+++ b/tests/output-eve-anomaly-04/test.yaml
@@ -8,3 +8,5 @@ checks:
     - shell:
         args: grep "only one 'anomaly' logger can be enabled" stderr | wc -l | xargs
         expect: 1
+
+exit-code: 1


### PR DESCRIPTION
This PR adjusts existing test cases that now fail due to the fix for 5836. Those changes cause log initialization issues to stop Suricata if they occur at startup.