### PR TITLE
datasets: disable memcap test for Suricata 7

### DIFF
--- a/tests/datasets-memcap-01/test.yaml
+++ b/tests/datasets-memcap-01/test.yaml
@@ -1,5 +1,8 @@
 pcap: ../flowbit-oring/input.pcap
 
+# need to be tested with Suricata 7 on latest MacOS
+skip: true
+
 requires:
   lt-version: 8
 


### PR DESCRIPTION
Redmine ticket: https://redmine.openinfosecfoundation.org/issues/3910

