### PR TITLE
tests/pgsql: add test for bug 6983 - v4

### DIFF
--- a/tests/pgsql/pgsql-bug-6983-ids/README.md
+++ b/tests/pgsql/pgsql-bug-6983-ids/README.md
@@ -1,0 +1,12 @@
+# Description
+
+Tests that alerts for the pgsql app-proto will include pgsql app-proto metadata.
+
+## PCAP
+
+Pcap file reused from pgsql-ssl-rejected-md5-auth-simple-query
+
+## Redmine ticket
+
+https://redmine.openinfosecfoundation.org/issues/6983
+https://redmine.openinfosecfoundation.org/issues/7000

--- a/tests/pgsql/pgsql-bug-6983-ids/suricata.yaml
+++ b/tests/pgsql/pgsql-bug-6983-ids/suricata.yaml
@@ -1,0 +1,18 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - pgsql:
+            enabled: yes
+            passwords: yes
+        - alert
+
+app-layer:
+  protocols:
+    pgsql:
+      enabled: yes

--- a/tests/pgsql/pgsql-bug-6983-ids/test.rules
+++ b/tests/pgsql/pgsql-bug-6983-ids/test.rules
@@ -1,0 +1,1 @@
+alert pgsql any any -> any any (msg:"PGSQL Test Rule"; content:"select * from"; sid:1; rev:1;)

--- a/tests/pgsql/pgsql-bug-6983-ids/test.yaml
+++ b/tests/pgsql/pgsql-bug-6983-ids/test.yaml
@@ -1,0 +1,25 @@
+requires:
+  min-version: 7.0
+
+pcap: ../pgsql-ssl-rejected-md5-auth-simple-query/input.pcap
+
+args:
+- -k none
+
+checks:
+- filter:
+    count: 7
+    match:
+      event_type: pgsql
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      alert.signature_id: 1
+- filter:
+    min-version: 8
+    count: 1
+    match:
+      event_type: alert
+      flow.pkts_toserver: 10
+      flow.pkts_toclient: 10

--- a/tests/pgsql/pgsql-bug-6983-ips/README.md
+++ b/tests/pgsql/pgsql-bug-6983-ips/README.md
@@ -1,0 +1,16 @@
+# Description
+
+Tests that alerts for the pgsql app-proto will include pgsql app-proto metadata,
+in IPS mode.
+
+As this test uses a stream rule, in IPS mode the engine generating two alerts is
+expected.
+
+## PCAP
+
+Pcap file reused from pgsql-ssl-rejected-md5-auth-simple-query
+
+## Redmine ticket
+
+https://redmine.openinfosecfoundation.org/issues/6983
+https://redmine.openinfosecfoundation.org/issues/7000

--- a/tests/pgsql/pgsql-bug-6983-ips/suricata.yaml
+++ b/tests/pgsql/pgsql-bug-6983-ips/suricata.yaml
@@ -1,0 +1,18 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - pgsql:
+            enabled: yes
+            passwords: yes
+        - alert
+
+app-layer:
+  protocols:
+    pgsql:
+      enabled: yes

--- a/tests/pgsql/pgsql-bug-6983-ips/test.rules
+++ b/tests/pgsql/pgsql-bug-6983-ips/test.rules
@@ -1,0 +1,1 @@
+alert pgsql any any -> any any (msg:"PGSQL Test Rule"; content:"select * from"; sid:1; rev:1;)

--- a/tests/pgsql/pgsql-bug-6983-ips/test.yaml
+++ b/tests/pgsql/pgsql-bug-6983-ips/test.yaml
@@ -1,0 +1,19 @@
+requires:
+  min-version: 7.0
+
+pcap: ../pgsql-ssl-rejected-md5-auth-simple-query/input.pcap
+
+args:
+- -k none
+- --simulate-ips
+
+checks:
+- filter:
+    count: 7
+    match:
+      event_type: pgsql
+- filter:
+    count: 2
+    match:
+      event_type: alert
+      alert.signature_id: 1


### PR DESCRIPTION
Related to
Bug #6983

Previous PR: https://github.com/OISF/suricata-verify/pull/1874

Changes from previous PR:
- rebase
- add something that could work as a check for the changes done and wouldn't necessarily rely on tx info being present -- the downside of doing this is that it sort of defeats the purpose of the original tests... 

I'll keep this PR, as it's needed to test the Suricata PR. And then will wait for feedback on the removal of pgsql metadata checks from the tests, here.

## Ticket

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/6983