### PR TITLE
test/eps: Test updates/additions for 6.0.x

### DIFF
--- a/tests/exception-policy-stream-reassembly-memcap-04/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-04/test.yaml
@@ -1,4 +1,5 @@
 requires:
+  min-version: 7
   features:
     - DEBUG
   files:

--- a/tests/exception-policy-stream-reassembly-memcap-05/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-05/test.yaml
@@ -1,4 +1,5 @@
 requires:
+  min-version: 7
   features:
     - DEBUG
   files:

--- a/tests/exception-policy-stream-reassembly-memcap-07/README.md
+++ b/tests/exception-policy-stream-reassembly-memcap-07/README.md
@@ -1,0 +1,5 @@
+# Description
+
+Test exception policy logic for stream reassembly.
+
+DEBUG is required to enable the "eps" logic.

--- a/tests/exception-policy-stream-reassembly-memcap-07/suricata.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-07/suricata.yaml
@@ -1,0 +1,34 @@
+%YAML 1.1
+---
+
+stats:
+  enabled: yes
+
+outputs:
+  - eve-log:
+      enabled: yes
+      types:
+        - alert:
+            tagged-packets: yes
+        - anomaly:
+            enabled: yes
+            types:
+              decode: no
+              stream: yes
+              applayer: yes
+        - tls:
+            extended: yes     # enable this for extended logging information
+        - drop:
+            alerts: yes      # log alerts that caused drops
+            flows: all       # start or all: 'start' logs only a single drop
+                             # per flow direction. All logs each dropped pkt.
+        - flow
+        - stats:
+            totals: yes       # stats for all threads merged together
+            threads: no       # per thread stats
+            deltas: no        # include delta values
+action-order:
+  - pass
+  - drop
+  - reject
+  - alert

--- a/tests/exception-policy-stream-reassembly-memcap-07/test.rules
+++ b/tests/exception-policy-stream-reassembly-memcap-07/test.rules
@@ -1,0 +1,5 @@
+pass tls any any -> any any (tls.sni; content:"example.com"; startswith; nocase; endswith; msg:"matching TLS allowlisted"; flow:to_server,established; sid:1;)
+drop tls any any -> any any (msg:"not matching any TLS allowlisted Domain"; flow:to_server,established; sid:2; rev:1;)
+
+# matches packet 4, but should not alert due to memcap drop
+alert tcp any any -> any any (seq:3964863680; ack:2403674603; dsize:214; sid:3;)

--- a/tests/exception-policy-stream-reassembly-memcap-07/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-07/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 7
+  lt-version: 7
   features:
     - DEBUG
   files:
@@ -49,8 +49,3 @@ checks:
       match:
         event_type: flow
         flow.action: drop
-  - filter:
-      count: 1
-      match:
-        event_type: stats
-        stats.ips.drop_reason.stream_reassembly: 1

--- a/tests/exception-policy-stream-reassembly-memcap-08/README.md
+++ b/tests/exception-policy-stream-reassembly-memcap-08/README.md
@@ -1,0 +1,5 @@
+# Description
+
+Test exception policy logic for stream reassembly.
+
+DEBUG is required to enable the "eps" logic.

--- a/tests/exception-policy-stream-reassembly-memcap-08/suricata.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-08/suricata.yaml
@@ -1,0 +1,20 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      types:
+        - alert:
+            tagged-packets: yes
+        - tls:
+            extended: yes     # enable this for extended logging information
+        - drop:
+            alerts: yes      # log alerts that caused drops
+            flows: all       # start or all: 'start' logs only a single drop
+                             # per flow direction. All logs each dropped pkt.
+        - flow
+        - stats:
+            totals: yes       # stats for all threads merged together
+            threads: no       # per thread stats
+            deltas: no        # include delta values

