### PR TITLE
ssh: do not enforce pcap_cnt

### DIFF
--- a/tests/bug-4903/bug-4903-04/test.yaml
+++ b/tests/bug-4903/bug-4903-04/test.yaml
@@ -89,7 +89,6 @@ checks:
       flow.bytes_toserver: 336
       flow.pkts_toclient: 3
       flow.pkts_toserver: 4
-      pcap_cnt: 7
       proto: TCP
       src_ip: 192.168.100.1
       src_port: 10003
@@ -115,7 +114,6 @@ checks:
       flow.bytes_toserver: 336
       flow.pkts_toclient: 3
       flow.pkts_toserver: 4
-      pcap_cnt: 7
       proto: TCP
       src_ip: 192.168.100.1
       src_port: 10003


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6775

Prerequisite for https://github.com/OISF/suricata/pull/10322 and next

#1640 with ticket number and only first prerequisite part