### PR TITLE
test/memcap: Validate memcap pressure values

### DIFF
--- a/tests/memcap-pressure/README.md
+++ b/tests/memcap-pressure/README.md
@@ -1,0 +1,8 @@
+# Test
+
+Validate that `memcap.pressure` and `memcap.pressure_max` exist.
+
+# Pcap
+
+Pcap is the result of a curl to www.testmyids.com, later extracted with
+Wireshark to keep the ``http`` packets only.

--- a/tests/memcap-pressure/test.rules
+++ b/tests/memcap-pressure/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (msg:"HTTP traffic"; sid:001; rev:1;)

--- a/tests/memcap-pressure/test.yaml
+++ b/tests/memcap-pressure/test.yaml
@@ -1,0 +1,16 @@
+requires:
+  min-version: 8
+pcap: ../alert-testmyids-midstream5/input.pcap
+
+args:
+- --set stream.midstream=true
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        has-key: stats.memcap.pressure_max
+        has-key: stats.memcap.pressure
+        not-has-key: stats.memcap_pressure_max
+        not-has-key: stats.memcap_pressure


### PR DESCRIPTION
Issue: 6398

This test validates that the memcap pressure stats are no longer in the global namespace.

[Suricata PR #10711](https://github.com/OISF/suricata/pull/10711)

Old:
- memcap_pressure
- memcap_pressure_max

New:
- memcap.pressure
- memcap.pressure_max


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: [6398](https://redmine.openinfosecfoundation.org/issues/6398)
