### PR TITLE
README/help: add info on IPS mode tests creation - v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Or to run a single test:
 
 - Create a directory that is the name of the new test.
 
+  If you want a test to run in IPS mode, add `ips` to the test name
+  this will make `--simulate-ips` command-line argument be passed when
+  the test is run.
+
 - Copy a single pcap file into the test directory. It must end in
   ".pcap".
 
@@ -200,6 +204,8 @@ directory.
 
 positional arguments:
   <test-name>           Name of the test folder
+                        Add `ips` to the test name if you want it to run in IPS mode
+                        the test is run.
   <pcap-file>           Path to the PCAP file
 
 optional arguments:
@@ -250,6 +256,15 @@ newer:
 ```
 ../suricata-verify/createst.py --min-version 6 --allow-events http,alert,flow \
 --rules ../suricata-verify/tests/no-payload-output/test.rules test-02 input.pcap
+```
+
+#### Example 3
+
+Create a Suricata-verify test named ``ips-drop-rule`` that will run over a pcap file
+called ``input.pcap``, match its traffic against the rules in the ``ips-test.rules``
+file and will have Suricata run the test in IPS mode:
+```
+../suricata-verify/createst.py --rules ../Documents/ips-test.rules ips-drop-rule input.pcap
 ```
 
 #### Add Required Features

--- a/createst.py
+++ b/createst.py
@@ -370,7 +370,7 @@ def parse_args():
         description="Create tests with a given PCAP. Execute the script"
                 " from a valid Suricata source directory.")
     parser.add_argument("test-name", metavar="<test-name>",
-                        help="Name of the test folder")
+                        help="Name of the test folder. Add `ips` to the test name if you want it to run in IPS mode.")
     parser.add_argument("pcap", metavar="<pcap-file>",
                         help="Path to the PCAP file")
     parser.add_argument("--rules", metavar="<rules>",


### PR DESCRIPTION
It is possible to create a test that runs in IPS mode by just adding `ips` to its name. But that is not documented.

Task #7039

## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/7039
