### PR TITLE
tests: add a test for bug 6278

### DIFF
--- a/tests/bug-6278-1/suricata.yaml
+++ b/tests/bug-6278-1/suricata.yaml
@@ -1,0 +1,5 @@
+%YAML 1.1
+---
+
+run-as:
+  user: totally-not-existing-user

--- a/tests/bug-6278-1/test.yaml
+++ b/tests/bug-6278-1/test.yaml
@@ -1,0 +1,12 @@
+requires:
+  min-version: 6
+
+pcap: false
+exit-code: 1
+args:
+  - --engine-analysis
+
+checks:
+  - shell:
+      args: grep -c 'unable to get the user ID' stderr
+      expect: 1

--- a/tests/bug-6278-2/suricata.yaml
+++ b/tests/bug-6278-2/suricata.yaml
@@ -1,0 +1,6 @@
+%YAML 1.1
+---
+
+run-as:
+  user: # null user
+  group: 

--- a/tests/bug-6278-2/test.yaml
+++ b/tests/bug-6278-2/test.yaml
@@ -1,0 +1,17 @@
+requires:
+  min-version: 6
+
+pcap: false
+exit-code: 1
+args:
+  - --engine-analysis
+
+checks:
+  - shell:
+      args: grep -c 'user name cannot be set to an empty value' stderr
+      expect: 1
+      version: 7
+  - shell:
+      args: grep -c 'unable to get the user ID' stderr
+      expect: 1
+      version: 6


### PR DESCRIPTION
PR tests "run-as":
  - non-existent user
  - NULL user (empty user string)

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6278
