### PR TITLE
test: add test for dns.rrtype v3

### DIFF
--- a/tests/dns/dns-rrtype/README.md
+++ b/tests/dns/dns-rrtype/README.md
@@ -1,0 +1,5 @@
+Test the `dns.rrtype` value.
+
+The PCAP here was reused from ./tests/dns/dns-answer-name/dns-udp-request-with-answer.pcap
+
+Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6666

--- a/tests/dns/dns-rrtype/test.rules
+++ b/tests/dns/dns-rrtype/test.rules
@@ -1,0 +1,8 @@
+# Only alert on requests.
+alert dns any any -> any any (dns.rrtype:1; flow:to_server; sid:1; rev:1;)
+
+# Only alert on responses.
+alert dns any any -> any any (dns.rrtype:1; flow:to_client; sid:2; rev:1;)
+
+# Negated rrtype value
+alert dns any any -> any any (dns.rrtype:!1; flow:to_client; sid:3; rev:1;)

--- a/tests/dns/dns-rrtype/test.yaml
+++ b/tests/dns/dns-rrtype/test.yaml
@@ -1,0 +1,34 @@
+requires:
+  min-version: 8
+
+pcap: ../dns-eve-empty-format/input.pcap
+
+checks:
+  - filter:
+      count: 1
+      match:
+        alert.signature_id: 1
+        dest_ip: 10.16.1.1
+        dest_port: 53
+        direction: to_server
+        app_proto: dns
+        event_type: alert
+        dns.query[0].rrtype: A
+        src_ip: 10.16.1.11
+        src_port: 57634
+  - filter:
+      count: 1
+      match:
+        alert.signature_id: 2
+        dest_ip: 10.16.1.11
+        dest_port: 33458
+        direction: to_client
+        app_proto: dns
+        event_type: alert
+        dns.answer.rrtype: A
+        src_ip: 10.16.1.1
+        src_port: 53
+  - filter:
+      count: 1
+      match:
+        alert.signature_id: 3


### PR DESCRIPTION
Feature #6666

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6666

Previous PR: https://github.com/OISF/suricata-verify/pull/1628

Suricata PR: https://github.com/OISF/suricata/pull/10306

Changes made:
- All SV tests are passing
- Included SV test for negated value
- Output after running SV test 
```
===> dns/dns-rrtype: OK

PASSED:  1
FAILED:  0
SKIPPED: 0
```

