### PR TITLE
tests/pgsql: showcase pgsql events - v1

### DIFF
--- a/tests/pgsql/pgsql-events/README.md
+++ b/tests/pgsql/pgsql-events/README.md
@@ -1,0 +1,11 @@
+Test
+====
+
+Showcase PGSQL events for truncated messages. This test will have an alert due
+to a `DataRow` message that has its contents split over more than one PGSQL
+message, leading to a TruncatedMessage event.
+
+Pcap
+====
+
+Pcap comes from PGSQL test for 5000 queries

--- a/tests/pgsql/pgsql-events/events.rules
+++ b/tests/pgsql/pgsql-events/events.rules
@@ -1,0 +1,3 @@
+alert pgsql any any -> any 5432 (msg: "PGSQL event!"; app-layer-event:pgsql.malformed_data; sid: 1; rev: 1;)
+alert pgsql any any -> any 5432 (msg: "PGSQL event!"; app-layer-event:pgsql.truncated_data; sid: 2; rev: 1;)
+alert pgsql any any -> any 5432 (msg: "PGSQL event!"; app-layer-event:pgsql.invalid_length; sid: 3; rev: 1;)

--- a/tests/pgsql/pgsql-events/suricata.yaml
+++ b/tests/pgsql/pgsql-events/suricata.yaml
@@ -1,0 +1,20 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - alert
+        - pgsql
+        - stats
+        - flow
+
+app-layer:
+  protocols:
+    pgsql:
+      enabled: yes
+      stream-depth: 0
+

--- a/tests/pgsql/pgsql-events/test.yaml
+++ b/tests/pgsql/pgsql-events/test.yaml
@@ -1,0 +1,29 @@
+requires:
+  min-version: 7
+
+pcap:
+  ../pgsql-5000-query-results/input.pcap
+
+args:
+- -k none
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+        alert.signature_id: 1
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 2
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+        alert.signature_id: 3
+  - filter:
+      count: 7
+      match:
+        event_type: pgsql


### PR DESCRIPTION
Add test for pgsql `TruncatedMessage` event.

TODO:

- add tests for malformed message and invalid length events

Related to
Task #5566
Bug #5524

## Ticket
Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/5524
https://redmine.openinfosecfoundation.org/issues/5566




