### PR TITLE
test-dump-counters: Test dump-counters via unix-command socket

### DIFF
--- a/tests/test-dump-counters/test.sh
+++ b/tests/test-dump-counters/test.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# This test runs Suricata as background process listening on the lo
+# interface with a BPF filter that makes it unlikely that we'll be
+# capturing anything. Rule loading is disabled, too.
+set -ux
+
+export PYTHONPATH=${SRCDIR}/python:${PYTHONPATH:-}
+
+POLL=0.1
+TIMEOUT=10
+SURICATASC=${SRCDIR}/python/bin/suricatasc
+BPF_FILTER='src host 8.8.8.8 and dst host 100.64.0.1'
+UNIX_COMMAND_FILENAME=${OUTPUT_DIR}/suricata.sock
+
+function run_suricatasc {
+    python3 "${SURICATASC}" -c "$@" "${UNIX_COMMAND_FILENAME}"
+}
+
+if ! run_suricatasc version -h > /dev/null; then
+    echo "suricatasc not functional" >&2
+    exit 1
+fi
+
+timeout -k 1 $TIMEOUT "${SRCDIR}/src/suricata" -v \
+    -c "${SRCDIR}/suricata.yaml" \
+    -l "${OUTPUT_DIR}" \
+    --af-packet=lo \
+    --runmode=workers \
+    --set af-packet.1.block-size=262144 \
+    --set af-packet.1.tpacket-v3=yes \
+    --set capture.disable-offloading=false \
+    --set capture.checksum-validation=none \
+    --set pcap.1.threads=2 \
+    --set flow.managers=3 \
+    --set flow.recyclers=5 \
+    --set stats.interval=1 \
+    --set rule-files.0=/dev/null \
+    --set unix-command.filename="${UNIX_COMMAND_FILENAME}" \
+    "${BPF_FILTER}" &
+
+SURICATA_PID=$!
+
+# Cleanup
+trap '{ echo trap; kill ${SURICATA_PID} ; exit 1; }' SIGINT SIGTERM ERR
+
+# suricatasc exits with 1 until stats are synchronized
+while ! run_suricatasc dump-counters; do
+    sleep $POLL
+done
+
+run_suricatasc dump-counters > "${OUTPUT_DIR}/dump-counters.json"
+
+run_suricatasc shutdown
+
+trap '' SIGINT SIGTERM ERR
+
+wait $SURICATA_PID

--- a/tests/test-dump-counters/test.yaml
+++ b/tests/test-dump-counters/test.yaml
@@ -1,0 +1,66 @@
+requires:
+    min-version: 7
+    script:
+      # Require root permissions, /proc and the lo loopback interface
+      - 'test `id -u` -eq 0'
+      - 'grep " *lo: *" /proc/net/dev >/dev/null'
+    pcap:
+
+command: ./test.sh
+
+checks:
+- filter:
+    filename: "dump-counters.json"
+    count: 1
+    match:
+      has-key: message.threads.Global.tcp.memuse
+- filter:
+    filename: "dump-counters.json"
+    count: 1
+    match:
+      has-key: message.threads.W#01-lo.capture.kernel_packets
+- filter:
+    filename: "dump-counters.json"
+    count: 1
+    match:
+      has-key: message.threads.W#02-lo.capture.kernel_packets
+- filter:
+    filename: "dump-counters.json"
+    count: 1
+    match:
+      has-key: message.threads.FM#01.flow.mgr.full_hash_pass
+- filter:
+    filename: "dump-counters.json"
+    count: 1
+    match:
+      has-key: message.threads.FM#02.flow.mgr.full_hash_pass
+- filter:
+    filename: "dump-counters.json"
+    count: 1
+    match:
+      has-key: message.threads.FM#03.flow.mgr.full_hash_pass
+- filter:
+    filename: "dump-counters.json"
+    count: 1
+    match:
+      has-key: message.threads.FR#01.flow.recycler.recycled
+- filter:
+    filename: "dump-counters.json"
+    count: 1
+    match:
+      has-key: message.threads.FR#02.flow.recycler.recycled
+- filter:
+    filename: "dump-counters.json"
+    count: 1
+    match:
+      has-key: message.threads.FR#03.flow.recycler.recycled
+- filter:
+    filename: "dump-counters.json"
+    count: 1
+    match:
+      has-key: message.threads.FR#04.flow.recycler.recycled
+- filter:
+    filename: "dump-counters.json"
+    count: 1
+    match:
+      has-key: message.threads.FR#05.flow.recycler.recycled


### PR DESCRIPTION
Replaces https://github.com/OISF/suricata-verify/pull/1683

Changes since v4:
* Switch to af-packet source because using pcap blocks Suricata termination on Debian 10 and Ubuntu 20.04.

Changes since v3:
* Don't use `ps`, not available in CI everywhere.
* Invoke suricatasc with python3.

Changes since v2:

* Rewrote as shell script invoking suricatasc instead of using the suricatasc Python module
* Set rule-files.0=/dev/null to prevent loading of rules
* Set a BPF filter to make capture on `lo` unlikely

Test for https://github.com/OISF/suricata/pull/10468

## Ticket

Ticket: 6732

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6732