### PR TITLE
tests: update drop and ssh tests for 6 - v2

### DIFF
--- a/tests/drop-protocol-change/test.yaml
+++ b/tests/drop-protocol-change/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7
 
 args:
   - -k none --set stream.midstream=true

--- a/tests/drop-protocol-change/test.yaml
+++ b/tests/drop-protocol-change/test.yaml
@@ -1,16 +1,27 @@
 requires:
-  min-version: 7
+  min-version: 6
 
 args:
   - -k none --set stream.midstream=true
 
 checks:
   - filter:
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: flow
         app_proto: http2
         app_proto_orig: http
+        flow.action: drop
+  - filter:
+      requires:
+        min-version: 6
+        lt-version: 7
+      count: 1
+      match:
+        event_type: flow
+        app_proto: http
         flow.action: drop
   - filter:
       count: 1

--- a/tests/ssh-newkeys/test.yaml
+++ b/tests/ssh-newkeys/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 7
+  min-version: 6
 
 args:
  - -k none

--- a/tests/ssh-newkeys/test.yaml
+++ b/tests/ssh-newkeys/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7
 
 args:
  - -k none


### PR DESCRIPTION
Update https://github.com/OISF/suricata-verify/pull/1712 for 6.

Previous PR: https://github.com/OISF/suricata-verify/pull/1713
Changes:
- The check for 6 is for 6 only, so add lt-version: 7
