### PR TITLE
tests: add rule to check for tcp/ack - v6

### DIFF
--- a/tests/rules/tcp_ack/README.md
+++ b/tests/rules/tcp_ack/README.md
@@ -1,0 +1,2 @@
+## Description
+Rule test for tcp-ack keyword engine-analysis output; includes the test.yaml and test.rules files.

--- a/tests/rules/tcp_ack/test.rules
+++ b/tests/rules/tcp_ack/test.rules
@@ -1,0 +1,3 @@
+alert tcp any any -> any any (msg:"Testing ack"; ack:782; sid:1;)
+alert tcp any any -> any any (msg:"Testing ack"; ack:15; sid:2;)
+alert tcp any any -> any any (msg:"Testing ack"; ack:437528; sid:3;)

--- a/tests/rules/tcp_ack/test.yaml
+++ b/tests/rules/tcp_ack/test.yaml
@@ -1,0 +1,28 @@
+requires:
+    min-version: 8.0
+    pcap: false
+
+args:
+    - --engine-analysis
+
+checks:
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 1
+      lists.packet.matches[0].name: "tcp.ack"
+      lists.packet.matches[0].ack.number: 782
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 2
+      lists.packet.matches[0].ack.number: 15
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 3
+      lists.packet.matches[0].name: "tcp.ack"
+      lists.packet.matches[0].ack.number: 437528


### PR DESCRIPTION
Test for rule type for tcp-ack keyword engine analysis output.

Related to
Issue: 6354

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6354

Suricata PR: https://github.com/OISF/suricata/pull/10266

Previous PR: https://github.com/OISF/suricata-verify/pull/1622