### PR TITLE
test: add test for dns.rcode v4

### DIFF
--- a/tests/dns/dns-rcode/README.md
+++ b/tests/dns/dns-rcode/README.md
@@ -1,0 +1,4 @@
+Test the `dns.rcode` header value.
+
+The PCAP here was reused from ./tests/dns-eve-v2-udp-nxdomain-soa/dns-udp-nxdomain-soa.pcap
+Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6621

--- a/tests/dns/dns-rcode/test.rules
+++ b/tests/dns/dns-rcode/test.rules
@@ -1,0 +1,5 @@
+# Should alert in client direction.
+alert dns any any -> any any (dns.rcode:3; sid:1; rev:1;)
+
+# Should only alert in client direction.
+alert dns any any -> any any (dns.rcode:!3; sid:2; rev:1;)

--- a/tests/dns/dns-rcode/test.yaml
+++ b/tests/dns/dns-rcode/test.yaml
@@ -1,0 +1,18 @@
+requires:
+  min-version: 8
+
+pcap: ../../dns-eve-v2-udp-nxdomain-soa/dns-udp-nxdomain-soa.pcap
+
+checks:
+  - filter:
+      count: 1
+      match:
+        alert.signature_id: 1
+        direction: to_client
+        app_proto: dns
+        event_type: alert
+        dns.answer.rcode: NXDOMAIN
+  - filter:
+      count: 1
+      match:
+        alert.signature_id: 2


### PR DESCRIPTION
Feature #6621

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6621

Previous PR: https://github.com/OISF/suricata-verify/pull/1574

Suricata PR: https://github.com/OISF/suricata/pull/10249

Changes made:
- Made edits to rcode tests so they are now passing.
- Added a test for negated values as well

Output after running `cat output/eve.json | jq 'select(.dns)`:
```
{
  "timestamp": "2017-01-27T16:03:18.623093+0000",
  "flow_id": 1831741271326429,
  "pcap_cnt": 1,
  "event_type": "alert",
  "src_ip": "10.16.1.11",
  "src_port": 59465,
  "dest_ip": "8.8.4.4",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "tx_id": 0,
  "alert": {
    "action": "allowed",
    "gid": 1,
    "signature_id": 2,
    "rev": 1,
    "signature": "",
    "category": "",
    "severity": 3
  },
  "dns": {
    "query": [
      {
        "type": "query",
        "id": 33429,
        "rrname": "dne.oisf.net",
        "rrtype": "A",
        "tx_id": 0,
        "opcode": 0
      }
    ]
  },
  "app_proto": "dns",
  "direction": "to_server",
  "flow": {
    "pkts_toserver": 1,
    "pkts_toclient": 0,
    "bytes_toserver": 95,
    "bytes_toclient": 0,
    "start": "2017-01-27T16:03:18.623093+0000",
    "src_ip": "10.16.1.11",
    "dest_ip": "8.8.4.4",
    "src_port": 59465,
    "dest_port": 53
  }
}
{
  "timestamp": "2017-01-27T16:03:18.623093+0000",
  "flow_id": 1831741271326429,
  "pcap_cnt": 1,
  "event_type": "dns",
  "src_ip": "10.16.1.11",
  "src_port": 59465,
  "dest_ip": "8.8.4.4",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "dns": {
    "type": "query",
    "id": 33429,
    "rrname": "dne.oisf.net",
    "rrtype": "A",
    "tx_id": 0,
    "opcode": 0
  }
}
{
  "timestamp": "2017-01-27T16:03:18.709160+0000",
  "flow_id": 1831741271326429,
  "pcap_cnt": 2,
  "event_type": "alert",
  "src_ip": "8.8.4.4",
  "src_port": 53,
  "dest_ip": "10.16.1.11",
  "dest_port": 59465,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "tx_id": 1,
  "alert": {
    "action": "allowed",
    "gid": 1,
    "signature_id": 1,
    "rev": 1,
    "signature": "",
    "category": "",
    "severity": 3
  },
  "dns": {
    "answer": {
      "version": 2,
      "type": "answer",
      "id": 33429,
      "flags": "8183",
      "qr": true,
      "rd": true,
      "ra": true,
      "opcode": 0,
      "rrname": "dne.oisf.net",
      "rrtype": "A",
      "rcode": "NXDOMAIN",
      "authorities": [
        {
          "rrname": "oisf.net",
          "rrtype": "SOA",
          "ttl": 899,
          "soa": {
            "mname": "ns-110.awsdns-13.com",
            "rname": "awsdns-hostmaster.amazon.com",
            "serial": 1,
            "refresh": 7200,
            "retry": 900,
            "expire": 1209600,
            "minimum": 86400
          }
        }
      ]
    }
  },
  "app_proto": "dns",
  "direction": "to_client",
  "flow": {
    "pkts_toserver": 1,
    "pkts_toclient": 1,
    "bytes_toserver": 95,
    "bytes_toclient": 164,
    "start": "2017-01-27T16:03:18.623093+0000",
    "src_ip": "10.16.1.11",
    "dest_ip": "8.8.4.4",
    "src_port": 59465,
    "dest_port": 53
  }
}
{
  "timestamp": "2017-01-27T16:03:18.709160+0000",
  "flow_id": 1831741271326429,
  "pcap_cnt": 2,
  "event_type": "dns",
  "src_ip": "10.16.1.11",
  "src_port": 59465,
  "dest_ip": "8.8.4.4",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "dns": {
    "version": 2,
    "type": "answer",
    "id": 33429,
    "flags": "8183",
    "qr": true,
    "rd": true,
    "ra": true,
    "opcode": 0,
    "rrname": "dne.oisf.net",
    "rrtype": "A",
    "rcode": "NXDOMAIN",
    "authorities": [
      {
        "rrname": "oisf.net",
        "rrtype": "SOA",
        "ttl": 899,
        "soa": {
          "mname": "ns-110.awsdns-13.com",
          "rname": "awsdns-hostmaster.amazon.com",
          "serial": 1,
          "refresh": 7200,
          "retry": 900,
          "expire": 1209600,
          "minimum": 86400
        }
      }
    ]
  }
}
```