### PR TITLE
tests: check exception policy stats counters - v5

### DIFF
--- a/tests/exception-policy-applayer-02/README.md
+++ b/tests/exception-policy-applayer-02/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Showcase exception policy stats counters for application layer protocol errors,
+including also indicating how it is possible to configure: exception policy
+stats to:
+- log counters even when they're zero
+- log counters per app-proto, instead of only a summary
+
+## Pcap
+
+Re-using pcap from exiting exception-policy-applayer-01 test.
+
+## Ticket
+
+https://redmine.openinfosecfoundation.org/issues/5816

--- a/tests/exception-policy-applayer-02/suricata.yaml
+++ b/tests/exception-policy-applayer-02/suricata.yaml
@@ -1,10 +1,6 @@
 %YAML 1.1
 ---
 
-stats:
-  enabled: yes
-  interval: 8
-
 outputs:
   - eve-log:
       enabled: yes
@@ -36,3 +32,9 @@ action-order:
   - drop
   - reject
   - alert
+
+stats:
+  enabled: yes
+  interval: 8
+  eps-zero-valued-counters: true
+  eps-per-app-proto-errors: true

--- a/tests/exception-policy-applayer-02/test.rules
+++ b/tests/exception-policy-applayer-02/test.rules
@@ -1,0 +1,5 @@
+#pass tls any any -> any any (tls.sni; content:"example.com"; startswith; nocase; endswith; msg:"matching TLS allowlisted"; flow:to_server,established; sid:1;)
+#drop tls any any -> any any (msg:"not matching any TLS allowlisted Domain"; flow:to_server,established; sid:2; rev:1;)
+
+# matches packet 4, but should not alert due to memcap drop
+alert tcp any any -> any any (seq:3964863680; ack:2403674603; dsize:214; sid:3;)

--- a/tests/exception-policy-applayer-02/test.yaml
+++ b/tests/exception-policy-applayer-02/test.yaml
@@ -1,16 +1,13 @@
 requires:
   features:
     - DEBUG
-  files:
-    - src/util-exception-policy.c
 pcap: ../tls/tls-certs-alert/input.pcap
 args:
 - --simulate-ips
 - -k none
-# pretend tcp memcap was hit in packet 4, the client hello containing the sni
-- --simulate-packet-tcp-reassembly-memcap=4
-- --set stream.reassembly.memcap-policy=pass-packet
-- --set app-layer.error-policy=ignore
+# pretend pretend error in the first data
+- --simulate-applayer-error-at-offset-ts=0
+- --set app-layer.error-policy=pass-packet
 checks:
   - filter:
       count: 0
@@ -24,11 +21,6 @@ checks:
       count: 0
       match:
         event_type: drop
-        drop.reason: "stream memcap"
-  - filter:
-      count: 0
-      match:
-        event_type: drop
         drop.reason: "flow drop"
   - filter:
       count: 0
@@ -36,7 +28,7 @@ checks:
         event_type: tls
         tls.sni: example.com
   - filter:
-      count: 1
+      count: 0
       match:
         event_type: tls
   - filter:
@@ -54,4 +46,5 @@ checks:
       count: 1
       match:
         event_type: stats
-        stats.tcp.reassembly_exception_policy.pass_packet: 1
+        stats.app_layer.error.tls.exception_policy.pass_packet: 1
+        stats.app_layer.error.tls.exception_policy.drop_packet: 0

--- a/tests/exception-policy-default-01/suricata.yaml
+++ b/tests/exception-policy-default-01/suricata.yaml
@@ -12,11 +12,16 @@ outputs:
         - drop:
             alerts: yes      # log alerts that caused drops
             flows: all       # start or all: 'start' logs only a single drop
-                             # per flow direction. All logs each dropped pkt.
+        - stats
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes
+
 action-order:
   - pass
   - drop
   - reject
   - alert
 
-    #exception-policy: ignore
+exception-policy: ignore

--- a/tests/exception-policy-default-01/test.yaml
+++ b/tests/exception-policy-default-01/test.yaml
@@ -1,9 +1,9 @@
 requires:
   features:
     - DEBUG
-  files:
-    - src/util-exception-policy.c
+
 pcap: ../tls/tls-certs-alert/input.pcap
+
 args:
 - --simulate-ips
 - -k none

--- a/tests/exception-policy-defrag-01/test.yaml
+++ b/tests/exception-policy-defrag-01/test.yaml
@@ -1,8 +1,6 @@
 requires:
   features:
     - DEBUG
-  files:
-    - src/util-exception-policy.c
 args:
 - --simulate-ips
 - -k none
@@ -40,3 +38,10 @@ checks:
       match:
         event_type: stats
         stats.ips.drop_reason.defrag_memcap: 1
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.defrag.memcap_exception_policy.drop_packet: 1
+

--- a/tests/exception-policy-midstream-01/suricata.yaml
+++ b/tests/exception-policy-midstream-01/suricata.yaml
@@ -1,6 +1,10 @@
 %YAML 1.1
 ---
 
