### PR TITLE
Add tests for exception policy midstream bug 5825 - v1

### DIFF
--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-bypass/README.md
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-bypass/README.md
@@ -1,0 +1,14 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``bypass``. This test is for IDS mode.
+
+# Behavior
+
+We expect to see no alerts nor ``http`` events logged, as the flow won't be inspected.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-bypass/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-bypass/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-bypass/test.rules
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-bypass/test.rules
@@ -1,0 +1,2 @@
+alert ip any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:2100498; rev:7;)
+alert http any any -> any any (msg:"HTTP traffic"; sid:001; rev:1;)

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-bypass/test.yaml
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-bypass/test.yaml
@@ -1,0 +1,20 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --set stream.midstream=false
+- --set stream.midstream-policy=bypass
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+  - filter:
+      count: 0
+      match:
+        event_type: http
+  - filter:
+      count: 1
+      match:
+        event_type: flow
+        flow.state: bypassed

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-drop-packet/README.md
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-drop-packet/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``drop-packet``. This test is for IDS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``drop-packet`` isn't a valid
+exception policy value for the midstream exception policy.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-drop-packet/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-drop-packet/suricata.yaml
@@ -1,0 +1,36 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats
+
+logging:
+  default-log-level: notice
+  outputs:
+  - console:
+      enabled: yes
+      type: json

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-drop-packet/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-drop-packet/suricata.yaml
@@ -31,6 +31,8 @@ outputs:
 logging:
   default-log-level: notice
   outputs:
-  - console:
+  - file:
       enabled: yes
+      level: notice
+      filename: suricata.json
       type: json

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-drop-packet/test.yaml
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-drop-packet/test.yaml
@@ -1,0 +1,9 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --set stream.midstream=false
+- --set stream.midstream-policy=drop-packet

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-drop-packet/test.yaml
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-drop-packet/test.yaml
@@ -1,4 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
+
 requires:
   min-version: 6
 
@@ -7,3 +8,11 @@ exit-code: 1
 args:
 - --set stream.midstream=false
 - --set stream.midstream-policy=drop-packet
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-ignore/README.md
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-ignore/README.md
@@ -1,0 +1,14 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``ignore``. This test is for IDS mode.
+
+# Behavior
+
+We expect to see no alerts nor ``http`` events logged, as the flow won't be inspected.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-ignore/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-ignore/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-ignore/test.rules
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-ignore/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (msg:"HTTP traffic"; sid:001; rev:1;)

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-ignore/test.yaml
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-ignore/test.yaml
@@ -1,0 +1,15 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --set stream.midstream=false
+- --set stream.midstream-policy=ignore
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+  - filter:
+      count: 0
+      match:
+        event_type: http

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-flow/README.md
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-flow/README.md
@@ -1,0 +1,14 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``pass-flow``. This test is for IDS mode.
+
+# Behavior
+
+We expect to see no alerts nor ``http`` events logged, as the flow won't be inspected.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-flow/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-flow/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-flow/test.rules
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-flow/test.rules
@@ -1,0 +1,2 @@
+alert ip any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:2100498; rev:7;)
+alert http any any -> any any (msg:"HTTP traffic"; sid:001; rev:1;)

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-flow/test.yaml
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-flow/test.yaml
@@ -1,0 +1,20 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --set stream.midstream=false
+- --set stream.midstream-policy=pass-flow
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+  - filter:
+      count: 0
+      match:
+        event_type: http
+  - filter:
+      count: 1
+      match:
+        event_type: flow
+        flow.action: pass

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-packet/README.md
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-packet/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``pass-packet``. This test is for IDS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``pass-packet`` isn't a valid
+exception policy value for the midstream exception policy.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-packet/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-packet/suricata.yaml
@@ -1,0 +1,36 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats
+
+logging:
+  default-log-level: notice
+  outputs:
+  - console:
+      enabled: yes
+      type: json

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-packet/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-packet/suricata.yaml
@@ -31,6 +31,8 @@ outputs:
 logging:
   default-log-level: notice
   outputs:
-  - console:
+  - file:
       enabled: yes
