### PR TITLE
runner: fix python escaping warnings

### DIFF
--- a/run.py
+++ b/run.py
@@ -51,8 +51,8 @@ LINUX = sys.platform.startswith("linux")
 suricata_yaml = "suricata.yaml" if WIN32 else "./suricata.yaml"
 
 # Determine the Suricata binary
-if os.path.exists("src\suricata.exe"):
-    suricata_bin = "src\suricata.exe"
+if os.path.exists("src\\suricata.exe"):
+    suricata_bin = "src\\suricata.exe"
 else:
     suricata_bin = "./src/suricata"
 
@@ -141,7 +141,7 @@ SuricataVersion = namedtuple(
     "SuricataVersion", ["major", "minor", "patch"])
 
 def parse_suricata_version(buf, expr=None):
-    m = re.search("(?:Suricata version |^)(\d+)\.?(\d+)?\.?(\d+)?.*", str(buf).strip())
+    m = re.search(r"(?:Suricata version |^)(\d+)\.?(\d+)?\.?(\d+)?.*", str(buf).strip())
     default_v = 0
     if expr is not None and expr == "equal":
         default_v = None
@@ -396,7 +396,7 @@ def find_value(name, obj):
             break
         name = None
         index = None
-        m = re.match("^(.*)\[(\d+)\]$", part)
+        m = re.match(r"^(.*)\[(\d+)\]$", part)
         if m:
             name = m.group(1)
             index = m.group(2)
@@ -870,7 +870,7 @@ class TestRunner:
         if "args" in self.config:
             assert(type(self.config["args"]) == type([]))
             for arg in self.config["args"]:
-                args += re.split("\s", arg)
+                args += re.split(r"\s", arg)
 
         # In Suricata 5.0 the classification.config and
         # reference.config were moved into the etc/ directory. For now


### PR DESCRIPTION
Fixes the following warnings in newer versions of Python:

/home/jason/oisf/dev/suricata-verify/dns-response-tests/run.py:54: SyntaxWarning: invalid escape sequence '\s'
  if os.path.exists("src\suricata.exe"):
/home/jason/oisf/dev/suricata-verify/dns-response-tests/run.py:55: SyntaxWarning: invalid escape sequence '\s'
  suricata_bin = "src\suricata.exe"
/home/jason/oisf/dev/suricata-verify/dns-response-tests/run.py:144: SyntaxWarning: invalid escape sequence '\d'
  m = re.search("(?:Suricata version |^)(\d+)\.?(\d+)?\.?(\d+)?.*", str(buf).strip())
/home/jason/oisf/dev/suricata-verify/dns-response-tests/run.py:399: SyntaxWarning: invalid escape sequence '\['
  m = re.match("^(.*)\[(\d+)\]$", part)
/home/jason/oisf/dev/suricata-verify/dns-response-tests/run.py:873: SyntaxWarning: invalid escape sequence '\s'
  args += re.split("\s", arg)
