### PR TITLE
smb: fix test for master6

### DIFF
--- a/tests/smb2-07/test.yaml
+++ b/tests/smb2-07/test.yaml
@@ -11,11 +11,12 @@ args:
 
 checks:
   - filter:
-      version: 6.0.0  # FIXME ref: https://redmine.openinfosecfoundation.org/issues/5820
-      count: 58
+      version: 6
+      count: 59
       match:
         event_type: smb
   - filter:
+      # additional event for file deletion
       min-version: 7
       count: 60
       match:


### PR DESCRIPTION
Difference with 7 is missing feature file deletion

Addition since 6.0.0 is async response cf smb2.aid wireshark filter

[Ticket: #5820](https://redmine.openinfosecfoundation.org/issues/5820)