### PR TITLE
dns/https: enable for 6.0

### DIFF
--- a/tests/dns-eve-log-https-only/test.yaml
+++ b/tests/dns-eve-log-https-only/test.yaml
@@ -1,6 +1,3 @@
-requires:
-  min-version: 7
-
 checks:
   # Check that we only have requests and responses for HTTPS records.
 - filter:


### PR DESCRIPTION
Issue: https://redmine.openinfosecfoundation.org/issues/4751

Backported to 6.0.
