### PR TITLE
Better support for nested directories - v1

### DIFF
--- a/run.py
+++ b/run.py
@@ -786,10 +786,11 @@ class TestRunner:
 
         if not check_value["failure"] and not check_value["skipped"]:
             if not self.quiet:
-                if os.path.basename(os.path.dirname(self.directory)) != "tests":
-                    path_name = os.path.join(os.path.basename(os.path.dirname(self.directory)), self.name)
+                test_name_offset = self.directory.find("tests/")
+                if test_name_offset > -1:
+                    path_name = self.directory[test_name_offset + len("tests/"):]
                 else:
-                    path_name = (os.path.basename(self.directory))
+                    path_name = os.path.basename(self.directory)
                 print("===> %s: OK%s" % (path_name, " (%dx)" % count if count > 1 else ""))
         elif not check_value["failure"]:
             if not self.quiet:

--- a/run.py
+++ b/run.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 #
-# Copyright (C) 2017-2022 Open Information Security Foundation
+# Copyright (C) 2017-2023 Open Information Security Foundation
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
@@ -1158,11 +1158,12 @@ def main():
         if not args.patterns:
             tests.append(dirpath)
         else:
+            test_name = dirpath[len(tdir) + 1:]
             for pattern in args.patterns:
                 if args.exact:
-                    if pattern == basename:
+                    if pattern == test_name:
                         tests.append(dirpath)
-                elif basename.find(pattern) > -1:
+                elif test_name.find(pattern) > -1:
                     tests.append(dirpath)
 
     # Sort alphabetically.


### PR DESCRIPTION
First, if doing `run.py pattern` consider the directories to the test as part of the test name. For example you might have a directory `foobar` with tests named `one`, `two` and so on.  You'd want `run.py foobar` to run all those tests.

Second, handle more then one level of sub-directories when displaying the test name.
