### PR TITLE
tests: add rule to check for tcp_mss - v1

### DIFF
--- a/tests/rules/tcp-mss/test.rules
+++ b/tests/rules/tcp-mss/test.rules
@@ -1,0 +1,1 @@
+alert tcp any any -> any any (msg:"Testing mss"; tcp.mss:<50; sid:1;)

--- a/tests/rules/tcp-mss/test.yaml
+++ b/tests/rules/tcp-mss/test.yaml
@@ -1,0 +1,14 @@
+requires:
+    min-version: 7.0.0
+    pcap: false
+
+args:
+    - --engine-analysis
+
+checks:
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+#      list.packet.matches[0].name: "tcp.mss"
+      list.packet.matches[0].mss.size: 536


### PR DESCRIPTION
Test for rule type for tcp-mss keyword

Related to
Issue: #6355

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6355

Suricata PR: https://github.com/OISF/suricata/pull/9673
