### PR TITLE
tests: fix exception policy tests

### DIFF
--- a/tests/exception-policy-default-01/test.yaml
+++ b/tests/exception-policy-default-01/test.yaml
@@ -14,24 +14,11 @@ checks:
       match:
         event_type: alert
   - filter:
-      lt-version: 7
       count: 0
       match:
         event_type: drop
   - filter:
-      min-version: 7
       count: 1
-      match:
-        event_type: drop
-  - filter:
-      lt-version: 7
-      count: 1
-      match:
-        event_type: tls
-        tls.sni: example.com
-  - filter:
-      min-version: 7
-      count: 0
       match:
         event_type: tls
         tls.sni: example.com

--- a/tests/exception-policy-default-04/test.yaml
+++ b/tests/exception-policy-default-04/test.yaml
@@ -1,18 +1,10 @@
 checks:
   - filter:
-      min-version: 7
-      count: 0
+      count: 1
       match:
         event_type: alert
   - filter:
-      min-version: 7
-      count: 1
-      match:
-        event_type: drop
-        drop.reason: stream midstream
-  - filter:
-      min-version: 7
-      count: 9
+      count: 0
       match:
         event_type: drop
   - filter:
@@ -21,8 +13,7 @@ checks:
         event_type: flow
         flow.state: bypassed
   - filter:
-      min-version: 7
-      count: 1
+      count: 0
       match:
         event_type: flow
         flow.action: drop
@@ -30,24 +21,6 @@ checks:
       count: 0
       match:
         event_type: http
-  # checks for Suricata 6
-  - filter:
-      lt-version: 7
-      count: 1
-      match:
-        event_type: alert
-  - filter:
-      lt-version: 7
-      count: 0
-      match:
-        event_type: drop
-        drop.reason: stream error
-  - filter:
-      lt-version: 7
-      count: 0
-      match:
-        event_type: flow
-        flow.action: drop
   - filter:
       filename: suricata.json
       lt-version: 7


### PR DESCRIPTION
No need for elaborate checks for 6 and 7 for things that shouldn't happen and can be checked in a simpler way.

Also, don't expect drops in IDS mode.


Fixes tests in #1322.