### PR TITLE
tests: add test for flow.memcap exception policy - v1

### DIFF
--- a/tests/exception-policy-simulated-flow-memcap/README.md
+++ b/tests/exception-policy-simulated-flow-memcap/README.md
@@ -1,0 +1,19 @@
+Test
+====
+
+Test both the exception policy for when Suricata reaches a flow memcap, and the
+command-line option to simulate said memcap hit.
+
+Expected Behavior
+=================
+
+When Suricata tries to create a new flow reaching packet 6, it will simulate a
+failure, therefore dropping said packet. As midstream pickup is said to true,
+Suri will later on register a midstream flow for that. Other packets/flows will
+be decoded and inspected normally.
+
+PCAP
+====
+
+Pcap from `tls` suricata-verify test.
+

--- a/tests/exception-policy-simulated-flow-memcap/suricata.yaml
+++ b/tests/exception-policy-simulated-flow-memcap/suricata.yaml
@@ -1,0 +1,24 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      types:
+        - alert:
+            tagged-packets: yes
+        - anomaly:
+            enabled: yes
+            types:
+              decode: no
+              stream: yes
+              applayer: yes
+        - tls:
+            extended: yes     # enable this for extended logging information
+        - drop:
+            alerts: yes      # log alerts that caused drops
+            flows: all       # start or all: 'start' logs only a single drop
+        - flow
+        - stats
+
+exception-policy: ignore

--- a/tests/exception-policy-simulated-flow-memcap/test.rules
+++ b/tests/exception-policy-simulated-flow-memcap/test.rules
@@ -1,0 +1,1 @@
+alert tls any any -> any any (msg:"tls app-proto"; sid:1000001; rev:1;)

--- a/tests/exception-policy-simulated-flow-memcap/test.yaml
+++ b/tests/exception-policy-simulated-flow-memcap/test.yaml
@@ -1,0 +1,32 @@
+requires:
+  features:
+    - DEBUG
+
+pcap: ../tls/tls-cert-issuer/tls.pcap
+
+args:
+- --simulate-ips
+- -k none
+- --set stream.midstream=true
+- --simulate-packet-flow-memcap=6
+- --set flow.memcap-policy=drop-flow
+
+checks:
+  - filter:
+      count: 97
+      match:
+        event_type: alert
+  - filter:
+      count: 1
+      match:
+        event_type: drop
+        drop.reason: "flow memcap"
+  - filter:
+      count: 5
+      match:
+        event_type: tls
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.midstream_pickups: 1


### PR DESCRIPTION
This test is for simulated flow memcaps only, as I wasn't able to craft a situation where there's a flow memcap.