### PR TITLE
test: add test for dns.rrtype v2

### DIFF
--- a/tests/dns/dns-rrtype/README.md
+++ b/tests/dns/dns-rrtype/README.md
@@ -1,0 +1,5 @@
+Test the `dns.rrtype` value.
+
+The PCAP here was reused from ./tests/dns/dns-answer-name/dns-udp-request-with-answer.pcap
+
+Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6666

--- a/tests/dns/dns-rrtype/test.rules
+++ b/tests/dns/dns-rrtype/test.rules
@@ -1,0 +1,8 @@
+# Only alert on requests.
+alert dns any any -> any any (dns.rrtype:1; flow:to_server; sid:1; rev:1;)
+
+# Only alert on responses.
+alert dns any any -> any any (dns.rrtype:1; flow:to_client; sid:2; rev:1;)
+
+# Negated rrtype value
+alert dns any any -> any any (dns.rrtype:!1; flow:to_client; sid:3; rev:1;)

--- a/tests/dns/dns-rrtype/test.yaml
+++ b/tests/dns/dns-rrtype/test.yaml
@@ -1,0 +1,26 @@
+requires:
+  min-version: 8
+
+pcap: ../dns-answer-name/dns-udp-request-with-answer.pcap
+
+checks:
+  - filter:
+      count: 1
+      match:
+        alert.signature_id: 1
+        direction: to_server
+        app_proto: dns
+        event_type: alert
+        dns.query[0].rrtype: A
+  - filter:
+      count: 1
+      match:
+        alert.signature_id: 2
+        direction: to_client
+        app_proto: dns
+        event_type: alert
+        dns.answer.rrtype: A
+  - filter:
+      count: 1
+      match:
+        alert.signature_id: 3


### PR DESCRIPTION
Feature #6666

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6666

Previous PR: https://github.com/OISF/suricata-verify/pull/1625

Suricata PR: https://github.com/OISF/suricata/pull/10306

Changes made:
- The SV test for negated value is failing. I tried different `rrtype` values but none of the worked. Should I use a different pcap instead?
- Also not sure on how to test range of `rrtype` values as the current pcap only has `rrtype: A`
- Output after running SV test 
`===> dns-rrtype: Sub test #3: FAIL : expected 1 matches; got 0 for filter {'count': 1, 'match': {'alert.signature_id': 3}}
`

Output after running `cat output/eve.json | jq 'select(.dns)`:
```
{
  "timestamp": "2023-11-16T15:12:21.322069+0000",
  "flow_id": 1664750815779451,
  "pcap_cnt": 1,
  "event_type": "alert",
  "src_ip": "10.16.1.11",
  "src_port": 10470,
  "dest_ip": "8.8.8.8",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "tx_id": 0,
  "alert": {
    "action": "allowed",
    "gid": 1,
    "signature_id": 1,
    "rev": 1,
    "signature": "",
    "category": "",
    "severity": 3
  },
  "dns": {
    "query": [
      {
        "type": "query",
        "id": 0,
        "rrname": "oisf.net",
        "rrtype": "A",
        "tx_id": 0,
        "opcode": 0
      }
    ]
  },
  "app_proto": "dns",
  "direction": "to_server",
  "flow": {
    "pkts_toserver": 1,
    "pkts_toclient": 0,
    "bytes_toserver": 92,
    "bytes_toclient": 0,
    "start": "2023-11-16T15:12:21.322069+0000",
    "src_ip": "10.16.1.11",
    "dest_ip": "8.8.8.8",
    "src_port": 10470,
    "dest_port": 53
  }
}
{
  "timestamp": "2023-11-16T15:12:21.322069+0000",
  "flow_id": 1664750815779451,
  "pcap_cnt": 1,
  "event_type": "dns",
  "src_ip": "10.16.1.11",
  "src_port": 10470,
  "dest_ip": "8.8.8.8",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "dns": {
    "type": "query",
    "id": 0,
    "rrname": "oisf.net",
    "rrtype": "A",
    "tx_id": 0,
    "opcode": 0
  }
}
{
  "timestamp": "2023-11-16T15:12:21.378871+0000",
  "flow_id": 1664750815779451,
  "pcap_cnt": 2,
  "event_type": "alert",
  "src_ip": "8.8.8.8",
  "src_port": 53,
  "dest_ip": "10.16.1.11",
  "dest_port": 10470,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "tx_id": 1,
  "alert": {
    "action": "allowed",
    "gid": 1,
    "signature_id": 2,
    "rev": 1,
    "signature": "",
    "category": "",
    "severity": 3
  },
  "dns": {
    "answer": {
      "version": 2,
      "type": "answer",
      "id": 0,
      "flags": "8180",
      "qr": true,
      "rd": true,
      "ra": true,
      "opcode": 0,
      "rrname": "oisf.net",
      "rrtype": "A",
      "rcode": "NOERROR"
    }
  },
  "app_proto": "dns",
  "direction": "to_client",
  "flow": {
    "pkts_toserver": 1,
    "pkts_toclient": 1,
    "bytes_toserver": 92,
    "bytes_toclient": 100,
    "start": "2023-11-16T15:12:21.322069+0000",
    "src_ip": "10.16.1.11",
    "dest_ip": "8.8.8.8",
    "src_port": 10470,
    "dest_port": 53
  }
}
{
  "timestamp": "2023-11-16T15:12:21.378871+0000",
  "flow_id": 1664750815779451,
  "pcap_cnt": 2,
  "event_type": "dns",
  "src_ip": "10.16.1.11",
  "src_port": 10470,
  "dest_ip": "8.8.8.8",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "dns": {
    "version": 2,
    "type": "answer",
    "id": 0,
    "flags": "8180",
    "qr": true,
    "rd": true,
    "ra": true,
    "opcode": 0,
    "rrname": "oisf.net",
    "rrtype": "A",
    "rcode": "NOERROR",
    "answers": [
      {
        "rrname": "oisf.net",
        "rrtype": "A",
        "ttl": 300,
        "rdata": "192.0.78.209"
      },
      {
        "rrname": "oisf.net",
        "rrtype": "A",
        "ttl": 300,
        "rdata": "192.0.78.190"
      }
    ],
    "grouped": {
      "A": [
        "192.0.78.209",
        "192.0.78.190"
      ]
    }
  }
}
```