### PR TITLE
Filemagic keywords v3

### DIFF
--- a/tests/file-data-prefilter/README.md
+++ b/tests/file-data-prefilter/README.md
@@ -1,0 +1,11 @@
+Description
+===========
+Tests the `prefilter` keyword for `file_data` and `file.data`.
+
+PCAP
+====
+PCAP comes from an [existing file-data test](https://github.com/OISF/suricata-verify/blob/master/tests/file-data-depth-inspection/file-data-depth-inpsection.pcap)
+
+Redmine ticket
+==============
+https://redmine.openinfosecfoundation.org/issues/5801

--- a/tests/file-data-prefilter/test.rules
+++ b/tests/file-data-prefilter/test.rules
@@ -1,0 +1,4 @@
+# test prefilter keyword for file_data
+alert tcp any any -> any 25 (msg:"VIRUS INBOUND bad file attachment"; flow:to_server,established; content:"content-disposition|3a| attachment|3b|"; nocase; content:".zip|22|"; nocase; within:128; file_data; content:".pdf.exe"; prefilter; within:64; sid:1; rev:1;)
+# test prefilter keyword for file.data
+alert tcp any any -> any 25 (msg:"VIRUS INBOUND bad file attachment"; flow:to_server,established; content:"content-disposition|3a| attachment|3b|"; nocase; content:".zip|22|"; nocase; within:128; file.data; content:".pdf.exe"; prefilter; within:64; sid:2; rev:1;)

--- a/tests/file-data-prefilter/test.yaml
+++ b/tests/file-data-prefilter/test.yaml
@@ -1,0 +1,13 @@
+pcap: ../file-data-depth-inspection/file-data-depth-inpsection.pcap
+
+checks:
+    - filter:
+        count: 2
+        match:
+            event_type: alert
+            alert.signature_id: 1
+    - filter:
+        count: 2
+        match:
+            event_type: alert
+            alert.signature_id: 2

--- a/tests/file-magic-keywords/README.md
+++ b/tests/file-magic-keywords/README.md
@@ -1,0 +1,11 @@
+Description
+===========
+Tests the `filemagic`  keyword.
+
+PCAP
+====
+PCAP comes from an [existing Filestore-filecontainer test](https://github.com/OISF/suricata-verify/blob/master/tests/filestore-filecontainer-http/filecontainer-http.pcap)
+
+Redmine ticket
+==============
+https://redmine.openinfosecfoundation.org/issues/5801

--- a/tests/file-magic-keywords/suricata.yaml
+++ b/tests/file-magic-keywords/suricata.yaml
@@ -1,0 +1,15 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      types:
+        - files
+        - stats
+        - alert
+  - file-store:
+      version: 2
+      enabled: yes
+      stream-depth: 0
+      write-fileinfo: true

--- a/tests/file-magic-keywords/test.rules
+++ b/tests/file-magic-keywords/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (msg:"store png images"; filemagic:"PNG image data"; filestore; sid:1; rev:1;)

--- a/tests/file-magic-keywords/test.yaml
+++ b/tests/file-magic-keywords/test.yaml
@@ -1,0 +1,24 @@
+pcap: ../filestore-filecontainer-http/filecontainer-http.pcap
+
+requires:
+  features:
+    - MAGIC
+  files:
+    - src/output-filestore.c
+
+checks:
+
+   - shell:
+        args: test -e filestore/e0/e092858d5bd66ab33085a966ee4ac0bf0edf6eab8d8b1e66432ee600e904bb4f
+
+   - shell:
+        args: test ! -e filestore/03/031b2bbeda6fd7e877e50298d2b2ded2073ce6e15f29029b4e50dbd9e81f6be6
+
+   - filter:
+       count: 1
+       match: 
+          event_type: alert 
+          alert.signature_id: 1
+
+   - stats:
+      file_store.fs_errors: 0


### PR DESCRIPTION
Previous PR: #1127
Describe Changes:

- Update comments for `file_data prefilter` tests
- Add `test.yaml` to add checks for `filestore` and incorporate stats.