### PR TITLE
test: http2 user info now works from version 7

### DIFF
--- a/tests/http2-userinfo-authority/test.yaml
+++ b/tests/http2-userinfo-authority/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.0
+  min-version: 7.0.0
 
 # disables checksum verification
 args:


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6426

#1480 but only for 7 as Suricata 6 is ok for the event, but not for the workaround signature