### PR TITLE
tests: Fixups for 6.0.x

### DIFF
--- a/tests/test-bad-content-dsize-rule-1/test.yaml
+++ b/tests/test-bad-content-dsize-rule-1/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 5.0.0
+  min-version: 6.0.16
   lt-version: 7
 
   features:
@@ -15,7 +15,7 @@ checks:
       count: 1
       match:
         event_type: engine
-        engine.message: "signature can't match as content length 30 is bigger than dsize 10."
+        engine.message: "signature can't match as required content length 30 exceeds dsize value 10"
 
   - filter:
       count: 1

--- a/tests/test-bad-dsize-offset-rule-1/test.yaml
+++ b/tests/test-bad-dsize-offset-rule-1/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 5.0.0
+  min-version: 6.0.16
   lt-version: 7
 
   features:
@@ -15,7 +15,7 @@ checks:
       count: 1
       match:
         event_type: engine
-        engine.message: "signature can't match as content length 2 with offset 100 (=102) is bigger than dsize 50."
+        engine.message: "signature can't match as required content length 102 exceeds dsize value 50"
 
 
   - filter:

--- a/tests/test-bad-dsize-range-offset-rule-1/test.yaml
+++ b/tests/test-bad-dsize-range-offset-rule-1/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 5.0.0
+  min-version: 6.0.16
   lt-version: 7
 
   features:
@@ -15,7 +15,7 @@ checks:
       count: 1
       match:
         event_type: engine
-        engine.message: "signature can't match as content length 4 with offset 8 (=12) is bigger than dsize 10."
+        engine.message: "signature can't match as required content length 12 exceeds dsize value 10"
 
   - filter:
       count: 1

--- a/tests/test-bad-dsize-range-rule-1/test.yaml
+++ b/tests/test-bad-dsize-range-rule-1/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 5.0.0
+  min-version: 6.0.16
   lt-version: 7
 
   features:
@@ -15,7 +15,7 @@ checks:
       count: 1
       match:
         event_type: engine
-        engine.message: "signature can't match as content length 30 is bigger than dsize 10."
+        engine.message: "signature can't match as required content length 30 exceeds dsize value 10"
 
   - filter:
       count: 1


### PR DESCRIPTION
Issue: 6549

Fixups for the tests for 6.0.x. The dsize/bsize validation message format has changed so the checks in the test.yaml are being updatd.


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
