### PR TITLE
tests: move exception policy stats checks to min 7 - v1

### DIFF
--- a/tests/exception-policy-applayer-01/test.yaml
+++ b/tests/exception-policy-applayer-01/test.yaml
@@ -55,7 +55,7 @@ checks:
         event_type: stats
         stats.ips.drop_reason.applayer_error: 1
   - filter:
-      min-version: 8
+      min-version: 7
       count: 1
       match:
         event_type: stats

--- a/tests/exception-policy-applayer-02/test.yaml
+++ b/tests/exception-policy-applayer-02/test.yaml
@@ -42,7 +42,7 @@ checks:
         event_type: flow
         flow.action: drop
   - filter:
-      min-version: 8
+      min-version: 7
       count: 1
       match:
         event_type: stats

--- a/tests/exception-policy-applayer-03/test.yaml
+++ b/tests/exception-policy-applayer-03/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7
   features:
     - DEBUG
 pcap: ../bittorrent-dht/input.pcap

--- a/tests/exception-policy-defrag-01/test.yaml
+++ b/tests/exception-policy-defrag-01/test.yaml
@@ -39,7 +39,7 @@ checks:
         event_type: stats
         stats.ips.drop_reason.defrag_memcap: 1
   - filter:
-      min-version: 8
+      min-version: 7
       count: 1
       match:
         event_type: stats

--- a/tests/exception-policy-midstream-01/test.yaml
+++ b/tests/exception-policy-midstream-01/test.yaml
@@ -19,7 +19,7 @@ checks:
       match:
         event_type: http
   - filter:
-      min-version: 8
+      min-version: 7
       count: 1
       match:
         event_type: stats

--- a/tests/exception-policy-midstream-02/test.yaml
+++ b/tests/exception-policy-midstream-02/test.yaml
@@ -31,7 +31,7 @@ checks:
         event_type: stats
         stats.ips.drop_reason.stream_midstream: 1
   - filter:
-      min-version: 8
+      min-version: 7
       count: 1
       match:
         event_type: stats

--- a/tests/exception-policy-midstream-04/test.yaml
+++ b/tests/exception-policy-midstream-04/test.yaml
@@ -20,7 +20,7 @@ checks:
     match:
       event_type: http
 - filter:
-    min-version: 8
+    min-version: 7
     count: 1
     match:
       event_type: stats

--- a/tests/exception-policy-midstream-05/test.yaml
+++ b/tests/exception-policy-midstream-05/test.yaml
@@ -19,7 +19,7 @@ checks:
       match:
         event_type: http
   - filter:
-      min-version: 8
+      min-version: 7
       count: 1
       match:
         event_type: stats

--- a/tests/exception-policy-midstream-06/test.yaml
+++ b/tests/exception-policy-midstream-06/test.yaml
@@ -17,7 +17,7 @@ checks:
         event_type: flow
         flow.action: drop
   - filter:
-      min-version: 8
+      min-version: 7
       count: 1
       match:
         event_type: stats

--- a/tests/exception-policy-simulated-flow-memcap/test.yaml
+++ b/tests/exception-policy-simulated-flow-memcap/test.yaml
@@ -33,7 +33,7 @@ checks:
         event_type: stats
         stats.ips.drop_reason.flow_memcap: 1
   - filter:
-      min-version: 8
+      min-version: 7
       count: 1
       match:
         event_type: stats

--- a/tests/exception-policy-stream-reassembly-memcap-06/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-06/test.yaml
@@ -50,7 +50,7 @@ checks:
         event_type: flow
         flow.action: drop
   - filter:
-      min-version: 8
+      min-version: 7
       count: 1
       match:
         event_type: stats

--- a/tests/exception-policy-stream-ssn-memcap-01/test.yaml
+++ b/tests/exception-policy-stream-ssn-memcap-01/test.yaml
@@ -54,7 +54,7 @@ checks:
         event_type: stats
         stats.ips.drop_reason.stream_memcap: 1
   - filter:
-      min-version: 8
+      min-version: 7
       count: 1
       match:
         event_type: stats


### PR DESCRIPTION
Related to
Task #6509

Min version updates from 8 to 7, needed for 7.0.x. backport of Exception policy stats

## Ticket

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/6509