+      level: notice
+      filename: suricata.json
       type: json

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-packet/test.yaml
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-packet/test.yaml
@@ -9,3 +9,10 @@ args:
 - --set stream.midstream=false
 - --set stream.midstream-policy=pass-packet
 
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-packet/test.yaml
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-pass-packet/test.yaml
@@ -1,0 +1,11 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --set stream.midstream=false
+- --set stream.midstream-policy=pass-packet
+

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-reject/README.md
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-reject/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``reject``. This test is for IDS mode.
+
+# Behavior
+
+We expect to see no alerts nor ``http`` events logged, as the session won't be
+tracked.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-reject/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-reject/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-reject/test.rules
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-reject/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (msg:"HTTP traffic"; sid:001; rev:1;)

--- a/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-reject/test.yaml
+++ b/tests/exception-policy-ids-midstream-disabled/exception-policy-midstream-disabled-reject/test.yaml
@@ -1,0 +1,20 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --set stream.midstream=false
+- --set stream.midstream-policy=reject
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+  - filter:
+      count: 0
+      match:
+        event_type: http
+  - filter:
+      count: 1
+      match:
+        event_type: flow
+        flow.action: drop

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-bypass/README.md
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-bypass/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``bypass``. This test is for IDS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``bypass`` isn't a valid
+exception policy value when midstream picku-up sessions are enabled.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-bypass/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-bypass/suricata.yaml
@@ -32,6 +32,8 @@ outputs:
 logging:
   default-log-level: notice
   outputs:
-  - console:
+  - file:
       enabled: yes
+      level: notice
+      filename: suricata.json
       type: json

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-bypass/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-bypass/suricata.yaml
@@ -1,0 +1,37 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats
+  - stats
+
+logging:
+  default-log-level: notice
+  outputs:
+  - console:
+      enabled: yes
+      type: json

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-bypass/test.rules
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-bypass/test.rules
@@ -1,0 +1,1 @@
+alert ip any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:2100498; rev:7;)

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-bypass/test.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-bypass/test.yaml
@@ -2,7 +2,6 @@ pcap: ../../exception-policy-midstream-03/input.pcap
 
 requires:
   min-version: 6
-  pcap: false
 
 exit-code: 1
 

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-bypass/test.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-bypass/test.yaml
@@ -1,0 +1,19 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+  pcap: false
+
+exit-code: 1
+
+args:
+- --set stream.midstream=true
+- --set stream.midstream-policy=bypass
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-drop-packet/README.md
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-drop-packet/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``drop-packet``. This test is for IDS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``drop-packet`` isn't a valid
+exception policy value when midstream picku-up sessions are enabled.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-drop-packet/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-drop-packet/suricata.yaml
@@ -1,0 +1,36 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats
+
+logging:
+  default-log-level: notice
+  outputs:
+  - console:
+      enabled: yes
+      type: json

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-drop-packet/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-drop-packet/suricata.yaml
@@ -31,6 +31,8 @@ outputs:
 logging:
   default-log-level: notice
   outputs:
-  - console:
+  - file:
       enabled: yes
+      level: notice
+      filename: suricata.json
       type: json

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-drop-packet/test.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-drop-packet/test.yaml
@@ -1,0 +1,10 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --set stream.midstream=true
+- --set stream.midstream-policy=drop-packet

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-drop-packet/test.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-drop-packet/test.yaml
@@ -8,3 +8,11 @@ exit-code: 1
 args:
 - --set stream.midstream=true
 - --set stream.midstream-policy=drop-packet
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-ignore/README.md
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-ignore/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``ignore``. This test is for IDS mode.
+
+# Behavior
+
+We expect to see alerts and ``http`` events logged, as the flow will
+be inspected.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-ignore/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-ignore/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-ignore/test.rules
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-ignore/test.rules
@@ -1,0 +1,1 @@
+alert ip any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:2100498; rev:7;)

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-ignore/test.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-ignore/test.yaml
@@ -1,0 +1,15 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --set stream.midstream=true
+- --set stream.midstream-policy=ignore
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+  - filter:
+      count: 1
+      match:
+        event_type: http

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-flow/README.md
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-flow/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``pass-flow``. This test is for IDS mode.
+
+# Behavior
+
+We expect to see no alerts, since detection won't run due to ``pass-flow``, but
+to see ``http`` events logged, as the flow will be inspected.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-flow/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-flow/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-flow/test.rules
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-flow/test.rules
@@ -1,0 +1,2 @@
+alert ip any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:2100498; rev:7;)
+alert http any any -> any any (msg:"HTTP traffic"; sid:001; rev:1;)

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-flow/test.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-flow/test.yaml
@@ -1,0 +1,15 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --set stream.midstream=true
+- --set stream.midstream-policy=pass-flow
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+  - filter:
+      count: 1
+      match:
+        event_type: http

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-packet/README.md
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-packet/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test, the exception policy
+for midstream sessions is set to ``pass-packet``. This test is for IDS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``pass-packet`` isn't a valid
+exception policy value for the midstream exception policy.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-packet/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-packet/suricata.yaml
@@ -1,0 +1,36 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats
+
+logging:
+  default-log-level: notice
+  outputs:
+  - console:
+      enabled: yes
+      type: json

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-packet/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-packet/suricata.yaml
@@ -31,6 +31,8 @@ outputs:
 logging:
   default-log-level: notice
   outputs:
