### PR TITLE
http2: adds more signature keywords test

### DIFF
--- a/tests/http2-keywords2/test.rules
+++ b/tests/http2-keywords2/test.rules
@@ -11,3 +11,9 @@ alert http2 any any -> any any (http.host.raw; content:"nghttp2.org"; sid:32;)
 
 alert http2 any any -> any any (http.header_names; content:"|0d 0a|user-agent|0d 0a|accept|0d 0a|"; sid:33;)
 alert http2 any any -> any any (http.header; content:"user-agent: curl/7.61.0|0d 0a|accept: */*|0d 0a|"; sid:34;)
+
+alert http2 any any -> any any (http.protocol; content:"HTTP/2"; sid:35;)
+alert http2 any any -> any any (http.response_body; content:"not found"; sid:36;)
+alert http2 any any -> any any (http_request_line; content:"GET /humans.txt HTTP/2"; sid:37;)
+alert http2 any any -> any any (http.stat_msg; content:!"OK"; sid:38;)
+alert http2 any any -> any any (http.stat_msg; bsize:0; sid:39;)

--- a/tests/http2-keywords2/test.yaml
+++ b/tests/http2-keywords2/test.yaml
@@ -60,3 +60,28 @@ checks:
       match:
         event_type: alert
         alert.signature_id: 34
+  - filter:
+      count: 12
+      match:
+        event_type: alert
+        alert.signature_id: 35
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 36
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 37
+  - filter:
+      count: 6
+      match:
+        event_type: alert
+        alert.signature_id: 38
+  - filter:
+      count: 6
+      match:
+        event_type: alert
+        alert.signature_id: 39


### PR DESCRIPTION
Ticket: #4067

Extends #1164 with more checks for signatures with `http.stat_msg` keyword

Requires next version of https://github.com/OISF/suricata/pull/8704