### PR TITLE
tests: check exception policy stats counters - v7

### DIFF
--- a/tests/exception-policy-applayer-01/README.md
+++ b/tests/exception-policy-applayer-01/README.md
@@ -1,0 +1,9 @@
+# Test
+
+Showcase exception policy stats counters for application layer protocol errors,
+showing only the summarized counters.
+
+## Ticket
+
+https://redmine.openinfosecfoundation.org/issues/5816
+

--- a/tests/exception-policy-applayer-02/README.md
+++ b/tests/exception-policy-applayer-02/README.md
@@ -1,0 +1,9 @@
+# Test
+
+Showcase exception policy stats counters for application layer protocol errors,
+including also indicating how it is possible to configure: exception policy
+stats to log counters per app-proto, instead of only a summary.
+
+## Ticket
+
+https://redmine.openinfosecfoundation.org/issues/5816

--- a/tests/exception-policy-applayer-02/suricata.yaml
+++ b/tests/exception-policy-applayer-02/suricata.yaml
@@ -1,10 +1,6 @@
 %YAML 1.1
 ---
 
-stats:
-  enabled: yes
-  interval: 8
-
 outputs:
   - eve-log:
       enabled: yes
@@ -36,3 +32,9 @@ action-order:
   - drop
   - reject
   - alert
+
+stats:
+  enabled: yes
+  interval: 8
+  exception-policy:
+    per-app-proto-errors: true

--- a/tests/exception-policy-applayer-02/test.rules
+++ b/tests/exception-policy-applayer-02/test.rules
@@ -1,0 +1,5 @@
+#pass tls any any -> any any (tls.sni; content:"example.com"; startswith; nocase; endswith; msg:"matching TLS allowlisted"; flow:to_server,established; sid:1;)
+#drop tls any any -> any any (msg:"not matching any TLS allowlisted Domain"; flow:to_server,established; sid:2; rev:1;)
+
+# matches packet 4, but should not alert due to memcap drop
+alert tcp any any -> any any (seq:3964863680; ack:2403674603; dsize:214; sid:3;)

--- a/tests/exception-policy-applayer-02/test.yaml
+++ b/tests/exception-policy-applayer-02/test.yaml
@@ -1,31 +1,24 @@
 requires:
   features:
     - DEBUG
-  files:
-    - src/util-exception-policy.c
 pcap: ../tls/tls-certs-alert/input.pcap
 args:
 - --simulate-ips
 - -k none
 # pretend pretend error in the first data
 - --simulate-applayer-error-at-offset-ts=0
-- --set app-layer.error-policy=drop-flow
+- --set app-layer.error-policy=pass-packet
 checks:
   - filter:
       count: 0
       match:
         event_type: alert
   - filter:
-      count: 29
+      count: 0
       match:
         event_type: drop
   - filter:
-      count: 1
-      match:
-        event_type: drop
-        drop.reason: "applayer error"
-  - filter:
-      count: 28
+      count: 0
       match:
         event_type: drop
         drop.reason: "flow drop"
@@ -44,20 +37,14 @@ checks:
         event_type: flow
         app_proto: tls
   - filter:
-      count: 1
+      count: 0
       match:
         event_type: flow
         flow.action: drop
-  - filter:
-      min-version: 7
-      count: 1
-      match:
-        event_type: stats
-        stats.ips.drop_reason.applayer_error: 1
   - filter:
       min-version: 8
       count: 1
       match:
         event_type: stats
-        stats.app_layer.error.exception_policy.drop_flow: 1
-        stats.app_layer.error.exception_policy.pass_flow: 0
+        stats.app_layer.error.tls.exception_policy.pass_packet: 1
+        stats.app_layer.error.tls.exception_policy.drop_packet: 0

--- a/tests/exception-policy-default-01/suricata.yaml
+++ b/tests/exception-policy-default-01/suricata.yaml
@@ -12,11 +12,16 @@ outputs:
         - drop:
             alerts: yes      # log alerts that caused drops
             flows: all       # start or all: 'start' logs only a single drop
-                             # per flow direction. All logs each dropped pkt.
+        - stats
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes
+
 action-order:
   - pass
   - drop
   - reject
   - alert
 
-    #exception-policy: ignore
+exception-policy: ignore

--- a/tests/exception-policy-default-01/test.yaml
+++ b/tests/exception-policy-default-01/test.yaml
@@ -1,9 +1,9 @@
 requires:
   features:
     - DEBUG
-  files:
-    - src/util-exception-policy.c
+
 pcap: ../tls/tls-certs-alert/input.pcap
+
 args:
 - --simulate-ips
 - -k none

--- a/tests/exception-policy-defrag-01/test.yaml
+++ b/tests/exception-policy-defrag-01/test.yaml
@@ -1,8 +1,6 @@
 requires:
   features:
     - DEBUG
-  files:
-    - src/util-exception-policy.c
 args:
 - --simulate-ips
 - -k none
@@ -40,3 +38,11 @@ checks:
       match:
         event_type: stats
         stats.ips.drop_reason.defrag_memcap: 1
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.defrag.memcap_exception_policy.drop_packet: 1
+        stats.defrag.memcap_exception_policy.pass_packet: 0
+

--- a/tests/exception-policy-midstream-01/suricata.yaml
+++ b/tests/exception-policy-midstream-01/suricata.yaml
@@ -1,6 +1,9 @@
 %YAML 1.1
 ---
 
