### PR TITLE
decode-event: change to match on protocol gre specifically

### DIFF
--- a/tests/decode-too-small/test.rules
+++ b/tests/decode-too-small/test.rules
@@ -1,3 +1,3 @@
 alert tcp any any -> any any (msg:"TCP packet too small"; decode-event:tcp.pkt_too_small; sid:1;)
 alert udp any any -> any any (msg:"UDP packet too small"; decode-event:udp.hlen_too_small; sid:2;)
-alert ip any any -> any any (msg:"GRE packet too small"; decode-event:gre.pkt_too_small; sid:3;)
+alert gre any any -> any any (msg:"GRE packet too small"; decode-event:gre.pkt_too_small; sid:3;)


### PR DESCRIPTION
Instead of matching on all packets or having to specify the GRE protocol number directly, we can use use the protocol keyword.

Feature: #6261

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6261
