### PR TITLE
test: add test for bug 6109 - v1

### DIFF
--- a/tests/bug-6109-reject-policy-ids/README.md
+++ b/tests/bug-6109-reject-policy-ids/README.md
@@ -1,0 +1,20 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``reject``. This test is for IDS mode.
+
+# Behavior
+
+We expect to see no alerts nor ``http`` events logged, as the session won't be
+tracked. The flow should be rejected, but not dropped, as in IDS mode there's no
+drop.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.
+
+# Note
+
+This test triggers Bug 6109 - exception/policy: reject changes flow action in IDS mode

--- a/tests/bug-6109-reject-policy-ids/suricata.yaml
+++ b/tests/bug-6109-reject-policy-ids/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/bug-6109-reject-policy-ids/test.rules
+++ b/tests/bug-6109-reject-policy-ids/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (msg:"HTTP traffic"; sid:001; rev:1;)

--- a/tests/bug-6109-reject-policy-ids/test.yaml
+++ b/tests/bug-6109-reject-policy-ids/test.yaml
@@ -1,0 +1,20 @@
+pcap: ../exception-policy-midstream-03/input.pcap
+
+args:
+- --set stream.midstream=false
+- --set stream.midstream-policy=reject
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+  - filter:
+      count: 0
+      match:
+        event_type: http
+  - filter:
+      count: 0
+      match:
+        event_type: flow
+        flow.action: drop


### PR DESCRIPTION
In IDS mode, with midstream disabled, it seems that the exception policy 'reject' is applying actions that should only be taken in IPS mode. This leads to the flow being dropped (or logged as such?) in IDS mode. This test showcases this.

Bug #6109 (https://redmine.openinfosecfoundation.org/issues/6109)

This test fails, currently.