### PR TITLE
test: add test for dns.rcode

### DIFF
--- a/tests/dns/dns-rcode/README.md
+++ b/tests/dns/dns-rcode/README.md
@@ -1,0 +1,5 @@
+Test the `dns.rcode` sticky buffer.
+
+The PCAP here was a request created with Scapy to include answers in
+the request. However the response is from a real DNS server with the
+provided request.

--- a/tests/dns/dns-rcode/test.rules
+++ b/tests/dns/dns-rcode/test.rules
@@ -1,0 +1,8 @@
+# Should alert in both directions as no flow is provided.
+alert dns any any -> any any (dns.rcode; content:"oisf"; sid:1; rev:1;)
+
+# Should only alert in the request direction.
+alert dns any any -> any any (dns.rcode; content:"oisf"; flow:to_server; sid:2; rev:1;)
+
+# Should only alert in the response direction.
+alert dns any any -> any any (dns.rcode; content:"oisf"; flow:to_client; sid:3; rev:1;)

--- a/tests/dns/dns-rcode/test.yaml
+++ b/tests/dns/dns-rcode/test.yaml
@@ -1,0 +1,43 @@
+requires:
+  min-version: 8
+
+checks:
+  - filter:
+      count: 2
+      match:
+        alert.signature_id: 1
+        app_proto: dns
+  - filter:
+      count: 1
+      match:
+        alert.signature_id: 1
+        direction: to_client
+        app_proto: dns
+  - filter:
+      count: 1
+      match:
+        alert.signature_id: 1
+        direction: to_server
+        app_proto: dns
+
+  - filter:
+      count: 1
+      match:
+        alert.signature_id: 2
+  - filter:
+      count: 1
+      match:
+        alert.signature_id: 2
+        direction: to_server
+        app_proto: dns
+
+  - filter:
+      count: 1
+      match:
+        alert.signature_id: 3
+  - filter:
+      count: 1
+      match:
+        alert.signature_id: 3
+        direction: to_client
+        app_proto: dns


### PR DESCRIPTION
Feature #6621


Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6621

Suricata PR: https://github.com/OISF/suricata/pull/10087

Output from stdout file:
```
Notice: suricata: This is Suricata version 8.0.0-dev (5cc872fa1 2023-12-19) running in USER mode [LogVersion:suricata.c:1147]
Warning: detect: 1 rule files specified, but no rules were loaded! [SigLoadSignatures:detect-engine-loader.c:359]

```