### PR TITLE
runner: allow a test to be retried

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ checks:
 
       # The number of records this filter should match.
       count: 1
-	  
+
       # The fields to match on.
       match:
         # Example match on event_type:
@@ -140,7 +140,7 @@ checks:
 
         # Example match on the length of an array.
         alert.metadata.tag.__len: 3
-		
+
         # Check that a field exists:
         has-key: alert.rule
 
@@ -246,4 +246,3 @@ newer:
 
 The features are taken from the `Features:` line in `suricata
 --build-info`.
-

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ command: |
   ${SRCDIR}/src/suricata -T -c ${TEST_DIR}/suricata.yaml -vvv \
       -l ${TEST_DIR}/output --set default-rule-path="${TEST_DIR}"
 
+# Retry a test 3 more times on failure. Some tests are subject to
+# timing errors on CI systems and this can help filter out the noise
+# of tests that fail in such environments. By default, tests are only
+# run once.
+retry: 3
+
 # Execute Suricata with the test parameters this many times. All checks will
 # done after each iteration.
 count: 10

--- a/tests/threshold/threshold-config-rate-filter-alert-pair/test.yaml
+++ b/tests/threshold/threshold-config-rate-filter-alert-pair/test.yaml
@@ -5,6 +5,8 @@ args:
 - --set threshold-file=${TEST_DIR}/threshold.config
 - --simulate-ips
 
+retry: 3
+
 checks:
   - filter:
       count: 19


### PR DESCRIPTION
Add a new parameter, retry that takes count. If the checks fail, the
test will be re-run. This could help us deal with failures in tests
that are sensitive to timing.

Example test that often fails in CI:
https://github.com/OISF/suricata/actions/runs/5404663247/jobs/9819234965?pr=9093#step:16:140
