### PR TITLE
tests: add exception/policy stats counters - v2

### DIFF
--- a/tests/exception-policy-applayer-01/suricata.yaml
+++ b/tests/exception-policy-applayer-01/suricata.yaml
@@ -14,12 +14,19 @@ outputs:
               stream: yes
               applayer: yes
         - tls:
-            extended: yes     # enable this for extended logging information
+            extended: yes
         - drop:
-            alerts: yes      # log alerts that caused drops
-            flows: all       # start or all: 'start' logs only a single drop
-                             # per flow direction. All logs each dropped pkt.
+            alerts: yes
+            flows: all
+        - stats:
+            totals: yes
+            threads: no
+            deltas: no
         - flow
+  - stats:
+      enabled: yes
+      filename: stats.log
+
 action-order:
   - pass
   - drop

--- a/tests/exception-policy-default-01/suricata.yaml
+++ b/tests/exception-policy-default-01/suricata.yaml
@@ -12,9 +12,12 @@ outputs:
         - drop:
             alerts: yes      # log alerts that caused drops
             flows: all       # start or all: 'start' logs only a single drop
-                             # per flow direction. All logs each dropped pkt.
+        - stats
+
 action-order:
   - pass
   - drop
   - reject
   - alert
+
+exception-policy: ignore

--- a/tests/exception-policy-default-01/test.yaml
+++ b/tests/exception-policy-default-01/test.yaml
@@ -1,12 +1,12 @@
 requires:
   features:
     - DEBUG
-  files:
-    - src/util-exception-policy.c
+
 pcap: ../tls/tls-ja3s/input.pcap
 args:
 - --simulate-ips
 - -k none
+
 checks:
   - filter:
       count: 0
@@ -21,3 +21,25 @@ checks:
       match:
         event_type: tls
         tls.sni: example.com
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        stats.flow.memcap_exception_policy.bypass: 0
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.reassembly_exception_policy.reject: 0
+        stats.tcp.midstream_exception_policy.pass_flow: 0
+        stats.tcp.ssn_memcap_exception_policy.drop_flow: 0
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        stats.app_layer.error.tls.exception_policy.drop_packet: 0
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        stats.defrag.memcap_exception_policy.ignore: 0

--- a/tests/exception-policy-defrag-01/suricata.yaml
+++ b/tests/exception-policy-defrag-01/suricata.yaml
@@ -20,6 +20,8 @@ outputs:
             flows: all       # start or all: 'start' logs only a single drop
                              # per flow direction. All logs each dropped pkt.
         - flow
+        - stats
+
 action-order:
   - pass
   - drop

--- a/tests/exception-policy-defrag-01/test.yaml
+++ b/tests/exception-policy-defrag-01/test.yaml
@@ -1,8 +1,6 @@
 requires:
   features:
     - DEBUG
-  files:
-    - src/util-exception-policy.c
 args:
 - --simulate-ips
 - -k none
@@ -34,3 +32,9 @@ checks:
         event_type: flow
         flow.action: drop
         proto: ICMP
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        stats.defrag.memcap_exception_policy.drop_packet: 1
+

--- a/tests/exception-policy-midstream-01/suricata.yaml
+++ b/tests/exception-policy-midstream-01/suricata.yaml
@@ -26,3 +26,6 @@ outputs:
         - drop:
             alerts: yes
             flows: all
+        - stats
+
+exception-policy: ignore

--- a/tests/exception-policy-midstream-01/test.yaml
+++ b/tests/exception-policy-midstream-01/test.yaml
@@ -16,3 +16,8 @@ checks:
       count: 0
       match:
         event_type: http
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.midstream_exception_policy.pass_flow: 9

--- a/tests/exception-policy-midstream-02/suricata.yaml
+++ b/tests/exception-policy-midstream-02/suricata.yaml
@@ -17,3 +17,4 @@ outputs:
             flows: start     # start or all: 'start' logs only a single drop
                              # per flow direction. All logs each dropped pkt.
         - flow
+        - stats

--- a/tests/exception-policy-midstream-02/test.yaml
+++ b/tests/exception-policy-midstream-02/test.yaml
@@ -22,3 +22,8 @@ checks:
       count: 0
       match:
         event_type: anomaly
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.midstream_exception_policy.drop_flow: 1

--- a/tests/exception-policy-midstream-03/suricata.yaml
+++ b/tests/exception-policy-midstream-03/suricata.yaml
@@ -15,3 +15,4 @@ outputs:
             http: yes
         - flow
         - http
+        - stats

--- a/tests/exception-policy-midstream-03/test.yaml
+++ b/tests/exception-policy-midstream-03/test.yaml
@@ -22,3 +22,8 @@ checks:
       match:
         event_type: http
         dest_port: 80
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.midstream_exception_policy.ignore: 1

--- a/tests/exception-policy-midstream-04/suricata.yaml
+++ b/tests/exception-policy-midstream-04/suricata.yaml
@@ -8,3 +8,4 @@ outputs:
         - alert
         - flow
         - http
+        - stats

--- a/tests/exception-policy-midstream-04/test.yaml
+++ b/tests/exception-policy-midstream-04/test.yaml
@@ -17,3 +17,8 @@ checks:
     count: 0
     match:
       event_type: http
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.tcp.midstream_exception_policy.pass_flow: 2

--- a/tests/exception-policy-midstream-05/suricata.yaml
+++ b/tests/exception-policy-midstream-05/suricata.yaml
@@ -22,6 +22,7 @@ outputs:
               deployment: reverse
               header: X-Forwarded-For
         - flow
