### PR TITLE
Add and update tests for midstream exception policy bug 5825 - v4

### DIFF
--- a/tests/bug-2491-02/test.yaml
+++ b/tests/bug-2491-02/test.yaml
@@ -4,7 +4,7 @@ requires:
 args:
 - --set stream.async-oneside=true
 - --set stream.midstream=true
-- --set stream.midstream-policy=drop-flow
+- --set stream.midstream-policy=ignore
 
 checks:
   - filter:

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-bypass/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-bypass/README.md
@@ -1,0 +1,14 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``bypass``. This test is for IDS mode.
+
+# Behavior
+
+We expect to see no alerts nor ``http`` events logged, as the flow won't be inspected.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-bypass/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-bypass/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-bypass/test.rules
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-bypass/test.rules
@@ -1,0 +1,2 @@
+alert ip any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:2100498; rev:7;)
+alert http any any -> any any (msg:"HTTP traffic"; sid:001; rev:1;)

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-bypass/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-bypass/test.yaml
@@ -1,0 +1,20 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --set stream.midstream=false
+- --set stream.midstream-policy=bypass
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+  - filter:
+      count: 0
+      match:
+        event_type: http
+  - filter:
+      count: 1
+      match:
+        event_type: flow
+        flow.state: bypassed

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-flow/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-flow/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``drop-flow``. This test is for IDS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``drop-flow`` isn't a valid
+exception policy value for the midstream exception policy.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-flow/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-flow/suricata.yaml
@@ -1,0 +1,38 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats
+
+logging:
+  default-log-level: notice
+  outputs:
+  - file:
+      enabled: yes
+      level: notice
+      filename: suricata.json
+      type: json

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-flow/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-flow/test.yaml
@@ -1,0 +1,18 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --set stream.midstream=false
+- --set stream.midstream-policy=drop-flow
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-packet/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-packet/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``drop-packet``. This test is for IDS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``drop-packet`` isn't a valid
+exception policy value for the midstream exception policy.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-packet/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-packet/suricata.yaml
@@ -1,0 +1,38 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats
+
+logging:
+  default-log-level: notice
+  outputs:
+  - file:
+      enabled: yes
+      level: notice
+      filename: suricata.json
+      type: json

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-packet/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-packet/test.yaml
@@ -1,0 +1,18 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --set stream.midstream=false
+- --set stream.midstream-policy=drop-packet
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-ignore/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-ignore/README.md
@@ -1,0 +1,14 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``ignore``. This test is for IDS mode.
+
+# Behavior
+
+We expect to see no alerts nor ``http`` events logged, as the flow won't be inspected.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-ignore/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-ignore/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-ignore/test.rules
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-ignore/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (msg:"HTTP traffic"; sid:001; rev:1;)

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-ignore/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-ignore/test.yaml
@@ -1,0 +1,15 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --set stream.midstream=false
+- --set stream.midstream-policy=ignore
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+  - filter:
+      count: 0
+      match:
+        event_type: http

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-flow/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-flow/README.md
@@ -1,0 +1,14 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``pass-flow``. This test is for IDS mode.
+
+# Behavior
+
+We expect to see no alerts nor ``http`` events logged, as the flow won't be inspected.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-flow/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-flow/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-flow/test.rules
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-flow/test.rules
@@ -1,0 +1,2 @@
+alert ip any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:2100498; rev:7;)
+alert http any any -> any any (msg:"HTTP traffic"; sid:001; rev:1;)

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-flow/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-flow/test.yaml
@@ -1,0 +1,20 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --set stream.midstream=false
+- --set stream.midstream-policy=pass-flow
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+  - filter:
+      count: 0
+      match:
+        event_type: http
+  - filter:
+      count: 1
+      match:
+        event_type: flow
+        flow.action: pass

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-packet/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-packet/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``pass-packet``. This test is for IDS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``pass-packet`` isn't a valid
+exception policy value for the midstream exception policy.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-packet/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-packet/suricata.yaml
@@ -1,0 +1,38 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats
+
+logging:
+  default-log-level: notice
+  outputs:
+  - file:
+      enabled: yes
+      level: notice
+      filename: suricata.json
+      type: json

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-packet/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-packet/test.yaml
@@ -1,0 +1,18 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --set stream.midstream=false
+- --set stream.midstream-policy=pass-packet
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-bypass/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-bypass/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``bypass``. This test is for IDS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``bypass`` isn't a valid
+exception policy value when midstream picku-up sessions are enabled.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-bypass/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-bypass/suricata.yaml
@@ -1,0 +1,39 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats
+  - stats
+
+logging:
+  default-log-level: notice
+  outputs:
+  - file:
+      enabled: yes
+      level: notice
+      filename: suricata.json
+      type: json

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-bypass/test.rules
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-bypass/test.rules
@@ -1,0 +1,1 @@
+alert ip any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:2100498; rev:7;)

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-bypass/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-bypass/test.yaml
@@ -1,0 +1,18 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --set stream.midstream=true
+- --set stream.midstream-policy=bypass
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-flow/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-flow/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``drop-flow``. This test is for IDS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``drop-flow`` isn't a valid
+exception policy value.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-flow/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-flow/suricata.yaml
@@ -1,0 +1,38 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats
+
+logging:
+  default-log-level: Config
+  outputs:
+  - file:
+      enabled: yes
+      level: notice
+      filename: suricata.json
+      type: json

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-flow/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-flow/test.yaml
@@ -1,0 +1,18 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --set stream.midstream=true
+- --set stream.midstream-policy=drop-flow
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-packet/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-packet/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``drop-packet``. This test is for IDS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``drop-packet`` isn't a valid
+exception policy value.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-packet/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-packet/suricata.yaml
@@ -1,0 +1,38 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats
+
+logging:
+  default-log-level: Config
+  outputs:
+  - file:
+      enabled: yes
+      level: notice
+      filename: suricata.json
+      type: json

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-packet/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-packet/test.yaml
@@ -1,0 +1,18 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --set stream.midstream=true
+- --set stream.midstream-policy=drop-packet
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-ignore/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-ignore/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``ignore``. This test is for IDS mode.
+
+# Behavior
+
+We expect to see alerts and ``http`` events logged, as the flow will
+be inspected.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-ignore/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-ignore/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-ignore/test.rules
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-ignore/test.rules
@@ -1,0 +1,1 @@
+alert ip any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:2100498; rev:7;)

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-ignore/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-ignore/test.yaml
@@ -1,0 +1,15 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --set stream.midstream=true
+- --set stream.midstream-policy=ignore
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+  - filter:
+      count: 1
+      match:
+        event_type: http

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-flow/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-flow/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``pass-flow``. This test is for IDS mode.
+
+# Behavior
+
+We expect to see no alerts, since detection won't run due to ``pass-flow``, but
+to see ``http`` events logged, as the flow will be inspected.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-flow/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-flow/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-flow/test.rules
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-flow/test.rules
@@ -1,0 +1,2 @@
+alert ip any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:2100498; rev:7;)
+alert http any any -> any any (msg:"HTTP traffic"; sid:001; rev:1;)

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-flow/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-flow/test.yaml
@@ -1,0 +1,20 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --set stream.midstream=true
+- --set stream.midstream-policy=pass-flow
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+  - filter:
+      count: 1
+      match:
+        event_type: http
+  - filter:
+      count: 1
+      match:
+        event_type: flow
+        flow.action: pass

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-packet/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-packet/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test, the exception policy
+for midstream sessions is set to ``pass-packet``. This test is for IDS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``pass-packet`` isn't a valid
+exception policy value for the midstream exception policy.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-packet/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-packet/suricata.yaml
@@ -1,0 +1,38 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats
+
+logging:
+  default-log-level: notice
+  outputs:
+  - file:
+      enabled: yes
+      level: notice
+      filename: suricata.json
+      type: json

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-packet/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-packet/test.yaml
@@ -1,0 +1,18 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --set stream.midstream=true
+- --set stream.midstream-policy=pass-packet
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-reject/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-reject/README.md
@@ -1,0 +1,16 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``reject``. This test is for IDS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``reject`` isn't a valid
+exception policy value when midstream picku-up sessions are enabled.
+
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-reject/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-reject/suricata.yaml
@@ -1,0 +1,39 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats
+  - stats
+
+logging:
+  default-log-level: notice
+  outputs:
+  - file:
+      enabled: yes
+      level: notice
+      filename: suricata.json
+      type: json

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-reject/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-reject/test.yaml
@@ -1,0 +1,20 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --set stream.midstream=true
+- --set stream.midstream-policy=reject
+
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error
+

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-bypass/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-bypass/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``bypass``. This test is for IPS mode.
+
+# Behavior
+
+We expect to see no alerts nor ``http`` events logged, as the flow won't be inspected.
+Flow will be bypassed.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-bypass/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-bypass/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-bypass/test.rules
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-bypass/test.rules
@@ -1,0 +1,2 @@
+alert ip any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:2100498; rev:7;)
+alert http any any -> any any (msg:"HTTP traffic"; sid:001; rev:1;)

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-bypass/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-bypass/test.yaml
@@ -1,0 +1,21 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --simulate-ips
+- --set stream.midstream=false
+- --set stream.midstream-policy=bypass
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+  - filter:
+      count: 0
+      match:
+        event_type: http
+  - filter:
+      count: 1
+      match:
+        event_type: flow
+        flow.state: bypassed

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-flow/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-flow/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``drop-flow``. This test is for IPS mode.
+
+# Behavior
+
+We expect to see no alerts nor ``http`` events logged, as the session won't be
+tracked. The flow should be dropped.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-flow/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-flow/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-flow/test.rules
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-flow/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (msg:"HTTP traffic"; sid:001; rev:1;)

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-flow/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-flow/test.yaml
@@ -1,0 +1,25 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --set stream.midstream=false
+- --set stream.midstream-policy=drop-flow
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+  - filter:
+      count: 0
+      match:
+        event_type: http
+  - filter:
+      count: 1
+      match:
+        event_type: drop
+        drop.reason: stream midstream
+  - filter:
+      count: 1
+      match:
+        event_type: flow
+        flow.action: drop

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-packet/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-packet/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``drop-packet``. This test is for IPS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``drop-packet`` isn't a valid
+exception policy value for the midstream exception policy.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-packet/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-packet/suricata.yaml
@@ -1,0 +1,11 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: notice
+  outputs:
+  - file:
+      enabled: yes
+      level: notice
+      filename: suricata.json
+      type: json

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-packet/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-packet/test.yaml
@@ -1,0 +1,19 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --simulate-ips
+- --set stream.midstream=false
+- --set stream.midstream-policy=drop-packet
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-ignore/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-ignore/README.md
@@ -1,0 +1,14 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``ignore``. This test is for IPS mode.
+
+# Behavior
+
+We expect to see no alerts nor ``http`` events logged, as the flow won't be inspected.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-ignore/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-ignore/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-ignore/test.rules
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-ignore/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (msg:"HTTP traffic"; sid:001; rev:1;)

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-ignore/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-ignore/test.yaml
@@ -1,0 +1,20 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --simulate-ips
+- --set stream.midstream=false
+- --set stream.midstream-policy=ignore
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+  - filter:
+      count: 0
+      match:
+        event_type: http
+  - filter:
+      count: 1
+      match:
+        event_type: flow

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-flow/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-flow/README.md
@@ -1,0 +1,14 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``pass-flow``. This test is for IPS mode.
+
+# Behavior
+
+We expect to see no alerts nor ``http`` events logged, as the flow won't be inspected.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-flow/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-flow/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-flow/test.rules
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-flow/test.rules
@@ -1,0 +1,2 @@
+alert ip any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:2100498; rev:7;)
+alert http any any -> any any (msg:"HTTP traffic"; sid:001; rev:1;)

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-flow/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-flow/test.yaml
@@ -1,0 +1,21 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --simulate-ips
+- --set stream.midstream=false
+- --set stream.midstream-policy=pass-flow
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+  - filter:
+      count: 0
+      match:
+        event_type: http
+  - filter:
+      count: 1
+      match:
+        event_type: flow
+        flow.action: pass

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-packet/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-packet/README.md
@@ -1,0 +1,16 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``pass-packet``. This test is for IPS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``pass-packet`` isn't a valid
+exception policy value.
+
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-packet/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-packet/suricata.yaml
@@ -1,0 +1,14 @@
+%YAML 1.1
+---
+
+outputs:
+  - stats
+
+logging:
+  default-log-level: notice
+  outputs:
+  - file:
+      enabled: yes
+      level: notice
+      filename: suricata.json
+      type: json

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-packet/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-packet/test.yaml
@@ -1,0 +1,21 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --simulate-ips
+- --set stream.midstream=true
+- --set stream.midstream-policy=pass-packet
+
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error
+

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-reject/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-reject/README.md
@@ -1,0 +1,16 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions disabled. In this test the exception policy
+for midstream sessions is set to ``reject``. This test is for IPS mode.
+
+# Behavior
+
+We expect to see no alerts nor ``http`` events logged, as the session won't be
+tracked. We also expect to see ``drop`` events, as in IPS mode the flow is
+rejected and dropped.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-reject/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-reject/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-reject/test.rules
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-reject/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (msg:"HTTP traffic"; sid:001; rev:1;)

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-reject/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-reject/test.yaml
@@ -1,0 +1,21 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --simulate-ips
+- --set stream.midstream=false
+- --set stream.midstream-policy=reject
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+  - filter:
+      count: 0
+      match:
+        event_type: http
+  - filter:
+      count: 1
+      match:
+        event_type: flow
+        flow.action: drop

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-bypass/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-bypass/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``bypass``. This test is for IPS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``bypass`` isn't a valid
+exception policy value when midstream picku-up sessions are enabled.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-bypass/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-bypass/suricata.yaml
@@ -1,0 +1,11 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: notice
+  outputs:
+  - file:
+      enabled: yes
+      level: notice
+      filename: suricata.json
+      type: json

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-bypass/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-bypass/test.yaml
@@ -1,0 +1,19 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --simulate-ips
+- --set stream.midstream=true
+- --set stream.midstream-policy=bypass
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-flow/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-flow/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``drop-flow``. This test is for IPS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``drop-flow`` isn't a valid
+exception policy value when midstream picku-up sessions are enabled.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-flow/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-flow/suricata.yaml
@@ -1,0 +1,11 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: notice
+  outputs:
+  - file:
+      enabled: yes
+      level: notice
+      filename: suricata.json
+      type: json

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-flow/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-flow/test.yaml
@@ -1,0 +1,19 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --simulate-ips
+- --set stream.midstream=true
+- --set stream.midstream-policy=drop-flow
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-packet/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-packet/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``drop-packet``. This test is for IPS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``drop-packet`` isn't a valid
+exception policy value when midstream picku-up sessions are enabled.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-packet/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-packet/suricata.yaml
@@ -1,0 +1,11 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: notice
+  outputs:
+  - file:
+      enabled: yes
+      level: notice
+      filename: suricata.json
+      type: json

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-packet/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-packet/test.yaml
@@ -1,0 +1,19 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --simulate-ips
+- --set stream.midstream=true
+- --set stream.midstream-policy=drop-packet
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-ignore/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-ignore/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``ignore``. This test is for IPS mode.
+
+# Behavior
+
+We expect to see alerts and ``http`` events logged, as the flow will
+be inspected.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-ignore/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-ignore/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-ignore/test.rules
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-ignore/test.rules
@@ -1,0 +1,1 @@
+alert ip any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:2100498; rev:7;)

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-ignore/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-ignore/test.yaml
@@ -1,0 +1,20 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --simulate-ips
+- --set stream.midstream=true
+- --set stream.midstream-policy=ignore
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+  - filter:
+      count: 1
+      match:
+        event_type: http
+  - filter:
+      count: 1
+      match:
+        event_type: flow

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-flow/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-flow/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``pass-flow``. This test is for IPS mode.
+
+# Behavior
+
+We expect to see no alerts, since detection won't run due to ``pass-flow``, but
+to see ``http`` events logged, as the flow will be inspected.
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-flow/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-flow/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: yes
+            payload-buffer-size: 4kb
+            payload-printable: yes
+            packet: yes
+            http: yes
+            tls: yes
+            ssh: yes
+            smtp: yes
+            xff:
+              enabled: yes
+              mode: extra-data
+              deployment: reverse
+              header: X-Forwarded-For
+        - flow
+        - http
+        - drop:
+            alerts: yes
+            flows: all
+        - stats

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-flow/test.rules
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-flow/test.rules
@@ -1,0 +1,2 @@
+alert ip any any -> any any (msg:"GPL ATTACK_RESPONSE id check returned root"; content:"uid=0|28|root|29|"; classtype:bad-unknown; sid:2100498; rev:7;)
+alert http any any -> any any (msg:"HTTP traffic"; sid:001; rev:1;)

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-flow/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-flow/test.yaml
@@ -1,0 +1,21 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+args:
+- --simulate-ips
+- --set stream.midstream=true
+- --set stream.midstream-policy=pass-flow
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+  - filter:
+      count: 1
+      match:
+        event_type: http
+  - filter:
+      count: 1
+      match:
+        event_type: flow
+        flow.action: pass

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-packet/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-packet/README.md
@@ -1,0 +1,16 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``pass-packet``. This test is for IPS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``pass-packet`` isn't a valid
+exception policy value.
+
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-packet/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-packet/suricata.yaml
@@ -1,0 +1,14 @@
+%YAML 1.1
+---
+
+outputs:
+  - stats
+
+logging:
+  default-log-level: notice
+  outputs:
+  - file:
+      enabled: yes
+      level: notice
+      filename: suricata.json
+      type: json

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-packet/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-packet/test.yaml
@@ -1,0 +1,21 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --simulate-ips
+- --set stream.midstream=true
+- --set stream.midstream-policy=pass-packet
+
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error
+

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-reject/README.md
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-reject/README.md
@@ -1,0 +1,16 @@
+# Test
+
+Check that the midstream exception policy is properly applied in case Suricata
+has stream midstream pick-up sessions enabled. In this test the exception policy
+for midstream sessions is set to ``reject``. This test is for IPS mode.
+
+# Behavior
+
+We expect Suri to error out without starting as ``reject`` isn't a valid
+exception policy value when midstream picku-up sessions are enabled.
+
+
+# Pcap
+
+Pcap comes from the test ``exception-policy-midstream-03`` and is the result of a
+curl to www.testmyids.com.

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-reject/suricata.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-reject/suricata.yaml
@@ -1,0 +1,11 @@
+%YAML 1.1
+---
+
+logging:
+  default-log-level: notice
+  outputs:
+  - file:
+      enabled: yes
+      level: notice
+      filename: suricata.json
+      type: json

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-reject/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-reject/test.yaml
@@ -1,0 +1,19 @@
+pcap: ../../exception-policy-midstream-03/input.pcap
+
+requires:
+  min-version: 6
+
+exit-code: 1
+
+args:
+- --simulate-ips
+- --set stream.midstream=true
+- --set stream.midstream-policy=reject
+
+checks:
+    - filter:
+        filename: suricata.json
+        count: 1
+        match:
+          event_type: engine
+          log_level: Error

