### PR TITLE
tests: add rule to check for tcp_mss - v4

### DIFF
--- a/tests/rules/tcp-mss/test.rules
+++ b/tests/rules/tcp-mss/test.rules
@@ -1,0 +1,8 @@
+alert tcp any any -> any any (msg:"Testing mss"; tcp.mss:50; sid:1;)
+alert tcp any any -> any any (msg:"Testing mss"; tcp.mss:>123; sid:2;)
+alert tcp any any -> any any (msg:"Testing mss"; tcp.mss:<536; sid:3;)
+alert tcp any any -> any any (msg:"Testing mss"; tcp.mss:123-456; sid:4;)
+alert tcp any any -> any any (msg:"Testing mss"; tcp.mss:>=439; sid:5;)
+alert tcp any any -> any any (msg:"Testing mss"; tcp.mss:<=70; sid:6;)
+alert tcp any any -> any any (msg:"Testing mss"; tcp.mss:!1000; sid:7;)
+alert tcp any any -> any any (msg:"Testing mss"; tcp.mss:!=953; sid:8;)

--- a/tests/rules/tcp-mss/test.yaml
+++ b/tests/rules/tcp-mss/test.yaml
@@ -1,0 +1,73 @@
+requires:
+    min-version: 7.0.0
+    pcap: false
+
+args:
+    - --engine-analysis
+
+checks:
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 1
+      lists.packet.matches[0].name: "tcp.mss"
+      lists.packet.matches[0].tcp_mss.operand: "equal"
+      lists.packet.matches[0].tcp_mss.value: 50
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 2
+      lists.packet.matches[0].name: "tcp.mss"
+      lists.packet.matches[0].tcp_mss.operand: "greater than"
+      lists.packet.matches[0].tcp_mss.value: 123
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 3
+      lists.packet.matches[0].name: "tcp.mss"
+      lists.packet.matches[0].tcp_mss.operand: "less than"
+      lists.packet.matches[0].tcp_mss.value: 536
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 4
+      lists.packet.matches[0].name: "tcp.mss"
+      lists.packet.matches[0].tcp_mss.operand: "range"
+      lists.packet.matches[0].tcp_mss.min: 123
+      lists.packet.matches[0].tcp_mss.max: 456
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 5
+      lists.packet.matches[0].name: "tcp.mss"
+      lists.packet.matches[0].tcp_mss.operand: "greater than or equal to"
+      lists.packet.matches[0].tcp_mss.value: 439
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 6
+      lists.packet.matches[0].name: "tcp.mss"
+      lists.packet.matches[0].tcp_mss.operand: "less than or equal to"
+      lists.packet.matches[0].tcp_mss.value: 70
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 7
+      lists.packet.matches[0].name: "tcp.mss"
+      lists.packet.matches[0].tcp_mss.operand: "not equal to"
+      lists.packet.matches[0].tcp_mss.value: 1000
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 8
+      lists.packet.matches[0].name: "tcp.mss"
+      lists.packet.matches[0].tcp_mss.operand: "not equal to"
+      lists.packet.matches[0].tcp_mss.value: 953


### PR DESCRIPTION
Test for rule for tcp-mss keyword.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6355

Previous PR: https://github.com/OISF/suricata-verify/pull/1461

Suricata PR: https://github.com/OISF/suricata/pull/9778