### PR TITLE
filestore: directionality fix backported to 7

### DIFF
--- a/tests/bug-6617/test.yaml
+++ b/tests/bug-6617/test.yaml
@@ -1,7 +1,7 @@
 pcap: ../filestore-v2.1-forced/suricata-update-pdf.pcap
 
 requires:
-  min-version: 8
+  min-version: 7
 
 args:
 - -k none


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6622

#1560 backport