Output after running `cat output/eve.json | jq 'select(.dns)`:
```
{
  "timestamp": "2016-05-24T23:27:01.960780+0000",
  "flow_id": 1593247356761763,
  "pcap_cnt": 1,
  "event_type": "alert",
  "src_ip": "10.16.1.11",
  "src_port": 53679,
  "dest_ip": "10.16.1.1",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "tx_id": 0,
  "alert": {
    "action": "allowed",
    "gid": 1,
    "signature_id": 1,
    "rev": 1,
    "signature": "",
    "category": "",
    "severity": 3
  },
  "dns": {
    "query": [
      {
        "type": "query",
        "id": 39339,
        "rrname": "client-cf.dropbox.com",
        "rrtype": "A",
        "tx_id": 0,
        "opcode": 0
      }
    ]
  },
  "app_proto": "dns",
  "direction": "to_server",
  "flow": {
    "pkts_toserver": 1,
    "pkts_toclient": 0,
    "bytes_toserver": 81,
    "bytes_toclient": 0,
    "start": "2016-05-24T23:27:01.960780+0000",
    "src_ip": "10.16.1.11",
    "dest_ip": "10.16.1.1",
    "src_port": 53679,
    "dest_port": 53
  }
}
{
  "timestamp": "2016-05-24T23:27:02.832606+0000",
  "flow_id": 1887169437757562,
  "pcap_cnt": 3,
  "event_type": "alert",
  "src_ip": "10.16.1.11",
  "src_port": 49697,
  "dest_ip": "10.16.1.1",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "tx_id": 0,
  "alert": {
    "action": "allowed",
    "gid": 1,
    "signature_id": 1,
    "rev": 1,
    "signature": "",
    "category": "",
    "severity": 3
  },
  "dns": {
    "query": [
      {
        "type": "query",
        "id": 3407,
        "rrname": "block.dropbox.com",
        "rrtype": "A",
        "tx_id": 0,
        "opcode": 0
      }
    ]
  },
  "app_proto": "dns",
  "direction": "to_server",
  "flow": {
    "pkts_toserver": 1,
    "pkts_toclient": 0,
    "bytes_toserver": 77,
    "bytes_toclient": 0,
    "start": "2016-05-24T23:27:02.832606+0000",
    "src_ip": "10.16.1.11",
    "dest_ip": "10.16.1.1",
    "src_port": 49697,
    "dest_port": 53
  }
}
{
  "timestamp": "2016-05-24T23:27:01.960780+0000",
  "flow_id": 1593247356761763,
  "pcap_cnt": 1,
  "event_type": "dns",
  "src_ip": "10.16.1.11",
  "src_port": 53679,
  "dest_ip": "10.16.1.1",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "dns": {
    "type": "query",
    "id": 39339,
    "rrname": "client-cf.dropbox.com",
    "rrtype": "A",
    "tx_id": 0,
    "opcode": 0
  }
}
{
  "timestamp": "2016-05-24T23:27:04.653864+0000",
  "flow_id": 275050925761971,
  "pcap_cnt": 7,
  "event_type": "alert",
  "src_ip": "10.16.1.11",
  "src_port": 57634,
  "dest_ip": "10.16.1.1",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "tx_id": 0,
  "alert": {
    "action": "allowed",
    "gid": 1,
    "signature_id": 1,
    "rev": 1,
    "signature": "",
    "category": "",
    "severity": 3
  },
  "dns": {
    "query": [
      {
        "type": "query",
        "id": 14681,
        "rrname": "client-cf.dropbox.com",
        "rrtype": "A",
        "tx_id": 0,
        "opcode": 0
      }
    ]
  },
  "app_proto": "dns",
  "direction": "to_server",
  "flow": {
    "pkts_toserver": 1,
    "pkts_toclient": 0,
    "bytes_toserver": 81,
    "bytes_toclient": 0,
    "start": "2016-05-24T23:27:04.653864+0000",
    "src_ip": "10.16.1.11",
    "dest_ip": "10.16.1.1",
    "src_port": 57634,
    "dest_port": 53
  }
}
{
  "timestamp": "2016-05-24T23:27:02.832606+0000",
  "flow_id": 1887169437757562,
  "pcap_cnt": 3,
  "event_type": "dns",
  "src_ip": "10.16.1.11",
  "src_port": 49697,
  "dest_ip": "10.16.1.1",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "dns": {
    "type": "query",
    "id": 3407,
    "rrname": "block.dropbox.com",
    "rrtype": "A",
    "tx_id": 0,
    "opcode": 0
  }
}
{
  "timestamp": "2016-05-24T23:27:04.653864+0000",
  "flow_id": 275050925761971,
  "pcap_cnt": 7,
  "event_type": "dns",
  "src_ip": "10.16.1.11",
  "src_port": 57634,
  "dest_ip": "10.16.1.1",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "dns": {
    "type": "query",
    "id": 14681,
    "rrname": "client-cf.dropbox.com",
    "rrtype": "A",
    "tx_id": 0,
    "opcode": 0
  }
}
{
  "timestamp": "2016-05-24T23:27:02.333141+0000",
  "flow_id": 1593247356761763,
  "pcap_cnt": 2,
  "event_type": "alert",
  "src_ip": "10.16.1.1",
  "src_port": 53,
  "dest_ip": "10.16.1.11",
  "dest_port": 53679,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "tx_id": 1,
  "alert": {
    "action": "allowed",
    "gid": 1,
    "signature_id": 2,
    "rev": 1,
    "signature": "",
    "category": "",
    "severity": 3
  },
  "dns": {
    "answer": {
      "version": 2,
      "type": "answer",
      "id": 39339,
      "flags": "8180",
      "qr": true,
      "rd": true,
      "ra": true,
      "opcode": 0,
      "rrname": "client-cf.dropbox.com",
      "rrtype": "A",
      "rcode": "NOERROR"
    }
  },
  "app_proto": "dns",
  "direction": "to_client",
  "flow": {
    "pkts_toserver": 1,
    "pkts_toclient": 1,
    "bytes_toserver": 81,
    "bytes_toclient": 97,
    "start": "2016-05-24T23:27:01.960780+0000",
    "src_ip": "10.16.1.11",
    "dest_ip": "10.16.1.1",
    "src_port": 53679,
    "dest_port": 53
  }
}
{
  "timestamp": "2016-05-24T23:27:03.213624+0000",
  "flow_id": 1887169437757562,
  "pcap_cnt": 5,
  "event_type": "alert",
  "src_ip": "10.16.1.1",
  "src_port": 53,
  "dest_ip": "10.16.1.11",
  "dest_port": 49697,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "tx_id": 1,
  "alert": {
    "action": "allowed",
    "gid": 1,
    "signature_id": 2,
    "rev": 1,
    "signature": "",
    "category": "",
    "severity": 3
  },
  "dns": {
    "answer": {
      "version": 2,
      "type": "answer",
      "id": 3407,
      "flags": "8180",
      "qr": true,
      "rd": true,
      "ra": true,
      "opcode": 0,
      "rrname": "block.dropbox.com",
      "rrtype": "A",
      "rcode": "NOERROR"
    }
  },
  "app_proto": "dns",
  "direction": "to_client",
  "flow": {
    "pkts_toserver": 1,
    "pkts_toclient": 1,
    "bytes_toserver": 77,
    "bytes_toclient": 116,
    "start": "2016-05-24T23:27:02.832606+0000",
    "src_ip": "10.16.1.11",
    "dest_ip": "10.16.1.1",
    "src_port": 49697,
    "dest_port": 53
  }
}
{
  "timestamp": "2016-05-24T23:27:04.654238+0000",
  "flow_id": 275050925761971,
  "pcap_cnt": 8,
  "event_type": "alert",
  "src_ip": "10.16.1.1",
  "src_port": 53,
  "dest_ip": "10.16.1.11",
  "dest_port": 57634,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "tx_id": 1,
  "alert": {
    "action": "allowed",
    "gid": 1,
    "signature_id": 2,
    "rev": 1,
    "signature": "",
    "category": "",
    "severity": 3
  },
  "dns": {
    "answer": {
      "version": 2,
      "type": "answer",
      "id": 14681,
      "flags": "8180",
      "qr": true,
      "rd": true,
      "ra": true,
      "opcode": 0,
      "rrname": "client-cf.dropbox.com",
      "rrtype": "A",
      "rcode": "NOERROR"
    }
  },
  "app_proto": "dns",
  "direction": "to_client",
  "flow": {
    "pkts_toserver": 1,
    "pkts_toclient": 1,
    "bytes_toserver": 81,
    "bytes_toclient": 97,
    "start": "2016-05-24T23:27:04.653864+0000",
    "src_ip": "10.16.1.11",
    "dest_ip": "10.16.1.1",
    "src_port": 57634,
    "dest_port": 53
  }
}
{
  "timestamp": "2016-05-24T23:27:02.333141+0000",
  "flow_id": 1593247356761763,
  "pcap_cnt": 2,
  "event_type": "dns",
  "src_ip": "10.16.1.11",
  "src_port": 53679,
  "dest_ip": "10.16.1.1",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "dns": {
    "version": 2,
    "type": "answer",
    "id": 39339,
    "flags": "8180",
    "qr": true,
    "rd": true,
    "ra": true,
    "opcode": 0,
    "rrname": "client-cf.dropbox.com",
    "rrtype": "A",
    "rcode": "NOERROR",
    "answers": [
      {
        "rrname": "client-cf.dropbox.com",
        "rrtype": "A",
        "ttl": 47,
        "rdata": "52.85.112.21"
      }
    ],
    "grouped": {
      "A": [
        "52.85.112.21"
      ]
    }
  }
}
{
  "timestamp": "2016-05-24T23:27:03.213624+0000",
  "flow_id": 1887169437757562,
  "pcap_cnt": 5,
  "event_type": "alert",
  "src_ip": "10.16.1.1",
  "src_port": 53,
  "dest_ip": "10.16.1.11",
  "dest_port": 49697,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "tx_id": 1,
  "alert": {
    "action": "allowed",
    "gid": 1,
    "signature_id": 3,
    "rev": 1,
    "signature": "",
    "category": "",
    "severity": 3
  },
  "dns": {
    "answer": {
      "version": 2,
      "type": "answer",
      "id": 3407,
      "flags": "8180",
      "qr": true,
      "rd": true,
      "ra": true,
      "opcode": 0,
      "rrname": "block.dropbox.com",
      "rrtype": "A",
      "rcode": "NOERROR"
    }
  },
  "app_proto": "dns",
  "direction": "to_client",
  "flow": {
    "pkts_toserver": 1,
    "pkts_toclient": 1,
    "bytes_toserver": 77,
    "bytes_toclient": 116,
    "start": "2016-05-24T23:27:02.832606+0000",
    "src_ip": "10.16.1.11",
    "dest_ip": "10.16.1.1",
    "src_port": 49697,
    "dest_port": 53
  }
}
{
  "timestamp": "2016-05-24T23:27:04.654238+0000",
  "flow_id": 275050925761971,
  "pcap_cnt": 8,
  "event_type": "dns",
  "src_ip": "10.16.1.11",
  "src_port": 57634,
  "dest_ip": "10.16.1.1",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "dns": {
    "version": 2,
    "type": "answer",
    "id": 14681,
    "flags": "8180",
    "qr": true,
    "rd": true,
    "ra": true,
    "opcode": 0,
    "rrname": "client-cf.dropbox.com",
    "rrtype": "A",
    "rcode": "NOERROR",
    "answers": [
      {
        "rrname": "client-cf.dropbox.com",
        "rrtype": "A",
        "ttl": 45,
        "rdata": "52.85.112.21"
      }
    ],
    "grouped": {
      "A": [
        "52.85.112.21"
      ]
    }
  }
}
{
  "timestamp": "2016-05-24T23:27:03.213624+0000",
  "flow_id": 1887169437757562,
  "pcap_cnt": 5,
  "event_type": "dns",
  "src_ip": "10.16.1.11",
  "src_port": 49697,
  "dest_ip": "10.16.1.1",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "dns": {
    "version": 2,
    "type": "answer",
    "id": 3407,
    "flags": "8180",
    "qr": true,
    "rd": true,
    "ra": true,
    "opcode": 0,
    "rrname": "block.dropbox.com",
    "rrtype": "A",
    "rcode": "NOERROR",
    "answers": [
      {
        "rrname": "block.dropbox.com",
        "rrtype": "CNAME",
        "ttl": 9,
        "rdata": "block.g1.dropbox.com"
      },
      {
        "rrname": "block.g1.dropbox.com",
        "rrtype": "A",
        "ttl": 8,
        "rdata": "45.58.70.33"
      }
    ],
    "grouped": {
      "CNAME": [
        "block.g1.dropbox.com"
      ],
      "A": [
        "45.58.70.33"
      ]
    }
  }
}
{
  "timestamp": "2016-05-24T23:27:03.085375+0000",
  "flow_id": 2055536298231463,
  "pcap_cnt": 4,
  "event_type": "alert",
  "src_ip": "10.16.1.11",
  "src_port": 33458,
  "dest_ip": "10.16.1.1",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "tx_id": 0,
  "alert": {
    "action": "allowed",
    "gid": 1,
    "signature_id": 1,
    "rev": 1,
    "signature": "",
    "category": "",
    "severity": 3
  },
  "dns": {
    "query": [
      {
        "type": "query",
        "id": 44779,
        "rrname": "codemonkey.net",
        "rrtype": "A",
        "tx_id": 0,
        "opcode": 0
      }
    ]
  },
  "app_proto": "dns",
  "direction": "to_server",
  "flow": {
    "pkts_toserver": 1,
    "pkts_toclient": 0,
    "bytes_toserver": 85,
    "bytes_toclient": 0,
    "start": "2016-05-24T23:27:03.085375+0000",
    "src_ip": "10.16.1.11",
    "dest_ip": "10.16.1.1",
    "src_port": 33458,
    "dest_port": 53
  }
}
{
  "timestamp": "2016-05-24T23:27:03.085375+0000",
  "flow_id": 2055536298231463,
  "pcap_cnt": 4,
  "event_type": "dns",
  "src_ip": "10.16.1.11",
  "src_port": 33458,
  "dest_ip": "10.16.1.1",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "dns": {
    "type": "query",
    "id": 44779,
    "rrname": "codemonkey.net",
    "rrtype": "A",
    "tx_id": 0,
    "opcode": 0
  }
}
{
  "timestamp": "2016-05-24T23:27:03.493333+0000",
  "flow_id": 2055536298231463,
  "pcap_cnt": 6,
  "event_type": "alert",
  "src_ip": "10.16.1.1",
  "src_port": 53,
  "dest_ip": "10.16.1.11",
  "dest_port": 33458,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "tx_id": 1,
  "alert": {
    "action": "allowed",
    "gid": 1,
    "signature_id": 2,
    "rev": 1,
    "signature": "",
    "category": "",
    "severity": 3
  },
  "dns": {
    "answer": {
      "version": 2,
      "type": "answer",
      "id": 44779,
      "flags": "8180",
      "qr": true,
      "rd": true,
      "ra": true,
      "opcode": 0,
      "rrname": "codemonkey.net",
      "rrtype": "A",
      "rcode": "NOERROR"
    }
  },
  "app_proto": "dns",
  "direction": "to_client",
  "flow": {
    "pkts_toserver": 1,
    "pkts_toclient": 1,
    "bytes_toserver": 85,
    "bytes_toclient": 90,
    "start": "2016-05-24T23:27:03.085375+0000",
    "src_ip": "10.16.1.11",
    "dest_ip": "10.16.1.1",
    "src_port": 33458,
    "dest_port": 53
  }
}
{
  "timestamp": "2016-05-24T23:27:03.493333+0000",
  "flow_id": 2055536298231463,
  "pcap_cnt": 6,
  "event_type": "dns",
  "src_ip": "10.16.1.11",
  "src_port": 33458,
  "dest_ip": "10.16.1.1",
  "dest_port": 53,
  "proto": "UDP",
  "pkt_src": "wire/pcap",
  "dns": {
    "version": 2,
    "type": "answer",
    "id": 44779,
    "flags": "8180",
    "qr": true,
    "rd": true,
    "ra": true,
    "opcode": 0,
    "rrname": "codemonkey.net",
    "rrtype": "A",
    "rcode": "NOERROR",
    "answers": [
      {
        "rrname": "codemonkey.net",
        "rrtype": "A",
        "ttl": 435,
        "rdata": "104.131.202.103"
      }
    ],
    "grouped": {
      "A": [
        "104.131.202.103"
      ]
    }
  }
}
```