### PR TITLE
tests: replace config stats option with newer term - v1

### DIFF
--- a/tests/feature-5976-zero-stats-01/suricata.yaml
+++ b/tests/feature-5976-zero-stats-01/suricata.yaml
@@ -26,7 +26,7 @@ outputs:
             totals: yes
             threads: no
             deltas: no
-            zero-valued-counters: false
+            null-values: false
         - flow
   - stats:
       enabled: yes

--- a/tests/feature-5976-zero-stats-02/suricata.yaml
+++ b/tests/feature-5976-zero-stats-02/suricata.yaml
@@ -13,7 +13,7 @@ outputs:
             totals: yes
             threads: no
             deltas: no
-            zero-valued-counters: false
+            null-values: false
         - flow
   - stats:
       enabled: yes


### PR DESCRIPTION
Replace `zero-valued-counters` for eve-log.stats counters options with the same term used for the pre-dated similar option for stats.log output.

Task #6962


## Ticket

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/6962