### PR TITLE
tests/pgsql: add checks and test for bug 6092 - v1

### DIFF
--- a/tests/pgsql/pgsql-5000-query-results/test.yaml
+++ b/tests/pgsql/pgsql-5000-query-results/test.yaml
@@ -64,6 +64,7 @@ checks:
       dest_port: 5432
       event_type: pgsql
       pcap_cnt: 29
+      not-has-key: pgsql.request.password
       pgsql.response.message: authentication_ok
       pgsql.response.parameter_status[0].application_name: psql
       pgsql.response.parameter_status[10].time_zone: Etc/UTC

--- a/tests/pgsql/pgsql-bug-6092-log-flags-and-metadata-01/README.md
+++ b/tests/pgsql/pgsql-bug-6092-log-flags-and-metadata-01/README.md
@@ -1,0 +1,12 @@
+# Description
+
+Tests that when PostgreSQL (pgsql) EVE log config is set to not log out password
+messages, it doesn't.
+
+## PCAP
+
+Pcap file reused from pgsql-ssl-rejected-md5-auth-simple-query
+
+## Redmine ticket
+
+https://redmine.openinfosecfoundation.org/issues/6092

--- a/tests/pgsql/pgsql-bug-6092-log-flags-and-metadata-01/suricata.yaml
+++ b/tests/pgsql/pgsql-bug-6092-log-flags-and-metadata-01/suricata.yaml
@@ -8,11 +8,11 @@ outputs:
       filename: eve.json
       types:
         - pgsql:
-            passwords: false
+            enabled: yes
+            #passwords: no   # enable output of passwords Default is false
+        - flow
 
 app-layer:
   protocols:
     pgsql:
       enabled: yes
-      stream-depth: 0
-

--- a/tests/pgsql/pgsql-bug-6092-log-flags-and-metadata-01/test.yaml
+++ b/tests/pgsql/pgsql-bug-6092-log-flags-and-metadata-01/test.yaml
@@ -1,0 +1,39 @@
+requires:
+# Pgsql was released on version 7.0
+  min-version: 7.0
+
+pcap: ../pgsql-ssl-rejected-md5-auth-simple-query/input.pcap
+
+args:
+- -k none
+
+checks:
+# subtest 1
+- filter:
+    count: 1
+    match:
+      dest_ip: 10.16.1.11
+      dest_port: 5432
+      event_type: pgsql
+      pcap_cnt: 25
+      proto: TCP
+      src_ip: 10.16.1.10
+      src_port: 40816
+      pgsql.tx_id: 2
+      pgsql.request.protocol_version: '3.0'
+      pgsql.request.startup_parameters.optional_parameters[0].database: indexer
+      pgsql.request.startup_parameters.user: indexer
+      pgsql.response.authentication_md5_password: "\\x9fi\x1A\\x8e"
+# subtest 2
+- filter:
+    count: 1
+    match:
+      dest_ip: 10.16.1.11
+      dest_port: 5432
+      event_type: pgsql
+      pcap_cnt: 29
+      pgsql.tx_id: 3
+      not-has-key: pgsql.request.password
+      pgsql.response.message: authentication_ok
+      pgsql.response.process_id: 61
+      pgsql.response.secret_key: 3152142766

--- a/tests/pgsql/pgsql-bug-6092-log-flags-and-metadata-02/README.md
+++ b/tests/pgsql/pgsql-bug-6092-log-flags-and-metadata-02/README.md
@@ -1,0 +1,12 @@
+# Description
+
+Tests that when PostgreSQL (pgsql) EVE log config is set to log password
+messages, it does.
+
+## PCAP
+
+Pcap file reused from pgsql-ssl-rejected-md5-auth-simple-query
+
+## Redmine ticket
+
+https://redmine.openinfosecfoundation.org/issues/6092

--- a/tests/pgsql/pgsql-bug-6092-log-flags-and-metadata-02/suricata.yaml
+++ b/tests/pgsql/pgsql-bug-6092-log-flags-and-metadata-02/suricata.yaml
@@ -8,11 +8,11 @@ outputs:
       filename: eve.json
       types:
         - pgsql:
-            passwords: false
+            enabled: yes
+            passwords: yes
+        - flow
 
 app-layer:
   protocols:
     pgsql:
       enabled: yes
-      stream-depth: 0
-

--- a/tests/pgsql/pgsql-bug-6092-log-flags-and-metadata-02/test.yaml
+++ b/tests/pgsql/pgsql-bug-6092-log-flags-and-metadata-02/test.yaml
@@ -1,0 +1,19 @@
+requires:
+# Pgsql was released on version 7.0
+  min-version: 7.0
+
+pcap: ../pgsql-ssl-rejected-md5-auth-simple-query/input.pcap
+
+args:
+- -k none
+
+checks:
+- filter:
+    count: 1
+    match:
+      dest_ip: 10.16.1.11
+      dest_port: 5432
+      event_type: pgsql
+      pcap_cnt: 29
+      has-key: pgsql.request.password
+      pgsql.response.message: authentication_ok

--- a/tests/pgsql/pgsql-cancel-request/test.yaml
+++ b/tests/pgsql/pgsql-cancel-request/test.yaml
@@ -36,6 +36,7 @@ checks:
       dest_ip: 100.96.199.113
       dest_port: 5432
       event_type: pgsql
+      not-has-key: pgsql.request.password
       pgsql.response.message: authentication_ok
       pgsql.response.parameter_status[0].application_name: psql
       pgsql.response.process_id: 28954

--- a/tests/pgsql/pgsql-pwd-output-disabled/test.yaml
+++ b/tests/pgsql/pgsql-pwd-output-disabled/test.yaml
@@ -44,6 +44,7 @@ checks:
       event_type: pgsql
       pcap_cnt: 12
       pgsql.response.message: authentication_ok
+      not-has-key: pgsql.request.password
       pgsql.response.parameter_status[0].application_name: psql
       pgsql.response.parameter_status[10].time_zone: Europe/London
       pgsql.response.parameter_status[1].client_encoding: UTF8


### PR DESCRIPTION
Ensure that pgsql metadata flags (for now, just setting whether passwords should be logged or not) are properly processed by Suri and logging functions.

Related to
Bug #6092

Updated existing tests where there could be logged a password message, but we disable that in the configuration. Add two tests specifically to test this when passwords enabled or disabled.

The Suri PR doesn't change the output behavior, just ensures that we pass pgsql config flags as metadata, therefore, these tests should pass with master, too.


## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6092
