### PR TITLE
detect/bytemath: Test multiplier operator

### DIFF
--- a/tests/detect-bytemath-mult-04/README.md
+++ b/tests/detect-bytemath-mult-04/README.md
@@ -1,0 +1,11 @@
+Description
+===========
+Test byte_math multiplication operator
+
+PCAP
+====
+PCAP comes from the suricata verify test[detect-bytemath-01]
+
+Redmine ticket
+==============
+https://redmine.openinfosecfoundation.org/issues/6070

--- a/tests/detect-bytemath-mult-04/test.rules
+++ b/tests/detect-bytemath-mult-04/test.rules
@@ -1,0 +1,6 @@
+alert tcp any any -> any any (msg:"byte_math multiplication operator"; \
+                    ipv4.hdr; \
+                    byte_extract: 1, 5, extracted_val, relative; \
+                    byte_math: bytes 1, offset 1, oper *,rvalue extracted_val, result var; \
+                    byte_test: 1, = , var, 1; \
+                    sid: 1;)

--- a/tests/detect-bytemath-mult-04/test.yaml
+++ b/tests/detect-bytemath-mult-04/test.yaml
@@ -1,0 +1,11 @@
+requires:
+  min-version: 6.0.12
+
+pcap: ../detect-bytemath-01/input.pcap
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 1


### PR DESCRIPTION
Issue: 6070

This commit adds a test for the byte-math multiplication operator. The operator was missing from 6.0.x; however, this test applies to 6.0.x and later once the Suricata PR is merged.