### PR TITLE
tests: test defrag exception policy with drop-flow - v1

### DIFF
--- a/tests/exception-policy-defrag-01/test.yaml
+++ b/tests/exception-policy-defrag-01/test.yaml
@@ -8,7 +8,7 @@ args:
 - -k none
 # pretend pretend error in the first fragment
 - --simulate-packet-defrag-memcap=1
-- --set defrag.memcap-policy=drop-packet
+- --set defrag.memcap-policy=drop-flow
 checks:
   - filter:
       count: 0


### PR DESCRIPTION
Defrag memcap and flow memcap do not support flow action for the exception policies, as there is no flow when the exception condition is hit. In such cases, the exception policy must be considered as `drop-packet`. This commit changes the defrag exception policy test to check if this behavior is working.