### PR TITLE
github: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+
+## Ticket
+
+If your pull request is related to a Suricata ticket, please provide
+the full URL to the ticket here so this pull request can monitor
+changes to the ticket status:
+
+Redmine ticket:


### PR DESCRIPTION
For now it just asks for a Redmine ticket URL. We can use this to link
Suricata-Verify pull requests to Suricata features and pull requests,
potentially creating a script to update S-V pull requests when the
ticket status changes, or a Suricata pull request has been merged.
