### PR TITLE
tests: showcase verdict field/events in tests - v2

### DIFF
--- a/tests/bug-4394-pdonly-drop/test.yaml
+++ b/tests/bug-4394-pdonly-drop/test.yaml
@@ -8,6 +8,7 @@ args:
 
 checks:
   - filter:
+      lt-version: 7
       count: 1
       match:
         event_type: alert
@@ -15,6 +16,7 @@ checks:
         alert.signature_id: 1
         pcap_cnt: 4
   - filter:
+      lt-version: 7
       count: 1
       match:
         event_type: alert
@@ -22,16 +24,91 @@ checks:
         alert.signature_id: 2
         pcap_cnt: 4
   - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 1
+        pcap_cnt: 4
+        verdict.action: drop
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 2
+        pcap_cnt: 4
+        verdict.action: drop
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: drop
+        pcap_cnt: 4
+        verdict.action: drop
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: drop
+        pcap_cnt: 5
+        verdict.action: drop
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: drop
+        pcap_cnt: 6
+        verdict.action: drop
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: drop
+        pcap_cnt: 7
+        verdict.action: drop
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: drop
+        pcap_cnt: 8
+        verdict.action: drop
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: drop
+        pcap_cnt: 9
+        verdict.action: drop
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: drop
+        pcap_cnt: 10
+        verdict.action: drop
+  - filter:
+      min-version: 7
       count: 0
       match:
         event_type: alert
         alert.signature_id: 3
+        verdict.action: alert
 
   - filter:
+      lt-version: 7
       count: 1
       match:
         event_type: drop
         alert.action: blocked
+        alert.signature_id: 1
+        pcap_cnt: 4
+  - filter:
+      lt-version: 7
+      count: 1
+      match:
+        event_type: drop
         alert.signature_id: 1
         pcap_cnt: 4
   - filter:

--- a/tests/exception-policy-stream-reassembly-memcap-05/suricata.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-05/suricata.yaml
@@ -14,3 +14,4 @@ outputs:
             flows: all       # start or all: 'start' logs only a single drop
                              # per flow direction. All logs each dropped pkt.
         - flow
+        - anomaly

--- a/tests/stream-depth-reached-event/test.yaml
+++ b/tests/stream-depth-reached-event/test.yaml
@@ -2,7 +2,9 @@ requires:
     min-version: 7
 
 args:
-- --set stream.reassembly.depth=50 --set outputs.1.eve-log.types.2.anomaly.types.stream=yes
+# 'outputs' command-line option might need to be adjusted if a new output type
+# is added to eve log.
+- --set stream.reassembly.depth=50 --set outputs.1.eve-log.types.3.anomaly.types.stream=yes
 
 checks:
   - filter:

--- a/tests/verdict-reject-ids/README.md
+++ b/tests/verdict-reject-ids/README.md
@@ -1,0 +1,13 @@
+# Test and Showcase the Verdict Field in IDS mode
+
+In IDS mode, the verdict field only makes sense with the `reject`
+rule action.
+
+# Behavior
+
+As with the `rate_filter` the rule action will change from `alert` to
+`reject`, we shall see alerts starting without, then with the `verdict` field.
+
+# Pcap
+
+Comes from the test `threshold-config-rate-filter-reject-hostdst`.

--- a/tests/verdict-reject-ids/input.rules
+++ b/tests/verdict-reject-ids/input.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (sid: 1000001;)

--- a/tests/verdict-reject-ids/suricata.yaml
+++ b/tests/verdict-reject-ids/suricata.yaml
@@ -1,16 +1,10 @@
 %YAML 1.1
 ---
 
-action-order:
-  - drop
-  - reject
-  - alert
-  - pass
-
 outputs:
   - eve-log:
       enabled: yes
-      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filetype: regular
       filename: eve.json
       types:
         - alert:
@@ -22,4 +16,3 @@ outputs:
         - http
         - anomaly
         - verdict
-

--- a/tests/verdict-reject-ids/test.yaml
+++ b/tests/verdict-reject-ids/test.yaml
@@ -1,0 +1,37 @@
+requires:
+  min-version: 7
+
+pcap: ../threshold/threshold-config-rate-filter-reject-hostdst/input.pcap
+
+args:
+- --set threshold-file=${TEST_DIR}/threshold.config
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 1000001
+        alert.action: allowed
+        verdict.action: alert
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 1000001
+        alert.action: blocked
+        verdict.action: alert
+        verdict.reject-target: source
+  - filter:
+      count: 1
+      match:
+        pcap_cnt: 5
+        event_type: verdict
+        verdict.action: alert
+  - filter:
+      count: 1
+      match:
+        pcap_cnt: 6
+        event_type: verdict
+        verdict.action: alert
+        verdict.reject-target: source

--- a/tests/verdict-reject-ids/threshold.config
+++ b/tests/verdict-reject-ids/threshold.config
@@ -1,0 +1,1 @@
+rate_filter gen_id 1, sig_id 1000001, track by_dst, count 1, seconds 60, new_action reject, timeout 1000


### PR DESCRIPTION
With the addition of the 'verdict' field, have at least one test that illustrates this, and adjust tests that were affected by that change.

Bug #5464

Previous PR: https://github.com/OISF/suricata-verify/pull/1145

Changes from previous PR: 
- update `stream-depth-reached-event` for the command-line argument to work
- update tests to showcase verdict

TODOs:
add more tests, to showcase examples seen in: https://github.com/OISF/suricata/pull/8596#discussion_r1197787688

## Ticket

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/5464