### PR TITLE
test: adds test for strip_pseudo_headers transform

### DIFF
--- a/tests/transform-strip-pseudo-headers/README.md
+++ b/tests/transform-strip-pseudo-headers/README.md
@@ -1,0 +1,9 @@
+# Description
+
+Test strip_pseudo_headers transform.
+https://redmine.openinfosecfoundation.org/issues/6546
+
+# PCAP
+
+The pcap comes from test http2-range.
+This pcap has both HTTP1 and HTTP2.

--- a/tests/transform-strip-pseudo-headers/test.rules
+++ b/tests/transform-strip-pseudo-headers/test.rules
@@ -1,0 +1,3 @@
+alert http any any -> any any (http.header_names; strip_pseudo_headers; content: "|0d 0a|accept-ranges"; startswith; nocase; sid:1; )
+alert http any any -> any any (http.header_names; content: "|0d 0a|accept-ranges"; startswith; nocase; sid:2; )
+alert http1 any any -> any any (http.header_names; content: "|0d 0a|accept-ranges"; startswith; nocase; sid:3; )

--- a/tests/transform-strip-pseudo-headers/test.yaml
+++ b/tests/transform-strip-pseudo-headers/test.yaml
@@ -1,0 +1,27 @@
+requires:
+  min-version: 8.0.0
+
+pcap: ../http2-range/http2-range.pcap
+
+# disables checksum verification
+args:
+  - -k none --set app-layer.protocols.http2.enabled=true
+
+checks:
+  # transform allows to get 3 more alerts, the ones from HTTP2
+  - filter:
+      count: 5
+      match:
+        event_type: alert
+        alert.signature_id: 1
+  # without transform, we only get the 2 alerts from HTTP1
+  - filter:
+      count: 2
+      match:
+        event_type: alert
+        alert.signature_id: 2
+  - filter:
+      count: 2
+      match:
+        event_type: alert
+        alert.signature_id: 3


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6546

Suricata PR incoming 

For now, targeting version 8, will do another SV PR to lower the version to 7 along with the Suricata backport.
Is it correct ?