--- a/tests/exception-policy-stream-reassembly-memcap-08/test.rules
+++ b/tests/exception-policy-stream-reassembly-memcap-08/test.rules
@@ -1,0 +1,3 @@
+pass tls any any -> any any (tls.sni; content:"example.com"; startswith; nocase; endswith; msg:"matching TLS allowlisted"; flow:to_server,established; priority:2; sid:1;)
+# matches packet 4, but no match due to memcap drop
+alert tcp any any -> any any (seq:3964863680; ack:2403674603; dsize:214; priority:1; sid:3;)

--- a/tests/exception-policy-stream-reassembly-memcap-08/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-08/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 7
+  lt-version: 7
   features:
     - DEBUG
   files:
@@ -49,8 +49,3 @@ checks:
       match:
         event_type: flow
         flow.action: drop
-  - filter:
-      count: 1
-      match:
-        event_type: stats
-        stats.ips.drop_reason.stream_reassembly: 1

--- a/tests/exception-policy-stream-reassembly-memcap-09/README.md
+++ b/tests/exception-policy-stream-reassembly-memcap-09/README.md
@@ -1,0 +1,5 @@
+# Description
+
+Test exception policy logic for stream reassembly.
+
+DEBUG is required to enable the "eps" logic.

--- a/tests/exception-policy-stream-reassembly-memcap-09/suricata.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-09/suricata.yaml
@@ -1,0 +1,20 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      types:
+        - alert:
+            tagged-packets: yes
+        - tls:
+            extended: yes     # enable this for extended logging information
+        - drop:
+            alerts: yes      # log alerts that caused drops
+            flows: all       # start or all: 'start' logs only a single drop
+                             # per flow direction. All logs each dropped pkt.
+        - flow
+        - stats:
+            totals: yes       # stats for all threads merged together
+            threads: no       # per thread stats
+            deltas: no        # include delta values

--- a/tests/exception-policy-stream-reassembly-memcap-09/test.rules
+++ b/tests/exception-policy-stream-reassembly-memcap-09/test.rules
@@ -1,0 +1,3 @@
+pass tls any any -> any any (tls.sni; content:"example.com"; startswith; nocase; endswith; msg:"matching TLS allowlisted"; flow:to_server,established; priority:2; sid:1;)
+# matches packet 4, but no match due to memcap drop
+alert tcp any any -> any any (seq:3964863680; ack:2403674603; dsize:214; priority:1; sid:3;)

--- a/tests/exception-policy-stream-reassembly-memcap-09/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-09/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 7
+  lt-version: 7
   features:
     - DEBUG
   files:
@@ -10,14 +10,15 @@ args:
 - -k none
 # pretend tcp memcap was hit in packet 4, the client hello containing the sni
 - --simulate-packet-tcp-reassembly-memcap=4
-- --set stream.reassembly.memcap-policy=drop-flow
+- --set stream.reassembly.memcap-policy=drop-packet
+- --set app-layer.error-policy=ignore
 checks:
   - filter:
       count: 0
       match:
         event_type: alert
   - filter:
-      count: 29
+      count: 1
       match:
         event_type: drop
   - filter:
@@ -26,7 +27,7 @@ checks:
         event_type: drop
         drop.reason: "stream reassembly"
   - filter:
-      count: 28
+      count: 0
       match:
         event_type: drop
         drop.reason: "flow drop"
@@ -36,21 +37,16 @@ checks:
         event_type: tls
         tls.sni: example.com
   - filter:
-      count: 0
+      count: 1
       match:
         event_type: tls
   - filter:
-      count: 0
+      count: 1
       match:
         event_type: flow
         app_proto: tls
   - filter:
-      count: 1
+      count: 0
       match:
         event_type: flow
         flow.action: drop
-  - filter:
-      count: 1
-      match:
-        event_type: stats
-        stats.ips.drop_reason.stream_reassembly: 1


### PR DESCRIPTION
This commit adds support for 6.0.x eps stream reassembly testing
- Output logging of ips drop reasons is limited to 7 and above
- Create 6.0.x specific test cases for -01, -04, -05

Issue: 6364

Suricata PR: [9505](https://github.com/OISF/suricata/pull/9505)

## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: [6364](https://redmine.openinfosecfoundation.org/issues/6364)
