### PR TITLE
ftp: fix command_data length

### DIFF
--- a/tests/ftp/ftp-too-long-command/test.yaml
+++ b/tests/ftp/ftp-too-long-command/test.yaml
@@ -5,7 +5,7 @@ checks:
       match:
         event_type: ftp
         ftp.command: RETR
-        ftp.command_data.__len: 4090
+        ftp.command_data.__len: 4091
         ftp.command_truncated: true
         ftp.reply_truncated: false
 


### PR DESCRIPTION
Given that we cap the long lines at 4096 bytes and command_data.__len is calculated by

request size - (command size + space) (ref: https://github.com/OISF/suricata/blob/master/src/output-json-ftp.c#L61)

which in this case, 4 (RETR) + 1 = 5

The command_data length should be 4091 bytes.

There are issues w the current code that I'm fixing and couldn't get this test to pass and am wondering now if the test is correct. As per my calculations above, test should be updated. Wdyt @jasonish ?