+stats:
+  enabled: yes
+  eps-zero-valued-counters: true
+
 outputs:
   - eve-log:
       enabled: yes
@@ -26,3 +30,10 @@ outputs:
         - drop:
             alerts: yes
             flows: all
+        - stats
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes
+
+exception-policy: ignore

--- a/tests/exception-policy-midstream-01/test.yaml
+++ b/tests/exception-policy-midstream-01/test.yaml
@@ -18,3 +18,9 @@ checks:
       count: 0
       match:
         event_type: http
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.midstream_exception_policy.pass_flow: 9

--- a/tests/exception-policy-midstream-02/test.yaml
+++ b/tests/exception-policy-midstream-02/test.yaml
@@ -30,3 +30,9 @@ checks:
       match:
         event_type: stats
         stats.ips.drop_reason.stream_midstream: 1
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.midstream_exception_policy.drop_flow: 1

--- a/tests/exception-policy-midstream-03/suricata.yaml
+++ b/tests/exception-policy-midstream-03/suricata.yaml
@@ -15,6 +15,11 @@ outputs:
             http: yes
         - flow
         - http
+        - stats
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes
 
 logging:
   default-log-level: notice

--- a/tests/exception-policy-midstream-04/suricata.yaml
+++ b/tests/exception-policy-midstream-04/suricata.yaml
@@ -8,3 +8,9 @@ outputs:
         - alert
         - flow
         - http
+        - stats
+
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes

--- a/tests/exception-policy-midstream-04/test.yaml
+++ b/tests/exception-policy-midstream-04/test.yaml
@@ -19,3 +19,9 @@ checks:
     count: 0
     match:
       event_type: http
+- filter:
+    min-version: 8
+    count: 1
+    match:
+      event_type: stats
+      stats.tcp.midstream_exception_policy.pass_flow: 2

--- a/tests/exception-policy-midstream-05/suricata.yaml
+++ b/tests/exception-policy-midstream-05/suricata.yaml
@@ -22,7 +22,12 @@ outputs:
               deployment: reverse
               header: X-Forwarded-For
         - flow
+        - stats
         - http
         - drop:
             alerts: yes
             flows: all
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes

--- a/tests/exception-policy-midstream-05/test.yaml
+++ b/tests/exception-policy-midstream-05/test.yaml
@@ -18,3 +18,9 @@ checks:
       count: 0
       match:
         event_type: http
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.midstream_exception_policy.bypass: 1

--- a/tests/exception-policy-midstream-06/suricata.yaml
+++ b/tests/exception-policy-midstream-06/suricata.yaml
@@ -8,6 +8,11 @@ outputs:
         - alert:
         - flow
         - http
+        - stats
         - drop:
             alerts: yes
             flows: all
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes

--- a/tests/exception-policy-midstream-06/test.yaml
+++ b/tests/exception-policy-midstream-06/test.yaml
@@ -16,4 +16,9 @@ checks:
       match:
         event_type: flow
         flow.action: drop
-
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.midstream_exception_policy.drop_flow: 1

--- a/tests/exception-policy-simulated-flow-memcap/test.yaml
+++ b/tests/exception-policy-simulated-flow-memcap/test.yaml
@@ -32,3 +32,9 @@ checks:
       match:
         event_type: stats
         stats.ips.drop_reason.flow_memcap: 1
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.flow.memcap_exception_policy.drop_packet: 1

--- a/tests/exception-policy-stream-reassembly-memcap-01/suricata.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-01/suricata.yaml
@@ -26,7 +26,12 @@ outputs:
         - stats:
             totals: yes       # stats for all threads merged together
             threads: no       # per thread stats
-            deltas: no        # include delta values
+            deltas: no
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes
+
 action-order:
   - pass
   - drop

--- a/tests/exception-policy-stream-reassembly-memcap-06/suricata.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-06/suricata.yaml
@@ -14,3 +14,9 @@ outputs:
             flows: all       # start or all: 'start' logs only a single drop
                              # per flow direction. All logs each dropped pkt.
         - flow
+        - stats
+
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes

--- a/tests/exception-policy-stream-ssn-memcap-01/test.yaml
+++ b/tests/exception-policy-stream-ssn-memcap-01/test.yaml
@@ -53,3 +53,9 @@ checks:
       match:
         event_type: stats
         stats.ips.drop_reason.stream_memcap: 1
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.ssn_memcap_exception_policy.drop_flow: 1


### PR DESCRIPTION
Edit the existing exception policy tests to check for the new exception policy stats counters.

Add one more test, to showcase behavior for exception policy stats counters when set up to log zero-valued counters and counters for each app-proto error.

Previous PR: https://github.com/OISF/suricata-verify/pull/1671

Changes from last PR:
- rebased
- do not set up deltas or threads for stats, as the JSON schema doesn't accept that yet

Ticket

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/5816