### PR TITLE
datasets: test to load invalid encoded string

### DIFF
--- a/tests/datasets-invalid-encoding/README.md
+++ b/tests/datasets-invalid-encoding/README.md
@@ -1,0 +1,9 @@
+# Test Description
+
+This test demonstrates that datasets would error out in case they're
+given a bad base64 encoded string to load.
+
+
+## Related issues
+
+https://redmine.openinfosecfoundation.org/issues/5885

--- a/tests/datasets-invalid-encoding/datasets.csv
+++ b/tests/datasets-invalid-encoding/datasets.csv
@@ -1,0 +1,1 @@
+Y3VybC83Lj!QzLjA=

--- a/tests/datasets-invalid-encoding/test.rules
+++ b/tests/datasets-invalid-encoding/test.rules
@@ -1,0 +1,2 @@
+alert http any any -> any any (http.user_agent; dataset:isset,ua-seen,type string,load datasets.csv; sid:1;)
+alert http any any -> any any (http.user_agent; dataset:isnotset,ua-seen,type string,load datasets.csv; sid:2;)

--- a/tests/datasets-invalid-encoding/test.yaml
+++ b/tests/datasets-invalid-encoding/test.yaml
@@ -1,0 +1,10 @@
+requires:
+  files:
+    - src/datasets.c
+
+pcap: false
+
+args:
+ - -k none
+
+exit-code: 1


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata-verify/pull/1149

Changes since v1:
- Remove pcap reference as it is not needed