### PR TITLE
tests: add rule to check for tcp/ack - v1

### DIFF
--- a/tests/rules/tcp-ack-keyword/test.rules
+++ b/tests/rules/tcp-ack-keyword/test.rules
@@ -1,0 +1,1 @@
+alert tcp any any -> any any (msg:"Testing ack";ack:273;sid:1;)

--- a/tests/rules/tcp-ack-keyword/test.yaml
+++ b/tests/rules/tcp-ack-keyword/test.yaml
@@ -1,0 +1,14 @@
+requires:
+    min-version: 7.0.0
+    pcap: false
+    
+args:
+    - --engine-analysis
+
+checks:
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 1
+      lists.packet.matches[0].name: "tcp.ack"


### PR DESCRIPTION
Test for rule type for tcp-ack keyword.

Related to
Issue: #6354

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6354

Suricata PR: https://github.com/OISF/suricata/pull/9608