### PR TITLE
    run.py: allow a test to require a feature not being enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ requires:
     # Restrict the test to builds with HAVE_LUA.
     - HAVE_LUA
 
+    # Only run a test when a feature is NOT present.
+    - -HAVE_JA4
+
   # Require that one or more files exist in the Suricata source directory
   files:
 	- src/detect-ipaddr.c

--- a/run.py
+++ b/run.py
@@ -342,7 +342,11 @@ def check_requires(requires, suricata_config: SuricataConfig):
                         "only for version {}".format(req_version))
         elif key == "features":
             for feature in requires["features"]:
-                if not suricata_config.has_feature(feature):
+                if feature.startswith("-"):
+                    if suricata_config.has_feature(feature[1:]):
+                        raise UnsatisfiedRequirementError(
+                            "not for feature %s" % (feature[1:]))
+                elif not suricata_config.has_feature(feature):
                     raise UnsatisfiedRequirementError(
                         "requires feature %s" % (feature))
         elif key == "env":
@@ -995,10 +999,10 @@ def run_test(dirpath, args, cwd, suricata_config):
     if args.outdir:
         outdir = os.path.join(os.path.realpath(args.outdir), name, "output")
 
-    test_runner = TestRunner(
-        cwd, dirpath, outdir, suricata_config, args.verbose, args.force,
-        args.quiet)
     try:
+        test_runner = TestRunner(
+            cwd, dirpath, outdir, suricata_config, args.verbose, args.force,
+            args.quiet)
         results = test_runner.run(outdir)
         if results["failure"] > 0:
             with lock:

--- a/tests/ja4-rules-requires-off/test.yaml
+++ b/tests/ja4-rules-requires-off/test.yaml
@@ -1,7 +1,7 @@
 requires:
   min-version: 8.0.0
-  script:
-    - ./src/suricata --build-info | grep "JA4 support" | grep no > /dev/null
+  features:
+    - -HAVE_JA4
 
 args:
   - -k none

--- a/tests/tls/tls-ja3s-requires-off/test.yaml
+++ b/tests/tls/tls-ja3s-requires-off/test.yaml
@@ -4,8 +4,7 @@ requires:
   min-version: 7.0.3
   features:
     - HAVE_LUA
-  script:
-    - ./src/suricata --build-info | grep "JA3 support" | grep no > /dev/null
+    - -HAVE_JA3
 
 args:
  - -k none


### PR DESCRIPTION
Example:
```
requires:
  features:
    - -HAVE_LUA
```
would require that Suricata does not have Lua support.
