### PR TITLE
Fix test to use http object instead of http2

### DIFF
--- a/tests/http2-deflate/test.yaml
+++ b/tests/http2-deflate/test.yaml
@@ -15,7 +15,8 @@ checks:
       count: 1
       match:
         event_type: fileinfo
-        http2.length: 30
+        http.length: 30
+        http.version: "2"
         fileinfo.size: 20
   - filter:
       count: 0


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6165
