### PR TITLE
requires: update skipped rules counter

### DIFF
--- a/tests/requires/test.yaml
+++ b/tests/requires/test.yaml
@@ -47,4 +47,4 @@ checks:
       count: 1
       match:
         event_type: stats
-        stats.detect.engines[0].rules_skipped: 6
+        stats.detect.engines[0].rules_skipped: 7


### PR DESCRIPTION
@jasonish this was fairly confusing to me.
1. If the `requires` keyword has bad language, why is it not an error?
2. If `requires` keyword has bad language, we skip the rule with a warning but the rule would still be parsed generating another error if the rule lang is bad elsewhere. Why do we allow this? [Case in point: `sid: 102` rule for `requires` test]