+        - stats
         - http
         - drop:
             alerts: yes

--- a/tests/exception-policy-midstream-05/test.yaml
+++ b/tests/exception-policy-midstream-05/test.yaml
@@ -16,3 +16,8 @@ checks:
       count: 0
       match:
         event_type: http
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.midstream_exception_policy.bypass: 1

--- a/tests/exception-policy-midstream-06/suricata.yaml
+++ b/tests/exception-policy-midstream-06/suricata.yaml
@@ -8,6 +8,7 @@ outputs:
         - alert:
         - flow
         - http
+        - stats
         - drop:
             alerts: yes
             flows: all

--- a/tests/exception-policy-midstream-06/test.yaml
+++ b/tests/exception-policy-midstream-06/test.yaml
@@ -16,4 +16,8 @@ checks:
       match:
         event_type: flow
         flow.action: drop
-
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.midstream_exception_policy.drop_flow: 1

--- a/tests/exception-policy-simulated-flow-memcap/README.md
+++ b/tests/exception-policy-simulated-flow-memcap/README.md
@@ -1,0 +1,19 @@
+Test
+====
+
+Test both the exception policy for when Suricata reaches a flow memcap, and the
+command-line option to simulate said memcap hit.
+
+Expected Behavior
+=================
+
+When Suricata tries to create a new flow reaching packet 6, it will simulate a
+failure, therefore dropping said packet. As midstream pickup is said to true,
+Suri will later on register a midstream flow for that. Other packets/flows will
+be decoded and inspected normally.
+
+PCAP
+====
+
+Pcap from `tls` suricata-verify test.
+

--- a/tests/exception-policy-simulated-flow-memcap/suricata.yaml
+++ b/tests/exception-policy-simulated-flow-memcap/suricata.yaml
@@ -1,0 +1,24 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      types:
+        - alert:
+            tagged-packets: yes
+        - anomaly:
+            enabled: yes
+            types:
+              decode: no
+              stream: yes
+              applayer: yes
+        - tls:
+            extended: yes     # enable this for extended logging information
+        - drop:
+            alerts: yes      # log alerts that caused drops
+            flows: all       # start or all: 'start' logs only a single drop
+        - flow
+        - stats
+
+exception-policy: ignore

--- a/tests/exception-policy-simulated-flow-memcap/test.rules
+++ b/tests/exception-policy-simulated-flow-memcap/test.rules
@@ -1,0 +1,1 @@
+alert tls any any -> any any (msg:"tls app-proto"; sid:1000001; rev:1;)

--- a/tests/exception-policy-simulated-flow-memcap/test.yaml
+++ b/tests/exception-policy-simulated-flow-memcap/test.yaml
@@ -1,0 +1,32 @@
+requires:
+  features:
+    - DEBUG
+
+pcap: ../tls/tls-cert-issuer/tls.pcap
+
+args:
+- --simulate-ips
+- -k none
+- --set stream.midstream=true
+- --simulate-packet-flow-memcap=6
+- --set flow.memcap-policy=drop-flow
+
+checks:
+  - filter:
+      count: 97
+      match:
+        event_type: alert
+  - filter:
+      count: 1
+      match:
+        event_type: drop
+        drop.reason: "flow memcap"
+  - filter:
+      count: 5
+      match:
+        event_type: tls
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.midstream_pickups: 1

--- a/tests/exception-policy-simulated-flow-memcap/test.yaml
+++ b/tests/exception-policy-simulated-flow-memcap/test.yaml
@@ -30,3 +30,4 @@ checks:
       match:
         event_type: stats
         stats.tcp.midstream_pickups: 1
+        stats.flow.memcap_exception_policy.drop_packet: 1

--- a/tests/exception-policy-stream-reassembly-memcap-01/suricata.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-01/suricata.yaml
@@ -20,6 +20,10 @@ outputs:
             flows: all       # start or all: 'start' logs only a single drop
                              # per flow direction. All logs each dropped pkt.
         - flow
+        - stats:
+            totals: yes
+            threads: no
+
 action-order:
   - pass
   - drop

--- a/tests/exception-policy-stream-reassembly-memcap-06/suricata.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-06/suricata.yaml
@@ -14,3 +14,5 @@ outputs:
             flows: all       # start or all: 'start' logs only a single drop
                              # per flow direction. All logs each dropped pkt.
         - flow
+        - stats
+

--- a/tests/exception-policy-stream-reassembly-memcap-06/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-06/test.yaml
@@ -49,3 +49,8 @@ checks:
       match:
         event_type: flow
         flow.action: drop
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.reassembly_exception_policy.pass_packet: 1

--- a/tests/exception-policy-stream-ssn-memcap-01/suricata.yaml
+++ b/tests/exception-policy-stream-ssn-memcap-01/suricata.yaml
@@ -20,6 +20,8 @@ outputs:
             flows: all       # start or all: 'start' logs only a single drop
                              # per flow direction. All logs each dropped pkt.
         - flow
+        - stats
+
 action-order:
   - pass
   - drop

--- a/tests/exception-policy-stream-ssn-memcap-01/test.yaml
+++ b/tests/exception-policy-stream-ssn-memcap-01/test.yaml
@@ -47,3 +47,8 @@ checks:
       match:
         event_type: flow
         flow.action: drop
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.ssn_memcap_exception_policy.drop_flow: 1


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata-verify/pull/1160

Add exception policy counters to the existing exception-policy tests

Includes commit that should hopefully be merged before this one (the simulated flow memcap tests).

Changes from previous PR:
- removed test for flowmemcap, since I wasn't able to craft one that works.
