### PR TITLE
tests: check midstream exception policy in 6 - v2

### DIFF
--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-bypass/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-bypass/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 args:
 - --set stream.midstream=false
 - --set stream.midstream-policy=bypass

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-flow/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-flow/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 exit-code: 1
 
 args:

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-ignore/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-ignore/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 args:
 - --set stream.midstream=false
 - --set stream.midstream-policy=ignore

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-flow/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-flow/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 args:
 - --set stream.midstream=false
 - --set stream.midstream-policy=pass-flow

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-packet/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-packet/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 exit-code: 1
 
 args:

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-bypass/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-bypass/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 exit-code: 1
 
 args:

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-flow/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-flow/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 exit-code: 1
 
 args:

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-packet/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-packet/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 exit-code: 1
 
 args:

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-ignore/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-ignore/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 args:
 - --set stream.midstream=true
 - --set stream.midstream-policy=ignore

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-flow/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-flow/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 args:
 - --set stream.midstream=true
 - --set stream.midstream-policy=pass-flow

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-packet/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-packet/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 exit-code: 1
 
 args:

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-reject/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-reject/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 exit-code: 1
 
 args:

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-bypass/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-bypass/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 args:
 - --simulate-ips
 - --set stream.midstream=false

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-flow/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-flow/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 args:
 - --set stream.midstream=false
 - --set stream.midstream-policy=drop-flow

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-packet/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-packet/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 exit-code: 1
 
 args:

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-ignore/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-ignore/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 args:
 - --simulate-ips
 - --set stream.midstream=false

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-flow/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-flow/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 args:
 - --simulate-ips
 - --set stream.midstream=false

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-packet/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-packet/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 exit-code: 1
 
 args:

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-reject/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-reject/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 args:
 - --simulate-ips
 - --set stream.midstream=false

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-bypass/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-bypass/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 exit-code: 1
 
 args:

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-flow/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-flow/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 exit-code: 1
 
 args:

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-packet/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-packet/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 exit-code: 1
 
 args:

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-ignore/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-ignore/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 args:
 - --simulate-ips
 - --set stream.midstream=true

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-flow/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-flow/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 args:
 - --simulate-ips
 - --set stream.midstream=true

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-packet/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-packet/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 exit-code: 1
 
 args:

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-reject/test.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-reject/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../../exception-policy-midstream-03/input.pcap
 
-requires:
-  min-version: 7
-
 exit-code: 1
 
 args:


### PR DESCRIPTION
Related to
Bug #5825
Bug #6169

Previous PR: #1268 

Describe changes: update midstream exception policy tests to check for 6

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/6035