### PR TITLE
detect/ipopts: Support 7.0.x

### DIFF
--- a/tests/detect-ipopts/test.yaml
+++ b/tests/detect-ipopts/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7.0.5
 
 args:
   - --set stream.midstream=true -k none


### PR DESCRIPTION
This commit resets the min-version to 7.0.5 to support the backport (issue 6882).


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: [6882](https://redmine.openinfosecfoundation.org/issues/6882)
