### PR TITLE
tests: update ips-state-1 test - v2

### DIFF
--- a/tests/ips-state-1/README.md
+++ b/tests/ips-state-1/README.md
@@ -1,13 +1,9 @@
 ## PCAP
 
-This PCAP contains 3 flows.  2 are http and one is TLS. The HTTP flows should
+This PCAP contains 3 flows. 2 are http and one is TLS. The HTTP flows should
 be full passed with no alerts, while the TLS flow should be dropped.
 
 ## Current Observations
 
-- HTTP response packets are being logged as dropped, however the transaction is
-  logged suggesting the drop is only in logging only, but not actually
-  occurring.
-
-- All the TLS packets apear to be getting dropped, but `flow.action` is never
-  set to true.
+- Test seems to indicate that Suricata mostly behaves as expected. BUT, although
+  we see TLS logged as dropped, the actual flow.action is never set to drop...

--- a/tests/ips-state-1/test.yaml
+++ b/tests/ips-state-1/test.yaml
@@ -8,8 +8,6 @@ checks:
 - filter:
     # We should see 2 http transactions as the pass rule should allow http
     # flows.
-    #
-    # This fails.
     count: 2
     match:
       event_type: http
@@ -27,14 +25,21 @@ checks:
     match:
       event_type: flow
       app_proto: http
-      flow.alerted: false 
+      flow.alerted: false
 
 - filter:
     # We should see NO drops (or alerts) for http
     count: 0
     match:
-      event_type: alert
+      event_type: drop
       app_proto: http
+
+- filter:
+    # There should be alerts for tls
+    count: 36
+    match:
+      event_type: alert
+      app_proto: tls
 
 - filter:
     # There should be one tls flow that is alerted
@@ -43,3 +48,13 @@ checks:
       event_type: flow
       dest_port: 443
       flow.alerted: true
+      flow.action: drop
+
+- filter:
+    # We should see NO drops (or alerts) for http
+    count: 2
+    match:
+      event_type: flow
+      app_proto: http
+      flow.action: pass
+      flow.alerted: false


### PR DESCRIPTION
This test indicated that there were FP drops for http and that another check was failing, but currently the test passes.

Previous PR: https://github.com/OISF/suricata-verify/pull/1227

Changes from previous PR:
- rebase
- add more checks
-- make test fail again, by checking for `flow.action: drop` for `tls` flow
- update README to indicate current test behavior

Question: do we expect to see `flow.action` set to `drop` here?