### PR TITLE
tests/pgsql: add test for bug 6983 - v1

### DIFF
--- a/tests/pgsql/pgsql-bug-6983/README.md
+++ b/tests/pgsql/pgsql-bug-6983/README.md
@@ -1,0 +1,16 @@
+# Description
+
+Tests that alerts for the pgsql app-proto will include pgsql app-proto metadata.
+
+This shows what might be a bug - more investigation is needed: that we may be
+logging not the transaction that triggered the alert itself, but maybe the
+subsequent one - or none, if the alert was triggered with the last seen message
+for PGSQL.
+
+## PCAP
+
+Pcap file reused from pgsql-ssl-rejected-md5-auth-simple-query
+
+## Redmine ticket
+
+https://redmine.openinfosecfoundation.org/issues/6983

--- a/tests/pgsql/pgsql-bug-6983/suricata.yaml
+++ b/tests/pgsql/pgsql-bug-6983/suricata.yaml
@@ -1,0 +1,16 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - pgsql
+        - alert
+
+app-layer:
+  protocols:
+    pgsql:
+      enabled: yes

--- a/tests/pgsql/pgsql-bug-6983/test.rules
+++ b/tests/pgsql/pgsql-bug-6983/test.rules
@@ -1,0 +1,1 @@
+alert pgsql any any -> any any (msg:"PGSQL Test Rule"; pkt_data; content:"|58|"; sid:1; rev:1;)

--- a/tests/pgsql/pgsql-bug-6983/test.yaml
+++ b/tests/pgsql/pgsql-bug-6983/test.yaml
@@ -1,0 +1,24 @@
+requires:
+  min-version: 7.0
+
+pcap: ../pgsql-ssl-rejected-md5-auth-simple-query/input.pcap
+
+args:
+- -k none
+
+checks:
+- filter:
+    count: 7
+    match:
+      event_type: pgsql
+- filter:
+    count: 2
+    match:
+      event_type: alert
+      alert.signature_id: 1
+- filter:
+    min-version: 8
+    count: 2
+    match:
+      event_type: alert
+      has-key: pgsql.request


### PR DESCRIPTION
Related to
Bug #6983

A test that actually tests adding App-layer info to alerts, as requested by @catenacyber (and also by Victor, but I hadn't understood it, back then).

## Ticket

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/6983