### PR TITLE
tests/requires: fix for suricata 8 (git master)

### DIFF
--- a/tests/requires/test.yaml
+++ b/tests/requires/test.yaml
@@ -44,7 +44,18 @@ checks:
         alert.signature_id: 9
 
   - filter:
+      requires:
+        min-version: 7
+        lt-version: 8
       count: 1
       match:
         event_type: stats
         stats.detect.engines[0].rules_skipped: 6
+
+  - filter:
+      requires:
+        min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.detect.engines[0].rules_skipped: 7


### PR DESCRIPTION
Suricata 8 will have 7 rules skipped, Suricata 7.0.3+ will have 6 rules
skipped as there is a rule in here for Suricata >= 7.0.3 but less than
8.
