### PR TITLE
Add test about enip stats with _udp prefix

### DIFF
--- a/tests/enip-stats-udp/README.md
+++ b/tests/enip-stats-udp/README.md
@@ -1,0 +1,11 @@
+# Description
+
+Test ENIP stats always have `_udp` or `_tcp` prefix
+
+# Issue
+
+https://redmine.openinfosecfoundation.org/issues/6304
+
+# PCAP
+
+The pcap is reused enip-alert test

--- a/tests/enip-stats-udp/suricata.yaml
+++ b/tests/enip-stats-udp/suricata.yaml
@@ -1,0 +1,18 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - flow
+        - stats
+
+app-layer:
+  protocols:
+    enip:
+      enabled: detection-only
+      detection-ports:
+        dp: 44818

--- a/tests/enip-stats-udp/test.yaml
+++ b/tests/enip-stats-udp/test.yaml
@@ -1,0 +1,28 @@
+requires:
+  min-version: 8
+
+pcap: ../enip-alert/enip_test1.pcap
+
+# disables checksum verification
+args:
+- -k none
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: flow
+        app_proto: enip
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        # not stats.app_layer.flow.enip
+        stats.app_layer.flow.enip_tcp: 1
+        stats.app_layer.flow.enip_udp: 0
+  - filter:
+      count: 0
+      match:
+        event_type: stats
+        # this key does not exist in eve output
+        stats.app_layer.flow.enip: 0


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6304
https://redmine.openinfosecfoundation.org/issues/6633

Suricata PR https://github.com/OISF/suricata/pull/10050 next version required

#1546 with enip flow accounted in stats