### PR TITLE
eve/stats: allow hiding counters whose valued is 0 - v3

### DIFF
--- a/tests/exception-policy-applayer-03/test.yaml
+++ b/tests/exception-policy-applayer-03/test.yaml
@@ -65,3 +65,9 @@ checks:
       proto: UDP
       src_ip: 190.0.0.2
       src_port: 50000
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.app_layer.error.exception_policy.pass_packet: 1
+      stats.app_layer.error.exception_policy.drop_packet: 0

--- a/tests/feature-5976-zero-stats-01/README.md
+++ b/tests/feature-5976-zero-stats-01/README.md
@@ -1,0 +1,12 @@
+# Test
+
+Showcase engine behavior when stats counters that are zero are hidden from the
+eve log stats event.
+
+## PCAP
+
+Reused from `tls-certs-alert` test.
+
+## Ticket
+
+https://redmine.openinfosecfoundation.org/issues/5976

--- a/tests/feature-5976-zero-stats-01/suricata.yaml
+++ b/tests/feature-5976-zero-stats-01/suricata.yaml
@@ -1,0 +1,39 @@
+%YAML 1.1
+---
+
+stats:
+  enabled: yes
+  interval: 8
+
+outputs:
+  - eve-log:
+      enabled: yes
+      types:
+        - alert:
+            tagged-packets: yes
+        - anomaly:
+            enabled: yes
+            types:
+              decode: no
+              stream: yes
+              applayer: yes
+        - tls:
+            extended: yes
+        - drop:
+            alerts: yes
+            flows: all
+        - stats:
+            totals: yes
+            threads: no
+            deltas: no
+            zero-valued-counters: false
+        - flow
+  - stats:
+      enabled: yes
+      filename: stats.log
+
+action-order:
+  - pass
+  - drop
+  - reject
+  - alert

--- a/tests/feature-5976-zero-stats-01/test.rules
+++ b/tests/feature-5976-zero-stats-01/test.rules
@@ -1,0 +1,5 @@
+pass tls any any -> any any (tls.sni; content:"example.com"; startswith; nocase; endswith; msg:"matching TLS allowlisted"; flow:to_server,established; sid:1;)
+drop tls any any -> any any (msg:"not matching any TLS allowlisted Domain"; flow:to_server,established; sid:2; rev:1;)
+
+# matches packet 4, but should not alert due to memcap drop
+alert tcp any any -> any any (seq:3964863680; ack:2403674603; dsize:214; sid:3;)

--- a/tests/feature-5976-zero-stats-01/test.yaml
+++ b/tests/feature-5976-zero-stats-01/test.yaml
@@ -1,0 +1,25 @@
+requires:
+  min-version: 8
+pcap: ../tls/tls-certs-alert/input.pcap
+args:
+- --simulate-ips
+- -k none
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        has-key: stats.decoder.pkts
+        not-has-key: stats.decoder.invalid
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        has-key: stats.ips.accepted
+        not-has-key: stats.ips.rejected
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        has-key: stats.tcp.sessions
+        not-has-key: stats.tcp.active_sessions

--- a/tests/feature-5976-zero-stats-02/README.md
+++ b/tests/feature-5976-zero-stats-02/README.md
@@ -1,0 +1,12 @@
+# Test
+
+Showcase engine behavior when stats counters that are zero are hidden from the
+eve log stats event.
+
+## PCAP
+
+Reused from `bug-3519` test.
+
+## Ticket
+
+https://redmine.openinfosecfoundation.org/issues/5976

--- a/tests/feature-5976-zero-stats-02/suricata.yaml
+++ b/tests/feature-5976-zero-stats-02/suricata.yaml
@@ -1,0 +1,20 @@
+%YAML 1.1
+---
+
+stats:
+  enabled: yes
+  interval: 8
+
+outputs:
+  - eve-log:
+      enabled: yes
+      types:
+        - stats:
+            totals: yes
+            threads: no
+            deltas: no
+            zero-valued-counters: false
+        - flow
+  - stats:
+      enabled: yes
+      filename: stats.log

--- a/tests/feature-5976-zero-stats-02/test.yaml
+++ b/tests/feature-5976-zero-stats-02/test.yaml
@@ -1,0 +1,12 @@
+requires:
+  min-version: 8
+
+pcap: ../bug-3519/input.pcap
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        has-key: stats.decoder.ipv4
+        not-has-key: stats.decoder.ipv6


### PR DESCRIPTION
Task #5976

Add two tests to showcase this. Don't know if we want more tests or more checks, or one with and one without, for comparison purposes.

Previous PR: https://github.com/OISF/suricata-verify/pull/1745

Changes from previous PR:
- rebase
- change the first test created to not require Suri to be in debug mode
- use `has-key` and `not-has-key` to check for the stats
- add another test for the feature
- fix `exception-policy-applayer-03` test, which was missing the actual check for the per-app-proto stats counters

## Ticket

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/5976
