### PR TITLE
detect/bsize: Version update for bsize/content

### DIFF
--- a/tests/detect-bsize-01/test.yaml
+++ b/tests/detect-bsize-01/test.yaml
@@ -1,5 +1,5 @@
 requires:
-    min-version: 7.0.0
+    min-version: 6.0.16
     pcap: false
 
 args:

--- a/tests/test-bad-content-dsize-rule-1/test.yaml
+++ b/tests/test-bad-content-dsize-rule-1/test.yaml
@@ -1,6 +1,6 @@
 requires:
   min-version: 5.0.0
-  lt-version: 7
+  lt-version: 6.0.16
 
   features:
     - HAVE_LIBJANSSON

--- a/tests/test-bad-content-dsize-rule-2/test.yaml
+++ b/tests/test-bad-content-dsize-rule-2/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  version: 7
+  min-version: 6.0.16
 
 command: |
   ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules

--- a/tests/test-bad-content-dsize-rule-3/test.yaml
+++ b/tests/test-bad-content-dsize-rule-3/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  version: 7
+  min-version: 6.0.16
 
 command: |
   ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/etc/classification.config" --set reference-config-file="${SRCDIR}/etc/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules

--- a/tests/test-bad-dsize-offset-rule-1/test.yaml
+++ b/tests/test-bad-dsize-offset-rule-1/test.yaml
@@ -1,6 +1,6 @@
 requires:
   min-version: 5.0.0
-  lt-version: 7
+  lt-version: 6.0.16
 
   features:
     - HAVE_LIBJANSSON

--- a/tests/test-bad-dsize-offset-rule-2/test.yaml
+++ b/tests/test-bad-dsize-offset-rule-2/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  version: 7
+  min-version: 6.0.16
 
 command: |
   ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules

--- a/tests/test-bad-dsize-range-offset-rule-1/test.yaml
+++ b/tests/test-bad-dsize-range-offset-rule-1/test.yaml
@@ -1,6 +1,6 @@
 requires:
   min-version: 5.0.0
-  lt-version: 7
+  lt-version: 6.0.16
 
   features:
     - HAVE_LIBJANSSON

--- a/tests/test-bad-dsize-range-offset-rule-2/test.yaml
+++ b/tests/test-bad-dsize-range-offset-rule-2/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 7
+  min-version: 6.0.16
 
 command: |
   ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules

--- a/tests/test-bad-dsize-range-rule-1/test.yaml
+++ b/tests/test-bad-dsize-range-rule-1/test.yaml
@@ -1,6 +1,6 @@
 requires:
   min-version: 5.0.0
-  lt-version: 7
+  lt-version: 6.0.16
 
   features:
     - HAVE_LIBJANSSON

--- a/tests/test-bad-dsize-range-rule-2/test.yaml
+++ b/tests/test-bad-dsize-range-rule-2/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 7
+  min-version: 6.0.16
 
 command: |
   ${SRCDIR}/src/suricata --set classification-file="${SRCDIR}/classification.config" --set reference-config-file="${SRCDIR}/reference.config" -l ${OUTPUT_DIR} -c ${TEST_DIR}/suricata.yaml -r ${TEST_DIR}/ -S ${TEST_DIR}/test.rules


### PR DESCRIPTION
Issue: 5606

This commit updates the min-version numbers for tests that ensure the bsize/dsize values agree with the content sizes.


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
