### PR TITLE
tests/pgsql: update password log disabled msgs - v1

### DIFF
--- a/tests/pgsql/pgsql-5000-query-results/test.yaml
+++ b/tests/pgsql/pgsql-5000-query-results/test.yaml
@@ -64,7 +64,7 @@ checks:
       dest_port: 5432
       event_type: pgsql
       pcap_cnt: 29
-      pgsql.request.password_message: password log disabled
+      pgsql.request.password_message: password_log_disabled
       pgsql.response.message: authentication_ok
       pgsql.response.parameter_status[0].application_name: psql
       pgsql.response.parameter_status[10].time_zone: Etc/UTC

--- a/tests/pgsql/pgsql-pwd-output-disabled/test.yaml
+++ b/tests/pgsql/pgsql-pwd-output-disabled/test.yaml
@@ -43,7 +43,7 @@ checks:
       dest_port: 5432
       event_type: pgsql
       pcap_cnt: 12
-      pgsql.request.password_message: password log disabled
+      pgsql.request.password_message: password_log_disabled
       pgsql.response.message: authentication_ok
       pgsql.response.parameter_status[0].application_name: psql
       pgsql.response.parameter_status[10].time_zone: Europe/London


### PR DESCRIPTION
Removing the white spaces from this log output, as these can cause issues with grepping commands querying log results, and also doesn't show a consistent behavior among different environments.

No ticket yet. But will create one if we think this should be merged and backported... I think we should.
