### PR TITLE
detect/transform/header_lowercase: support from 7.0.3

### DIFF
--- a/tests/transform-header-lowercase/test.yaml
+++ b/tests/transform-header-lowercase/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.0
+  min-version: 7.0.3
 
 pcap: ../http2-range/http2-range.pcap
 


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6613

https://github.com/OISF/suricata-verify/pull/1479 with lowering version support.

Do I get it right to put 7.0.3 which is not out yet ?
