### PR TITLE
tests: showcase verdict & no action field in test - v2

### DIFF
--- a/tests/bug-4394-pdonly-drop/suricata.yaml
+++ b/tests/bug-4394-pdonly-drop/suricata.yaml
@@ -13,7 +13,8 @@ outputs:
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
       types:
-        - alert
+        - alert:
+            action: false
         - drop:
             flows: all
             alerts: true

--- a/tests/bug-4394-pdonly-drop/test.yaml
+++ b/tests/bug-4394-pdonly-drop/test.yaml
@@ -8,6 +8,7 @@ args:
 
 checks:
   - filter:
+      lt-version: 7
       count: 1
       match:
         event_type: alert
@@ -15,6 +16,7 @@ checks:
         alert.signature_id: 1
         pcap_cnt: 4
   - filter:
+      lt-version: 7
       count: 1
       match:
         event_type: alert
@@ -22,17 +24,91 @@ checks:
         alert.signature_id: 2
         pcap_cnt: 4
   - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 1
+        verdict: reject
+        pcap_cnt: 4
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 2
+        verdict: reject
+        pcap_cnt: 4
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: drop
+        verdict: reject
+        pcap_cnt: 4
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: drop
+        verdict: drop
+        pcap_cnt: 5
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: drop
+        verdict: drop
+        pcap_cnt: 6
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: drop
+        verdict: drop
+        pcap_cnt: 7
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: drop
+        verdict: drop
+        pcap_cnt: 8
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: drop
+        verdict: drop
+        pcap_cnt: 9
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: drop
+        verdict: drop
+        pcap_cnt: 10
+  - filter:
       count: 0
       match:
         event_type: alert
         alert.signature_id: 3
 
   - filter:
+      lt-version: 7
       count: 1
       match:
         event_type: drop
         alert.action: blocked
         alert.signature_id: 1
+        pcap_cnt: 4
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: drop
+        alert.signature_id: 1
+        verdict: reject
         pcap_cnt: 4
   - filter:
       count: 1


### PR DESCRIPTION
With the addition of the 'verdict' field and making the 'action' field optional, have at least one test that illustrates this.

Bug #5464

Previous PR: #1057 

Changes from previous PR:
- rebased and just changed how was disabling the action field in the alert event (s/no/false)