### PR TITLE
tests/ja4: Enable ja4 tests in 7.0.6 and later

### DIFF
--- a/tests/ja4-quic/test.yaml
+++ b/tests/ja4-quic/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.0
+  min-version: 7.0.6
   features:
     - HAVE_JA4
 

--- a/tests/ja4-rules-bug-7010/README.md
+++ b/tests/ja4-rules-bug-7010/README.md
@@ -1,0 +1,1 @@
+Confirm that Suricata logs JA4 being enabled due to a rule.

--- a/tests/ja4-rules-bug-7010/test.rules
+++ b/tests/ja4-rules-bug-7010/test.rules
@@ -1,0 +1,1 @@
+alert quic any any -> any any (msg:"JA4 QUIC Test 1"; requires: feature ja4; ja4.hash; content: "q13d0310h3_55b375c5d22e_cd85d2d88918"; sid:1;)

--- a/tests/ja4-rules-bug-7010/test.yaml
+++ b/tests/ja4-rules-bug-7010/test.yaml
@@ -1,0 +1,16 @@
+requires:
+  min-version: 7.0.6
+  lt-version: 8
+  features:
+    - HAVE_JA4
+
+pcap: ../ja4-rules/input.pcap
+
+args:
+  - -k none
+  - --set logging.default-log-level=config
+
+checks:
+  - shell:
+      args: grep -c "enabling JA4 due to rule usage" stdout
+      expect: 1

--- a/tests/ja4-rules-disabled/test.yaml
+++ b/tests/ja4-rules-disabled/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.0
+  min-version: 7.0.6
   files:
     - rust/src/ja4.rs
 

--- a/tests/ja4-rules-invalid/test.yaml
+++ b/tests/ja4-rules-invalid/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.0
+  min-version: 7.0.6
   pcap: false
   features:
     - HAVE_JA4

--- a/tests/ja4-rules-requires-off/test.yaml
+++ b/tests/ja4-rules-requires-off/test.yaml
@@ -1,10 +1,11 @@
 requires:
-  min-version: 8.0.0
+  min-version: 7.0.6
   script:
     - ./src/suricata --build-info | grep "JA4 support" | grep no > /dev/null
 
 args:
   - -k none
+  - --set logging.default-log-level=info
 
 checks:
   - filter:

--- a/tests/ja4-rules-requires/test.yaml
+++ b/tests/ja4-rules-requires/test.yaml
@@ -1,10 +1,12 @@
 requires:
-  min-version: 8.0.0
+  min-version: 7.0.6
   features:
     - HAVE_JA4
 
 args:
-  - -k none --set app-layer.protocols.tls.ja4-fingerprints=no
+  - -k none
+  - --set app-layer.protocols.tls.ja4-fingerprints=no
+  - --set logging.default-log-level=info
 
 checks:
   - filter:

--- a/tests/ja4-rules/test.yaml
+++ b/tests/ja4-rules/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.0
+  min-version: 7.0.6
   features:
     - HAVE_JA4
 

--- a/tests/ja4-tls-quic/test.yaml
+++ b/tests/ja4-tls-quic/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 7.0.0
+  min-version: 7.0.6
   features:
     - HAVE_JA4
 

--- a/tests/ja4-tls/test.yaml
+++ b/tests/ja4-tls/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 7.0.0
+  min-version: 7.0.6
   features:
     - HAVE_JA4
 


### PR DESCRIPTION
Continuation of #1825 

Issue: 7010

Enable the JA4 tests for Suricata 7.0.6 and later.

Updates:
- Moved new tests into separate commit

## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7010
