### PR TITLE
github-ci: fix almalinux version

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -88,7 +88,7 @@ jobs:
   almalinux:
     name: AlmaLinux 8
     runs-on: ubuntu-latest
-    container: almalinux:latest
+    container: almalinux:8
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
AlmaLinux:latest is now 9, and this job is for AlmaLinux 8.
