### PR TITLE
ssh: remove usage of deprecated keyword

### DIFF
--- a/tests/ssh-banner-only/test.rules
+++ b/tests/ssh-banner-only/test.rules
@@ -1,4 +1,3 @@
 alert ssh any any -> any any (ssh.software; content:"OpenSSH"; sid:1;)
-# ssh.softwareversion is deprecated in favor of ssh.software this is just to check if it still works
-alert ssh any any -> any any (ssh.softwareversion:OpenSSH_7.4; sid:2;)
+alert ssh any any -> any any (ssh.software; content:"OpenSSH_7.4"; sid:2;)
 alert ssh any any -> any any (ssh.proto; content:"2"; sid:3;)


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/2377
