### PR TITLE
test: pcap-log with lz4 write to non-writable directory

### DIFF
--- a/tests/pcap-log-lz4-write/README.md
+++ b/tests/pcap-log-lz4-write/README.md
@@ -1,0 +1,6 @@
+Test that Suricata will not crash if pcap-log is enabled with LZ4
+compression and a non-writable pcap-log directory.
+
+## Issue
+
+https://redmine.openinfosecfoundation.org/issues/5022

--- a/tests/pcap-log-lz4-write/suricata.yaml
+++ b/tests/pcap-log-lz4-write/suricata.yaml
@@ -1,0 +1,21 @@
+%YAML 1.1
+---
+
+outputs:
+  - pcap-log:
+      enabled: yes
+      filename: log.pcap
+      compression: lz4
+      mode: normal
+      dir: pcap-log
+
+# Enable enging logging to JSON so we can verify it.
+logging:
+  outputs:
+    - console:
+        enabled: yes
+    - file:
+        enabled: yes
+        level: info
+        filename: eve.json
+        type: json

--- a/tests/pcap-log-lz4-write/test.yaml
+++ b/tests/pcap-log-lz4-write/test.yaml
@@ -1,0 +1,22 @@
+requires:
+  features:
+    - liblz4
+
+skip:
+  - uid: 0
+    msg: "Test requires non-root user"
+
+setup:
+  # Create a pcap-log directory without write permission
+  - script: |
+      rm -rf pcap-log
+      mkdir pcap-log
+      chmod 555 pcap-log
+      
+pcap: ../alert-testmyids/input.pcap
+
+checks:
+  - filter:
+      count: 1
+      match:
+        engine.message: "Error opening file for compressed output: Permission denied"


### PR DESCRIPTION
Redmine ticket: https://redmine.openinfosecfoundation.org/issues/5022

To fail, Suricata needs to be running as a non-root user.  We only have CI job that does this, and it can be seen failing against this test here: https://github.com/jasonish/suricata/actions/runs/5404061042/jobs/9817895318#step:17:140

Suricata PR: https://github.com/OISF/suricata/pull/9092