-  - console:
+  - file:
       enabled: yes
+      level: notice
+      filename: suricata.json
       type: json

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-packet/test.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-packet/test.yaml
@@ -10,6 +10,9 @@ args:
 - --set stream.midstream-policy=pass-packet
 
 checks:
-    - shell:
-        args: grep "Exception Policy \"pass-packet\" is not an accepted value for stream.midstream_exception_policy." eve.json | wc -l | xargs
-        expect: 1
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-packet/test.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-pass-packet/test.yaml
@@ -1,0 +1,15 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --set stream.midstream=true
+- --set stream.midstream-policy=pass-packet
+
+checks:
+    - shell:
+        args: grep "Exception Policy \"pass-packet\" is not an accepted value for stream.midstream_exception_policy." eve.json | wc -l | xargs
+        expect: 1

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-reject/README.md
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-reject/README.md
@@ -1,0 +1,16 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``reject``. This test is for IDS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``reject`` isn't a valid
+exception policy value when midstream picku-up sessions are enabled.
+
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-reject/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-reject/suricata.yaml
@@ -32,6 +32,8 @@ outputs:
 logging:
   default-log-level: notice
   outputs:
-  - console:
+  - file:
       enabled: yes
+      level: notice
+      filename: suricata.json
       type: json

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-reject/suricata.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-reject/suricata.yaml
@@ -1,0 +1,37 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats
+  - stats
+
+logging:
+  default-log-level: notice
+  outputs:
+  - console:
+      enabled: yes
+      type: json

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-reject/test.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-reject/test.yaml
@@ -1,0 +1,17 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --set stream.midstream=true
+- --set stream.midstream-policy=reject
+
+
+checks:
+    - shell:
+        args: grep "Exception Policy \"reject\" is not an accepted value for stream.midstream_exception_policy when stream.midstream=true." eve.json | wc -l | xargs
+        expect: 1
+

--- a/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-reject/test.yaml
+++ b/tests/exception-policy-ids-midstream-enabled/exception-policy-midstream-enabled-reject/test.yaml
@@ -11,7 +11,10 @@ args:
 
 
 checks:
-    - shell:
-        args: grep "Exception Policy \"reject\" is not an accepted value for stream.midstream_exception_policy when stream.midstream=true." eve.json | wc -l | xargs
-        expect: 1
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error
 

--- a/tests/exception-policy-midstream-03/suricata.yaml
+++ b/tests/exception-policy-midstream-03/suricata.yaml
@@ -15,3 +15,14 @@ outputs:
             http: yes
         - flow
         - http
+
+logging:
+  default-log-level: notice
+  outputs:
+  - console:
+      enabled: yes
+  - file:
+      enabled: yes
+      level: notice
+      filename: suricata.json
+      type: json

--- a/tests/exception-policy-midstream-03/test.yaml
+++ b/tests/exception-policy-midstream-03/test.yaml
@@ -1,3 +1,6 @@
+requires:
+  min-version: 6
+
 args:
 - --simulate-ips
 - --set stream.midstream=true


### PR DESCRIPTION
Related to #5825

TODOs:
- add tests for IPS mode
- (probably) remove eve.json config from `suricata.yaml` for the tests that error out and don't use it
- (possibly) update IDS `drop` tests with proper expected results if we keep the current behavior of suri setting these to `ignore`
- (possibly) adding the missing tests for IDS (thought they might be repetitive, dunno)