### PR TITLE
tests: add rule to check for tcp_mss - v2

### DIFF
--- a/tests/rules/tcp-mss/test.rules
+++ b/tests/rules/tcp-mss/test.rules
@@ -1,0 +1,4 @@
+alert tcp any any -> any any (msg:"Testing mss"; tcp.mss:50; sid:1;)
+alert tcp any any -> any any (msg:"Testing mss"; tcp.mss:>123; sid:2;)
+alert tcp any any -> any any (msg:"Testing mss"; tcp.mss:<536; sid:3;)
+alert tcp any any -> any any (msg:"Testing mss"; tcp.mss:123-456; sid:4;)

--- a/tests/rules/tcp-mss/test.yaml
+++ b/tests/rules/tcp-mss/test.yaml
@@ -1,0 +1,40 @@
+requires:
+    min-version: 7.0.0
+    pcap: false
+
+args:
+    - --engine-analysis
+
+checks:
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 1
+      lists.packet.matches[0].name: "tcp.mss"
+      lists.packet.matches[0].tcp_mss.value1: 50
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 2
+      lists.packet.matches[0].name: "tcp.mss"
+      lists.packet.matches[0].tcp_mss.mode: "greater than"
+      lists.packet.matches[0].tcp_mss.value1: 123
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 3
+      lists.packet.matches[0].name: "tcp.mss"
+      lists.packet.matches[0].tcp_mss.mode: "less than"
+      lists.packet.matches[0].tcp_mss.value1: 536
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 4
+      lists.packet.matches[0].name: "tcp.mss"
+      lists.packet.matches[0].tcp_mss.mode: "range"
+      lists.packet.matches[0].tcp_mss.value1: 123
+      lists.packet.matches[0].tcp_mss.value2: 456


### PR DESCRIPTION
Test for rule type for tcp-mss keyword

Related to
Issue: #6355

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6355

Suricata PR: https://github.com/OISF/suricata/pull/9681