### PR TITLE
smtp-eve: fix filesize and version check

### DIFF
--- a/tests/smtp-eve/test.yaml
+++ b/tests/smtp-eve/test.yaml
@@ -64,7 +64,7 @@ checks:
       src_port: 1470
       tx_id: 0
 - filter:
-    version: 6.0.0 # FIXME ref: https://redmine.openinfosecfoundation.org/issues/5821
+    min-version: 6.0.0
     count: 1
     match:
       app_proto: smtp
@@ -77,11 +77,10 @@ checks:
       event_type: fileinfo
       fileinfo.filename: NEWS.txt
       fileinfo.gaps: false
-      fileinfo.size: 10735
+      fileinfo.size: 10809
       fileinfo.state: CLOSED
       fileinfo.stored: false
       fileinfo.tx_id: 0
-      pcap_cnt: 51
       proto: TCP
       smtp.helo: GP
       smtp.mail_from: <gurpartap@patriots.in>


### PR DESCRIPTION
Earlier, the CRLFs that were a part of the file were also stripped off as a part of finding and stripping the delimiters in the MIME handler. This was fixed as a part of
https://redmine.openinfosecfoundation.org/issues/5725. This patch fixes the test too to reflect the fix.

Ticket: [5821](https://redmine.openinfosecfoundation.org/issues/5821)