### PR TITLE
mqtt: add tests for MQTT log limiting - v2

### DIFF
--- a/tests/mqtt-limit-msg-1/README.md
+++ b/tests/mqtt-limit-msg-1/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Test if, for MQTT publish/subscribe messages with long content, the truncation
+via the `mqtt.msg-log-limit` option works as intended for a maximum length
+shorter than the actual length of the message payload. This is done by
+checking if the log entries in the EVE-JSON are of the correct length and also
+contain the truncation tag.
+
+## PCAP
+
+Using the one from the `mqtt-limit-2` test.
+
+## Ticket
+
+https://redmine.openinfosecfoundation.org/issues/6984

--- a/tests/mqtt-limit-msg-1/suricata.yaml
+++ b/tests/mqtt-limit-msg-1/suricata.yaml
@@ -1,0 +1,16 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - mqtt:
+            msg-log-limit: 10
+
+app-layer:
+  protocols:
+    mqtt:
+      enabled: yes

--- a/tests/mqtt-limit-msg-1/test.yaml
+++ b/tests/mqtt-limit-msg-1/test.yaml
@@ -1,0 +1,39 @@
+pcap: ../mqtt-limit-2/input.pcap
+
+requires:
+  files:
+    - rust/src/mqtt/parser.rs
+
+args:
+  - -k none
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: mqtt
+        mqtt.publish.qos: 1
+        mqtt.publish.retain: false
+        mqtt.publish.dup: false
+        mqtt.publish.message: ZZZZZZZZZZ[truncated]
+        mqtt.puback.message_id: 4
+
+  - filter:
+      count: 1
+      match:
+        event_type: mqtt
+        mqtt.publish.qos: 1
+        mqtt.publish.retain: false
+        mqtt.publish.dup: false
+        mqtt.publish.message: XXXXXXXXXX[truncated]
+        mqtt.puback.message_id: 2
+
+  - filter:
+      count: 1
+      match:
+        event_type: mqtt
+        mqtt.publish.qos: 1
+        mqtt.publish.retain: false
+        mqtt.publish.dup: false
+        mqtt.publish.message: YYYYYYYYYY[truncated]
+        mqtt.puback.message_id: 3

--- a/tests/mqtt-limit-msg-2/README.md
+++ b/tests/mqtt-limit-msg-2/README.md
@@ -1,0 +1,14 @@
+# Test
+
+Test if, for MQTT publish/subscribe messages with long content, the truncation
+via the `mqtt.msg-log-limit` option works as intended for a maximum length
+longer than the actual length of the message payload. This is done by
+checking if log entries in the EVE-JSON are unrestricted in length.
+
+## PCAP
+
+Using the one from the `mqtt-limit-2` test.
+
+## Ticket
+
+https://redmine.openinfosecfoundation.org/issues/6984

--- a/tests/mqtt-limit-msg-2/suricata.yaml
+++ b/tests/mqtt-limit-msg-2/suricata.yaml
@@ -1,0 +1,16 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - mqtt:
+            msg-log-limit: 1mb
+
+app-layer:
+  protocols:
+    mqtt:
+      enabled: yes

--- a/tests/mqtt-limit-msg-2/test.yaml
+++ b/tests/mqtt-limit-msg-2/test.yaml
@@ -1,0 +1,19 @@
+pcap: ../mqtt-limit-2/input.pcap
+
+requires:
+  files:
+    - rust/src/mqtt/parser.rs
+
+args:
+  - -k none
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: mqtt
+        mqtt.publish.qos: 1
+        mqtt.publish.retain: false
+        mqtt.publish.dup: false
+        mqtt.publish.message: ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+        mqtt.puback.message_id: 4

--- a/tests/mqtt-limit-msg-fail/README.md
+++ b/tests/mqtt-limit-msg-fail/README.md
@@ -1,0 +1,12 @@
+# Test
+
+Test if Suricata, as expected, errors out at startup when the `mqtt.msg-log-limit`
+option contains an invalid (i.e. not parseable) value.
+
+## PCAP
+
+Using the one from the `mqtt-limit-2` test.
+
+## Ticket
+
+https://redmine.openinfosecfoundation.org/issues/6984

--- a/tests/mqtt-limit-msg-fail/suricata.yaml
+++ b/tests/mqtt-limit-msg-fail/suricata.yaml
@@ -1,0 +1,16 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - mqtt:
+            msg-log-limit: XXX
+
+app-layer:
+  protocols:
+    mqtt:
+      enabled: yes

--- a/tests/mqtt-limit-msg-fail/test.yaml
+++ b/tests/mqtt-limit-msg-fail/test.yaml
@@ -1,0 +1,16 @@
+pcap: ../mqtt-limit-2/input.pcap
+
+requires:
+  files:
+    - rust/src/mqtt/parser.rs
+
+args:
+  - -k none
+
+exit-code: 1
+
+checks:
+  - shell:
+        args: |
+          grep "misc: invalid size argument - XXX. Valid size argument should be in the format" stderr | wc -l 
+        expect: 1


### PR DESCRIPTION
Previous PR: #1828 

Changes compared to previous PR:
* Add `README.md`s for all tests.
* Slim down test checks to be more descriptive for the reader; reduce to the aspects to be checked.
* Reduce duplication of pcap files by referencing across test cases.
* Remove some requirements: obsolete checks such as libjansson but also checks that would cause the test to be skipped because the associated Suricata PR wasn't merged yet (the latter at reviewer's request)

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6984
