### PR TITLE
datasets-memcap-01: add os and arch requirements

### DIFF
--- a/tests/datasets-memcap-01/test.yaml
+++ b/tests/datasets-memcap-01/test.yaml
@@ -2,6 +2,8 @@ pcap: ../flowbit-oring/input.pcap
 
 requires:
   lt-version: 8
+  os: linux
+  arch: x86_64
 
 args:
  - -k none


### PR DESCRIPTION
## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/3910

Previous PR: https://github.com/OISF/suricata-verify/pull/1960

Changes since v1:
- added os and arch checks instead of skipping the test
