### PR TITLE
tests: update ips-state-1 test - v3

### DIFF
--- a/tests/ips-state-1/README.md
+++ b/tests/ips-state-1/README.md
@@ -1,13 +1,11 @@
 ## PCAP
 
-This PCAP contains 3 flows.  2 are http and one is TLS. The HTTP flows should
+This PCAP contains 3 flows. 2 are http and one is TLS. The HTTP flows should
 be full passed with no alerts, while the TLS flow should be dropped.
 
 ## Current Observations
 
-- HTTP response packets are being logged as dropped, however the transaction is
-  logged suggesting the drop is only in logging only, but not actually
-  occurring.
-
-- All the TLS packets apear to be getting dropped, but `flow.action` is never
-  set to true.
+- TLS packets appear to be getting dropped, but `flow.action` is never
+set to true.
+- Test seems to indicate that Suricata mostly behaves as expected. BUT, although
+  we see TLS logged as dropped, the actual flow.action is never set to drop...

--- a/tests/ips-state-1/suricata.yaml
+++ b/tests/ips-state-1/suricata.yaml
@@ -1,0 +1,23 @@
+%YAML 1.1
+---
+
+vars:
+  address-groups:
+    HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
+
+    EXTERNAL_NET: "!$HOME_NET"
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert
+        - drop:
+            flows: all
+            alerts: true
+        - http
+        - tls
+        - flow
+        - stats

--- a/tests/ips-state-1/test.yaml
+++ b/tests/ips-state-1/test.yaml
@@ -8,8 +8,6 @@ checks:
 - filter:
     # We should see 2 http transactions as the pass rule should allow http
     # flows.
-    #
-    # This fails.
     count: 2
     match:
       event_type: http
@@ -22,24 +20,50 @@ checks:
       app_proto: http
 
 - filter:
-    # There should be 2 http flow events without alerts.
-    count: 2
-    match:
-      event_type: flow
-      app_proto: http
-      flow.alerted: false 
-
-- filter:
     # We should see NO drops (or alerts) for http
     count: 0
     match:
-      event_type: alert
+      event_type: drop
       app_proto: http
 
 - filter:
+    # There should be alerts for tls
+    count: 37
+    match:
+      event_type: alert
+      app_proto: tls
+
+- filter:
+    # Not all packets are identified as tls
+    count: 40
+    match:
+      event_type: alert
+      alert.signature_id: 2
+
+- filter:
+    # We should see drops for tls packets
+    count: 39
+    match:
+      event_type: drop
+      drop.reason: rules
+      alert.signature_id: 2
+
+- filter:
     # There should be one tls flow that is alerted
+    # this check currently fails
     count: 1
     match:
       event_type: flow
       dest_port: 443
       flow.alerted: true
+      flow.action: drop
+
+- filter:
+    # There should be 2 http flow events without alerts.
+    count: 2
+    match:
+      event_type: flow
+      app_proto: http
+      flow.action: pass
+      flow.alerted: false
+


### PR DESCRIPTION
This test indicated that there were FP drops for http and that another check was failing, but currently the are no more FP for http.

Updated the checks to reflect this.

flow.action still not set to drop with the tls drops...

Previous PR: #1496

Changes from previous PR:
- rebase
- add a few more checks - for drop events, for all existing alerts, for drop reason...
- improve README description - kept the previous comment about the TLS behavior

## Ticket

Redmine ticket:
none, so far. Should I create one, as in, do we think there's a possible bug here?