### PR TITLE
tests: add a test for a bug 6278 v4

### DIFF
--- a/tests/bug-6278-1/README.md
+++ b/tests/bug-6278-1/README.md
@@ -1,0 +1,8 @@
+# Test Description
+
+Test to make sure Suricata handles well non-existent user as an input 
+in the user field.
+
+## Related Issue
+
+https://redmine.openinfosecfoundation.org/issues/6278

--- a/tests/bug-6278-1/suricata.yaml
+++ b/tests/bug-6278-1/suricata.yaml
@@ -1,0 +1,5 @@
+%YAML 1.1
+---
+
+run-as:
+  user: totally-not-existing-user

--- a/tests/bug-6278-1/test.yaml
+++ b/tests/bug-6278-1/test.yaml
@@ -1,0 +1,12 @@
+requires:
+  min-version: 6
+
+pcap: false
+exit-code: 1
+args:
+  - --engine-analysis
+
+checks:
+  - shell:
+      args: grep -c 'unable to get the user ID' stderr
+      expect: 1

--- a/tests/bug-6278-2/README.md
+++ b/tests/bug-6278-2/README.md
@@ -1,0 +1,7 @@
+# Test Description
+
+Test to make sure Suricata handles well null input in the user field.
+
+## Related Issue
+
+https://redmine.openinfosecfoundation.org/issues/6278

--- a/tests/bug-6278-2/suricata.yaml
+++ b/tests/bug-6278-2/suricata.yaml
@@ -1,0 +1,6 @@
+%YAML 1.1
+---
+
+run-as:
+  user: # null user
+  group: 

--- a/tests/bug-6278-2/test.yaml
+++ b/tests/bug-6278-2/test.yaml
@@ -1,0 +1,17 @@
+requires:
+  min-version: 6
+
+pcap: false
+exit-code: 1
+args:
+  - --engine-analysis
+
+checks:
+  - shell:
+      args: grep -c 'no user name was provided - ensure it is specified either in the configuration file or in command-line arguments' stderr
+      expect: 1
+      min-version: 7
+  - shell:
+      args: grep -c 'unable to get the user ID' stderr
+      expect: 1
+      version: 6


### PR DESCRIPTION
PR tests for "run-as":
- non-existent user
- NULL user (empty user string)

Follow-up of https://github.com/OISF/suricata-verify/pull/1413

Changes from the previous PR:
- new docs
- min-version

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6278

PR https://github.com/OISF/suricata/pull/9596 has a fix for this.