### PR TITLE
tests: add rule to check for tcp_seq - v1

### DIFF
--- a/tests/rules/tcp-seq-keyword/test.rules
+++ b/tests/rules/tcp-seq-keyword/test.rules
@@ -1,0 +1,2 @@
+alert tcp any any -> any any (msg:"Testing seq"; seq:624; sid:1;)
+alert tcp any any -> any any (msg:"Testing seq"; seq:723833; sid:2;)

--- a/tests/rules/tcp-seq-keyword/test.yaml
+++ b/tests/rules/tcp-seq-keyword/test.yaml
@@ -1,0 +1,21 @@
+requires:
+    min-version: 7.0.0
+    pcap: false
+
+args:
+    - --engine-analysis
+
+checks:
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 1
+      lists.packet.matches[0].name: "tcp.seq"
+      lists.packet.matches[0].seq.number: 624
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+        id: 2
+        lists.packet.matches[0].seq.number: 723833


### PR DESCRIPTION
Test for rule type for tcp-seq keyword

Related to
Issue: #6353

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6353

Previous Suricata PR: https://github.com/OISF/suricata/pull/9676

Suricata PR: https://github.com/OISF/suricata/pull/9677