### PR TITLE
tests: add a test for missing runmode v2

### DIFF
--- a/tests/runmode_test/README.md
+++ b/tests/runmode_test/README.md
@@ -1,0 +1,10 @@
+# Suricata Missing Runmode Issue
+
+This directory contains test files and documentation for addressing the "Missing runmode" issue 5711 in Suricata.
+
+## Issue Description
+
+The issue relates to Suricata not providing adequate feedback when the runmode is missing, leading to confusion for users.
+
+
+

--- a/tests/runmode_test/suricata.yaml
+++ b/tests/runmode_test/suricata.yaml
@@ -1,0 +1,12 @@
+%YAML 1.1
+---
+
+runmodes:
+  - workers:
+      enabled: yes
+       
+  
+    
+
+
+

--- a/tests/runmode_test/test.yaml
+++ b/tests/runmode_test/test.yaml
@@ -1,0 +1,16 @@
+requires:
+  min-version: 7 
+  pcap: false
+
+exit-code: 1
+args:
+   - --dump-config
+
+checks:
+   - shell:
+       args: suricata -S /dev/null
+       expect: 1  
+
+         
+      
+                                           


### PR DESCRIPTION
Ticket: 5711

Test for missing suricata capture runmode hint
Incoporated previous feedback on  running test

Previous PR: https://github.com/OISF/suricata-verify/pull/1434
Suricata PR: https://github.com/OISF/suricata/pull/9692
Redmine ticket: https://redmine.openinfosecfoundation.org/issues/5711
