### PR TITLE
requires: check stat; unknown requires keyword - v2

### DIFF
--- a/tests/requires/test.rules
+++ b/tests/requires/test.rules
@@ -13,3 +13,5 @@ alert vxlan any any -> any any (requires: version >= 10; sid:1;)
 alert udp any any -> any any (vxlan_vni:10; requires: version >= 10; sid:2;)
 alert http any any => any any (requires: version >= 10; sid:3;)
 alert tcp any any -> any any (frame:smtp.not_supported; requires: version >= 10; sid:4;)
+
+alert asdf any any -> any any (requires: version >= 6, foo bar; sid:102; rev:1;)

--- a/tests/requires/test.yaml
+++ b/tests/requires/test.yaml
@@ -42,3 +42,9 @@ checks:
       count: 0
       match:
         alert.signature_id: 9
+
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        stats.detect.engines[0].rules_skipped: 7


### PR DESCRIPTION
For the requires keyword, check the new state, `rules_skipped`. Also add a test
for an unknown requires keyword to make sure the rule doesn't error out.

Feature: https://redmine.openinfosecfoundation.org/issues/6637