+stats:
+  enabled: yes
+
 outputs:
   - eve-log:
       enabled: yes
@@ -26,3 +29,10 @@ outputs:
         - drop:
             alerts: yes
             flows: all
+        - stats
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes
+
+exception-policy: ignore

--- a/tests/exception-policy-midstream-01/test.yaml
+++ b/tests/exception-policy-midstream-01/test.yaml
@@ -18,3 +18,9 @@ checks:
       count: 0
       match:
         event_type: http
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.midstream_exception_policy.pass_flow: 9

--- a/tests/exception-policy-midstream-02/test.yaml
+++ b/tests/exception-policy-midstream-02/test.yaml
@@ -30,3 +30,9 @@ checks:
       match:
         event_type: stats
         stats.ips.drop_reason.stream_midstream: 1
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.midstream_exception_policy.drop_flow: 1

--- a/tests/exception-policy-midstream-03/suricata.yaml
+++ b/tests/exception-policy-midstream-03/suricata.yaml
@@ -15,6 +15,11 @@ outputs:
             http: yes
         - flow
         - http
+        - stats
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes
 
 logging:
   default-log-level: notice

--- a/tests/exception-policy-midstream-04/suricata.yaml
+++ b/tests/exception-policy-midstream-04/suricata.yaml
@@ -8,3 +8,8 @@ outputs:
         - alert
         - flow
         - http
+        - stats
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes

--- a/tests/exception-policy-midstream-04/test.yaml
+++ b/tests/exception-policy-midstream-04/test.yaml
@@ -19,3 +19,9 @@ checks:
     count: 0
     match:
       event_type: http
+- filter:
+    min-version: 8
+    count: 1
+    match:
+      event_type: stats
+      stats.tcp.midstream_exception_policy.pass_flow: 2

--- a/tests/exception-policy-midstream-05/suricata.yaml
+++ b/tests/exception-policy-midstream-05/suricata.yaml
@@ -22,7 +22,12 @@ outputs:
               deployment: reverse
               header: X-Forwarded-For
         - flow
+        - stats
         - http
         - drop:
             alerts: yes
             flows: all
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes

--- a/tests/exception-policy-midstream-05/test.yaml
+++ b/tests/exception-policy-midstream-05/test.yaml
@@ -18,3 +18,9 @@ checks:
       count: 0
       match:
         event_type: http
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.midstream_exception_policy.bypass: 1

--- a/tests/exception-policy-midstream-06/suricata.yaml
+++ b/tests/exception-policy-midstream-06/suricata.yaml
@@ -8,6 +8,11 @@ outputs:
         - alert:
         - flow
         - http
+        - stats
         - drop:
             alerts: yes
             flows: all
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes

--- a/tests/exception-policy-midstream-06/test.yaml
+++ b/tests/exception-policy-midstream-06/test.yaml
@@ -16,4 +16,9 @@ checks:
       match:
         event_type: flow
         flow.action: drop
-
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.midstream_exception_policy.drop_flow: 1

--- a/tests/exception-policy-simulated-flow-memcap/suricata.yaml
+++ b/tests/exception-policy-simulated-flow-memcap/suricata.yaml
@@ -1,6 +1,9 @@
 %YAML 1.1
 ---
 
+stats:
+  enabled: yes
+
 outputs:
   - eve-log:
       enabled: yes

--- a/tests/exception-policy-simulated-flow-memcap/test.yaml
+++ b/tests/exception-policy-simulated-flow-memcap/test.yaml
@@ -32,3 +32,10 @@ checks:
       match:
         event_type: stats
         stats.ips.drop_reason.flow_memcap: 1
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.flow.memcap_exception_policy.drop_packet: 1
+        stats.flow.memcap_exception_policy.pass_packet: 0

--- a/tests/exception-policy-stream-reassembly-memcap-01/suricata.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-01/suricata.yaml
@@ -26,7 +26,12 @@ outputs:
         - stats:
             totals: yes       # stats for all threads merged together
             threads: no       # per thread stats
-            deltas: no        # include delta values
+            deltas: no
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes
+
 action-order:
   - pass
   - drop

--- a/tests/exception-policy-stream-reassembly-memcap-06/suricata.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-06/suricata.yaml
@@ -14,3 +14,9 @@ outputs:
             flows: all       # start or all: 'start' logs only a single drop
                              # per flow direction. All logs each dropped pkt.
         - flow
+        - stats
+
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes

--- a/tests/exception-policy-stream-reassembly-memcap-06/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-06/test.yaml
@@ -49,3 +49,9 @@ checks:
       match:
         event_type: flow
         flow.action: drop
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.reassembly_exception_policy.pass_packet: 1

--- a/tests/exception-policy-stream-ssn-memcap-01/test.yaml
+++ b/tests/exception-policy-stream-ssn-memcap-01/test.yaml
@@ -53,3 +53,9 @@ checks:
       match:
         event_type: stats
         stats.ips.drop_reason.stream_memcap: 1
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.tcp.ssn_memcap_exception_policy.drop_flow: 1


### PR DESCRIPTION
Edit the existing exception policy tests to check for the new exception policy stats counters.

Ticket #5816

Previous PR: https://github.com/OISF/suricata-verify/pull/1742

Changes from previous PR:
- rebase
- remove work related to hiding zero-valued stats counters

## Ticket

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/5816