### PR TITLE
mqtt: add tests for MQTT log limiting -- v3

### DIFF
--- a/tests/mqtt-limit-log-1/README.md
+++ b/tests/mqtt-limit-log-1/README.md
@@ -1,0 +1,15 @@
+# Test
+
+Test if, for MQTT publish/subscribe messages with long content, the truncation
+via the `mqtt.string-log-limit` option works as intended for a maximum length
+shorter than the actual length of the message payload. This is done by
+checking if the log entries in the EVE-JSON are of the correct length and also
+contain the truncation tag.
+
+## PCAP
+
+Using the one from the `mqtt-limit-2` test.
+
+## Ticket
+
+https://redmine.openinfosecfoundation.org/issues/6984

--- a/tests/mqtt-limit-log-1/suricata.yaml
+++ b/tests/mqtt-limit-log-1/suricata.yaml
@@ -1,0 +1,16 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - mqtt:
+            string-log-limit: 10
+
+app-layer:
+  protocols:
+    mqtt:
+      enabled: yes

--- a/tests/mqtt-limit-log-1/test.yaml
+++ b/tests/mqtt-limit-log-1/test.yaml
@@ -1,0 +1,38 @@
+pcap: ../mqtt-limit-2/input.pcap
+
+requires:
+  min-version: 8
+
+args:
+  - -k none
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: mqtt
+        mqtt.publish.qos: 1
+        mqtt.publish.retain: false
+        mqtt.publish.dup: false
+        mqtt.publish.message: ZZZZZZZZZZ[truncated 90 additional bytes]
+        mqtt.puback.message_id: 4
+
+  - filter:
+      count: 1
+      match:
+        event_type: mqtt
+        mqtt.publish.qos: 1
+        mqtt.publish.retain: false
+        mqtt.publish.dup: false
+        mqtt.publish.message: XXXXXXXXXX[truncated 99990 additional bytes]
+        mqtt.puback.message_id: 2
+
+  - filter:
+      count: 1
+      match:
+        event_type: mqtt
+        mqtt.publish.qos: 1
+        mqtt.publish.retain: false
+        mqtt.publish.dup: false
+        mqtt.publish.message: YYYYYYYYYY[truncated 990 additional bytes]
+        mqtt.puback.message_id: 3

--- a/tests/mqtt-limit-log-2/README.md
+++ b/tests/mqtt-limit-log-2/README.md
@@ -1,0 +1,14 @@
+# Test
+
+Test if, for MQTT publish/subscribe messages with long content, the truncation
+via the `mqtt.string-log-limit` option works as intended for a maximum length
+longer than the actual length of the message payload. This is done by
+checking if log entries in the EVE-JSON are unrestricted in length.
+
+## PCAP
+
+Using the one from the `mqtt-limit-2` test.
+
+## Ticket
+
+https://redmine.openinfosecfoundation.org/issues/6984

--- a/tests/mqtt-limit-log-2/suricata.yaml
+++ b/tests/mqtt-limit-log-2/suricata.yaml
@@ -1,0 +1,16 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - mqtt:
+            string-log-limit: 1mb
+
+app-layer:
+  protocols:
+    mqtt:
+      enabled: yes

--- a/tests/mqtt-limit-log-2/test.yaml
+++ b/tests/mqtt-limit-log-2/test.yaml
@@ -1,0 +1,18 @@
+pcap: ../mqtt-limit-2/input.pcap
+
+requires:
+  min-version: 8
+
+args:
+  - -k none
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: mqtt
+        mqtt.publish.qos: 1
+        mqtt.publish.retain: false
+        mqtt.publish.dup: false
+        mqtt.publish.message: ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+        mqtt.puback.message_id: 4

--- a/tests/mqtt-limit-log-3/README.md
+++ b/tests/mqtt-limit-log-3/README.md
@@ -1,0 +1,27 @@
+# Test
+
+Test if, for MQTT subscribe messages with multiple topics, the truncation
+via the `mqtt.string-log-limit` option works as intended when the concatenation
+of the topic names exceeds the limit while each individual topic name is within
+the limit. This was an additional requirement to address circumventing the limit
+to cause excessive logging by simply creating more topics instead of crafting
+longer topic names.
+
+For example, for the topics:
+
+ * `topicX`
+ * `topicY`
+ * `topicZ`
+
+ and a max length of 10, we will get the following result:
+
+ * `topicX`
+ * `topi[truncated 2 additional bytes]`
+
+## PCAP
+
+Using the one from the `mqtt5-sub-userpass` test.
+
+## Ticket
+
+https://redmine.openinfosecfoundation.org/issues/6984

--- a/tests/mqtt-limit-log-3/suricata.yaml
+++ b/tests/mqtt-limit-log-3/suricata.yaml
@@ -1,0 +1,16 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - mqtt:
+            string-log-limit: 10
+
+app-layer:
+  protocols:
+    mqtt:
+      enabled: yes

--- a/tests/mqtt-limit-log-3/test.yaml
+++ b/tests/mqtt-limit-log-3/test.yaml
@@ -1,0 +1,19 @@
+pcap: ../mqtt5-sub-userpass/input.pcap
+
+requires:
+  min-version: 8
+
+args:
+  - -k none
+
+checks:
+
+  - filter:
+      count: 1
+      match:
+        event_type: mqtt
+        mqtt.subscribe.qos: 1
+        mqtt.subscribe.retain: false
+        mqtt.subscribe.dup: false
+        mqtt.subscribe.topics: [ {topic: topicX, qos: 0}, {topic: "topi[truncated 2 additional bytes]", qos: 0} ]
+        mqtt.subscribe.message_id: 1

--- a/tests/mqtt-limit-log-fail/README.md
+++ b/tests/mqtt-limit-log-fail/README.md
@@ -1,0 +1,12 @@
+# Test
+
+Test if Suricata, as expected, errors out at startup when the `mqtt.string-log-limit`
+option contains an invalid (i.e. not parseable) value.
+
+## PCAP
+
+Using the one from the `mqtt-limit-2` test.
+
+## Ticket
+
+https://redmine.openinfosecfoundation.org/issues/6984

--- a/tests/mqtt-limit-log-fail/suricata.yaml
+++ b/tests/mqtt-limit-log-fail/suricata.yaml
@@ -1,0 +1,16 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - mqtt:
+            string-log-limit: XXX
+
+app-layer:
+  protocols:
+    mqtt:
+      enabled: yes

--- a/tests/mqtt-limit-log-fail/test.yaml
+++ b/tests/mqtt-limit-log-fail/test.yaml
@@ -1,0 +1,17 @@
+pcap: ../mqtt-limit-2/input.pcap
+
+requires:
+  min-version: 8
+  files:
+    - rust/src/mqtt/parser.rs
+
+args:
+  - -k none
+
+exit-code: 1
+
+checks:
+  - shell:
+        args: |
+          grep "misc: invalid size argument - XXX. Valid size argument should be in the format" stderr | wc -l 
+        expect: 1


### PR DESCRIPTION
Previous PR: #1836 

Changes compared to previous PR:
* Rebase against current master.
* Rename tests to `mqtt-limit-log-*` to reflect the fact we're not only restricting messages anymore.
* Add test for topic array limiting.
* Remove unneeded requirements, add minimum version 8 requirement.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6984
