### PR TITLE
stats: add checks for drop reason counters - v1

### DIFF
--- a/tests/exception-policy-applayer-01/suricata.yaml
+++ b/tests/exception-policy-applayer-01/suricata.yaml
@@ -20,6 +20,8 @@ outputs:
             flows: all       # start or all: 'start' logs only a single drop
                              # per flow direction. All logs each dropped pkt.
         - flow
+        - stats
+
 action-order:
   - pass
   - drop

--- a/tests/exception-policy-applayer-01/test.yaml
+++ b/tests/exception-policy-applayer-01/test.yaml
@@ -48,3 +48,9 @@ checks:
       match:
         event_type: flow
         flow.action: drop
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: stats
+        stats.ips.drop_reason.applayer_error: 1

--- a/tests/exception-policy-defrag-01/suricata.yaml
+++ b/tests/exception-policy-defrag-01/suricata.yaml
@@ -20,6 +20,8 @@ outputs:
             flows: all       # start or all: 'start' logs only a single drop
                              # per flow direction. All logs each dropped pkt.
         - flow
+        - stats
+
 action-order:
   - pass
   - drop

--- a/tests/exception-policy-defrag-01/test.yaml
+++ b/tests/exception-policy-defrag-01/test.yaml
@@ -34,3 +34,9 @@ checks:
         event_type: flow
         flow.action: drop
         proto: ICMP
+  - filter:
+      min-version: 1
+      count: 1
+      match:
+        event_type: stats
+        stats.ips.drop_reason.defrag_memcap: 1

--- a/tests/exception-policy-midstream-02/suricata.yaml
+++ b/tests/exception-policy-midstream-02/suricata.yaml
@@ -17,3 +17,4 @@ outputs:
             flows: start     # start or all: 'start' logs only a single drop
                              # per flow direction. All logs each dropped pkt.
         - flow
+        - stats

--- a/tests/exception-policy-midstream-02/test.yaml
+++ b/tests/exception-policy-midstream-02/test.yaml
@@ -22,3 +22,9 @@ checks:
       count: 0
       match:
         event_type: anomaly
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: stats
+        stats.ips.drop_reason.stream_midstream: 1

--- a/tests/exception-policy-simulated-flow-memcap/test.yaml
+++ b/tests/exception-policy-simulated-flow-memcap/test.yaml
@@ -30,3 +30,9 @@ checks:
       match:
         event_type: stats
         stats.tcp.midstream_pickups: 1
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: stats
+        stats.ips.drop_reason.flow_memcap: 1

--- a/tests/exception-policy-stream-reassembly-memcap-01/suricata.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-01/suricata.yaml
@@ -20,6 +20,8 @@ outputs:
             flows: all       # start or all: 'start' logs only a single drop
                              # per flow direction. All logs each dropped pkt.
         - flow
+        - stats
+
 action-order:
   - pass
   - drop

--- a/tests/exception-policy-stream-reassembly-memcap-01/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-01/test.yaml
@@ -48,3 +48,9 @@ checks:
       match:
         event_type: flow
         flow.action: drop
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: stats
+        stats.ips.drop_reason.stream_memcap: 1

--- a/tests/exception-policy-stream-ssn-memcap-01/suricata.yaml
+++ b/tests/exception-policy-stream-ssn-memcap-01/suricata.yaml
@@ -20,6 +20,8 @@ outputs:
             flows: all       # start or all: 'start' logs only a single drop
                              # per flow direction. All logs each dropped pkt.
         - flow
+        - stats
+
 action-order:
   - pass
   - drop

--- a/tests/exception-policy-stream-ssn-memcap-01/test.yaml
+++ b/tests/exception-policy-stream-ssn-memcap-01/test.yaml
@@ -47,3 +47,9 @@ checks:
       match:
         event_type: flow
         flow.action: drop
+  - filter:
+      min-version: 7
+      count: 1
+      match:
+        event_type: stats
+        stats.ips.drop_reason.stream_memcap: 1


### PR DESCRIPTION
Add a few tests that showcase the new drop reason counters.
These tests cover drop reasons achievable with exception policies, as those were easier to get.

Related to:
https://redmine.openinfosecfoundation.org/issues/6230
