### PR TITLE
tests: update ips-state-1 test - v1

### DIFF
--- a/tests/ips-state-1/README.md
+++ b/tests/ips-state-1/README.md
@@ -5,9 +5,5 @@ be full passed with no alerts, while the TLS flow should be dropped.
 
 ## Current Observations
 
-- HTTP response packets are being logged as dropped, however the transaction is
-  logged suggesting the drop is only in logging only, but not actually
-  occurring.
-
 - All the TLS packets apear to be getting dropped, but `flow.action` is never
   set to true.

--- a/tests/ips-state-1/test.yaml
+++ b/tests/ips-state-1/test.yaml
@@ -8,8 +8,6 @@ checks:
 - filter:
     # We should see 2 http transactions as the pass rule should allow http
     # flows.
-    #
-    # This fails.
     count: 2
     match:
       event_type: http
@@ -27,13 +25,13 @@ checks:
     match:
       event_type: flow
       app_proto: http
-      flow.alerted: false 
+      flow.alerted: false
 
 - filter:
     # We should see NO drops (or alerts) for http
     count: 0
     match:
-      event_type: alert
+      event_type: drop
       app_proto: http
 
 - filter:


### PR DESCRIPTION
This test indicated that there were FP drops for http and that another check was failing, but currently the test passes and we don't observe such things. 

The flow event for 'tls' still doesn't show the 'action' field, though, as the flag for ACTION_DROP isn't marked as true (as the README says). Should we add a check for that and make it so that the test fails again?