### PR TITLE
Bug 6207 for 6/v4 + debug output fixes for s-v

### DIFF
--- a/run.py
+++ b/run.py
@@ -1186,7 +1186,7 @@ def main():
                     try:
                         with open(path, "r") as fcontents:
                             try:
-                                buf = fcontents.read().decode()
+                                buf = fcontents.read()
                                 print(buf)
                             except:
                                 print("    - [Not dumping file that won't utf-8 decode]")

--- a/run.py
+++ b/run.py
@@ -1006,6 +1006,7 @@ def run_test(dirpath, args, cwd, suricata_config):
         check_args_fail()
         with lock:
             count_dict["failed"] += 1
+            failedLogs.append(dirpath)
     except Exception as err:
         print("===> {}: FAILED: Unexpected exception: {}".format(os.path.basename(dirpath), err))
         traceback.print_exc()
@@ -1014,6 +1015,7 @@ def run_test(dirpath, args, cwd, suricata_config):
         with lock:
             check_args['fail'] = 1
             count_dict["failed"] += 1
+            failedLogs.append(dirpath)
             raise TerminatePoolError()
 
 def run_mp(jobs, tests, dirpath, args, cwd, suricata_config):

--- a/tests/bug-6207-1/test.yaml
+++ b/tests/bug-6207-1/test.yaml
@@ -1,6 +1,3 @@
-requires:
-  min-version: 7
-
 args:
 - -k none
 

--- a/tests/bug-6207-2/test.yaml
+++ b/tests/bug-6207-2/test.yaml
@@ -1,5 +1,6 @@
 requires:
-  min-version: 7
+  features:
+    - HAVE_NSS
 
 args:
 - -k none

--- a/tests/filestore-alert-log/test.yaml
+++ b/tests/filestore-alert-log/test.yaml
@@ -3,6 +3,7 @@ pcap: ../filestore-filecontainer-http/filecontainer-http.pcap
 requires:
   features:
     - MAGIC
+    - HAVE_NSS
   files:
     - src/output-filestore.c
 


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata-verify/pull/1330

Changes since v3:
- require NSS on the tests as master-6 still needs it