### PR TITLE
alert-testmyids: add target to rule

### DIFF
--- a/tests/alert-testmyids/test.rules
+++ b/tests/alert-testmyids/test.rules
@@ -1,1 +1,1 @@
-alert ip any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:2100498; rev:7;)
+alert ip any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; target:dest_ip; classtype:bad-unknown; sid:2100498; rev:7;)


### PR DESCRIPTION
Choose a simple test to add the target keyword to as no other tests do
this. This will excercise the "source" and "target" fields in the JSON
schema.
