### PR TITLE
tests: suricata hint missing runmode v1

### DIFF
--- a/tests/runmode_test/README.md
+++ b/tests/runmode_test/README.md
@@ -1,0 +1,14 @@
+# Suricata Missing Runmode Issue
+
+This repository contains test files and documentation for addressing the "Missing runmode" issue 5711 in Suricata.
+
+## Issue Description
+
+The issue relates to Suricata not providing adequate feedback when the runmode is missing, leading to confusion for users.
+
+## Test Files
+
+- `test.yaml`: This file defines a verification test that checks for the "Missing runmode" error.
+- `runmode_test`: A directory where you can place any necessary configuration files or rules for the test.
+
+

--- a/tests/runmode_test/test.yaml
+++ b/tests/runmode_test/test.yaml
@@ -1,0 +1,10 @@
+requires:
+  min-version: 7.0.0
+  pcap: false
+
+checks:
+  - shell:
+      args: suricata
+      expect: 1  # Expect an exit code of 1, indicating an error
+      expect-output: "ERROR: Missing runmode"  # Verify that the error message is present
+


### PR DESCRIPTION
Ticket: 5711

Test for missing suricata capture runmode hint

Suricata PR: https://github.com/OISF/suricata/pull/9674
Redmine ticket: https://redmine.openinfosecfoundation.org/issues/5711
