### PR TITLE
tests/verdict: remove min check for version 7 - v1

### DIFF
--- a/tests/bug-5464-verdict-01/test.yaml
+++ b/tests/bug-5464-verdict-01/test.yaml
@@ -8,35 +8,7 @@ args:
 pcap:  ../detect-app-layer-protocol-02/input.pcap
 
 checks:
-  # checks for Suricata 6
   - filter:
-      lt-version: 7
-      count: 1
-      match:
-        pcap_cnt: 1
-        event_type: drop
-        alert.action: blocked
-        alert.signature_id: 1
-  - filter:
-      lt-version: 7
-      count: 1
-      match:
-        pcap_cnt: 1
-        event_type: alert
-        alert.action: blocked
-        alert.signature_id: 1
-  - filter:
-      lt-version: 7
-      count: 1
-      match:
-        pcap_cnt: 1
-        event_type: alert
-        alert.action: blocked
-        alert.signature_id: 2
-
-  # checks for Suricata 7
-  - filter:
-      min-version: 7
       count: 1
       match:
         event_type: alert
@@ -46,7 +18,6 @@ checks:
         verdict.reject-target: to_server
         verdict.reject: ["tcp-reset"]
   - filter:
-      min-version: 7
       count: 1
       match:
         event_type: alert
@@ -56,65 +27,55 @@ checks:
         verdict.reject-target: to_server
         verdict.reject: ["tcp-reset"]
   - filter:
-      min-version: 7
       count: 1
       match:
         event_type: drop
         pcap_cnt: 1
         verdict.action: drop
-        verdict.reject-target: to_server 
+        verdict.reject-target: to_server
         verdict.reject: ["tcp-reset"]
   - filter:
-      min-version: 7
       count: 0
       match:
         event_type: alert
         alert.signature_id: 3
         verdict.action: alert
   - filter:
-      min-version: 7
       count: 1
       match:
         event_type: drop
         pcap_cnt: 5
         verdict.action: drop
   - filter:
-      min-version: 7
       count: 1
       match:
         event_type: drop
         pcap_cnt: 6
         verdict.action: drop
   - filter:
-      min-version: 7
       count: 1
       match:
         event_type: drop
         pcap_cnt: 7
         verdict.action: drop
   - filter:
-      min-version: 7
       count: 1
       match:
         event_type: drop
         pcap_cnt: 8
         verdict.action: drop
   - filter:
-      min-version: 7
       count: 1
       match:
         event_type: drop
         pcap_cnt: 9
         verdict.action: drop
   - filter:
-      min-version: 7
       count: 1
       match:
         event_type: drop
         pcap_cnt: 10
         verdict.action: drop
-
-  # Checks valid for both
   - filter:
       count: 1
       match:

--- a/tests/bug-5464-verdict-02/test.yaml
+++ b/tests/bug-5464-verdict-02/test.yaml
@@ -1,6 +1,3 @@
-requires:
-  min-version: 7
-
 args:
 - --simulate-ips
 

--- a/tests/bug-5464-verdict-03/test.yaml
+++ b/tests/bug-5464-verdict-03/test.yaml
@@ -1,5 +1,4 @@
 requires:
-  min-version: 7
   features:
     - LIBNET1.1
 

--- a/tests/bug-5464-verdict-04/test.yaml
+++ b/tests/bug-5464-verdict-04/test.yaml
@@ -1,6 +1,3 @@
-requires:
-  min-version: 7
-
 pcap: ../tls/tls-ja3s/input.pcap
 
 args:

--- a/tests/bug-5464-verdict-05/test.yaml
+++ b/tests/bug-5464-verdict-05/test.yaml
@@ -1,6 +1,3 @@
-requires:
-  min-version: 7
-
 args:
 - -k none
 - --runmode=single

--- a/tests/bug-5464-verdict-06/test.yaml
+++ b/tests/bug-5464-verdict-06/test.yaml
@@ -1,5 +1,4 @@
 requires:
-  min-version: 7
   features:
     - LIBNET1.1
 

--- a/tests/bug-5464-verdict-07/test.yaml
+++ b/tests/bug-5464-verdict-07/test.yaml
@@ -1,5 +1,4 @@
 requires:
-  min-version: 7
   features:
     - LIBNET1.1
 
@@ -14,5 +13,5 @@ checks:
       match:
         event_type: alert
         verdict.action: alert
-        verdict.reject-target: to_client 
+        verdict.reject-target: to_client
         verdict.reject: [icmp-prohib]


### PR DESCRIPTION
Related to verdict backports

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/5794