### PR TITLE
Fix missing require in .lua files. V1

### DIFF
--- a/tests/dns-lua-rules/test-request.lua
+++ b/tests/dns-lua-rules/test-request.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 function init (args)
    local needs = {}
    needs["dns.request"] = tostring(true)

--- a/tests/dns-lua-rules/test-response.lua
+++ b/tests/dns-lua-rules/test-response.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 function init (args)
    local needs = {}
    needs["dns.response"] = tostring(true)

--- a/tests/dns-lua-rules/test-rrname.lua
+++ b/tests/dns-lua-rules/test-rrname.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 function init (args)
    local needs = {}
    needs["dns.rrname"] = tostring(true)

--- a/tests/lua-byte-extract/lua-byte-extract.lua
+++ b/tests/lua-byte-extract/lua-byte-extract.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 function init(args)
     local needs = {}
     needs["bytevar"] = {"var1", "var2"}

--- a/tests/lua-byte-extract/lua-byte-math.lua
+++ b/tests/lua-byte-extract/lua-byte-math.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 function init(args)
     local needs = {}
     needs["bytevar"] = {"var2"}

--- a/tests/lua-match-scrule/lua-scrule-action.lua
+++ b/tests/lua-match-scrule/lua-scrule-action.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 function init(args)
     local needs = {}
     return needs

--- a/tests/lua-match-scrule/lua-scrule-class.lua
+++ b/tests/lua-match-scrule/lua-scrule-class.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 function init(args)
     local needs = {}
     return needs

--- a/tests/lua-match-scrule/lua-scrule-ids.lua
+++ b/tests/lua-match-scrule/lua-scrule-ids.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 function init(args)
     local needs = {}
     return needs

--- a/tests/lua-match-scrule/lua-scrule-msg.lua
+++ b/tests/lua-match-scrule/lua-scrule-msg.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 function init(args)
     local needs = {}
     return needs

--- a/tests/lua-output-dns/test.lua
+++ b/tests/lua-output-dns/test.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 filename = "lua-dns.log"
 
 function init (args)

--- a/tests/lua-output-http/http.lua
+++ b/tests/lua-output-http/http.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 -- simple fast-log to file lua module
 name = "http_lua.log"
 

--- a/tests/lua-output-smtp/smtp.lua
+++ b/tests/lua-output-smtp/smtp.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 -- simple fast-log to file lua module
 name = "smtp_lua.log"
 

--- a/tests/lua-scfileinfo/scfileinfo.lua
+++ b/tests/lua-scfileinfo/scfileinfo.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 -- Output test for SCFileInfo
 file_name = "scfileinfo.log"
 

--- a/tests/lua-scflowstats/lua-scflowstats.lua
+++ b/tests/lua-scflowstats/lua-scflowstats.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 -- lua_pushinteger output test for SCFlowStats and ...
 name = "lua-scflowstats.log"
 

--- a/tests/lua-scflowtuple/scflowtuple.lua
+++ b/tests/lua-scflowtuple/scflowtuple.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 -- simple SCFlowTuple log test
 name = "scflow-tuple.log"
 

--- a/tests/lua-scflowvarget/test.lua
+++ b/tests/lua-scflowvarget/test.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 function init (args)
     local needs = {}
     needs["http.request_headers"] = tostring(true)

--- a/tests/lua-scpackettuple/scpackettuple.lua
+++ b/tests/lua-scpackettuple/scpackettuple.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 -- simple SCPacketTuple log test
 name = "scpacket-tuple.log"
 

--- a/tests/lua-scrule-ids/lua-scrule-ids.lua
+++ b/tests/lua-scrule-ids/lua-scrule-ids.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 -- lua_pushinteger output test for SCRuleIds and ...
 name = "lua-scrule-ids.log"
 

--- a/tests/tls-ja3s/test-ja3s-hash.lua
+++ b/tests/tls-ja3s/test-ja3s-hash.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 function init(args)
     local needs = {}
     needs["tls"] = tostring(true)

--- a/tests/tls-ja3s/test-ja3s-string.lua
+++ b/tests/tls-ja3s/test-ja3s-string.lua
@@ -1,3 +1,4 @@
+local io = require("io")
 function init(args)
     local needs = {}
     needs["tls"] = tostring(true)


### PR DESCRIPTION
Without "local io = require("io")", the tests that use .lua files did not work with Lua 5.2.4