--- a/tests/exception-policy-midstream-03/README.md
+++ b/tests/exception-policy-midstream-03/README.md
@@ -1,14 +1,15 @@
 # Test
 
 Check that Suricata behaves as expected with no midstream-policy set (that is,
-with default behavior), in IPS mode, in a stream first seen by Suricata in
-SYNACK stage.
+with default behavior) and midstream enabled, in IPS mode, in a stream first
+seen by Suricata in SYNACK stage.
 
 # Behavior
 
 With midstream true but no exception policy for midstream set we expect to see
 alerts and ``http`` events logged, as the portion of the flow available will be
-inspected and no exception policy for midstream will be applied.
+inspected and no exception policy for midstream will be applied, as with
+midstream enabled, "auto" is set to "ignore" in IPS mode as well.
 
 # Pcap
 

--- a/tests/exception-policy-midstream-03/suricata.yaml
+++ b/tests/exception-policy-midstream-03/suricata.yaml
@@ -15,3 +15,12 @@ outputs:
             http: yes
         - flow
         - http
+
+logging:
+  default-log-level: notice
+  outputs:
+  - file:
+      enabled: yes
+      level: notice
+      filename: suricata.json
+      type: json


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata-verify/pull/1226

Changes:
- remove test 'exception-policy-ids-disabled-reject', and move it to its own PR, to track bug 6109 (https://github.com/OISF/suricata-verify/pull/1229)

Suricata PR: https://github.com/OISF/suricata/pull/8969