### PR TITLE
README/help: add info on IPS mode tests creation - v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Or to run a single test:
 
 - Create a directory that is the name of the new test.
 
+  If you want a test to run in IPS mode, add `ips` to the test name
+  this will make `--simulate-ips` command-line argument be passed when
+  the test is run.
+
 - Copy a single pcap file into the test directory. It must end in
   ".pcap".
 
@@ -207,7 +211,7 @@ Create tests with a given PCAP. Execute the script from a valid Suricata source
 directory.
 
 positional arguments:
-  <test-name>           Name of the test folder
+  <test-name>           Name of the test folder. Add `ips` to run test in IPS mode.
   <pcap-file>           Path to the PCAP file
 
 options:
@@ -259,6 +263,15 @@ newer:
 ```
 ../suricata-verify/createst.py --min-version 6 --allow-events http,alert,flow \
 --rules ../suricata-verify/tests/no-payload-output/test.rules test-02 input.pcap
+```
+
+#### Example 3
+
+Create a Suricata-verify test named ``ips-drop-rule`` that will run over a pcap file
+called ``input.pcap``, match its traffic against the rules in the ``ips-test.rules``
+file and will have Suricata run the test in IPS mode:
+```
+../suricata-verify/createst.py --rules ../Documents/ips-test.rules ips-drop-rule input.pcap
 ```
 
 #### Add Required Features

--- a/README.md
+++ b/README.md
@@ -197,10 +197,10 @@ This needs to be run from a valid Suricata source directory.
 
 ### Usage
 ```
-usage: createst.py [-h] [--output-path <output-path>] [--eventtype-only]
-                   [--allow-events [ALLOW_EVENTS]] [--rules <rules-file>]
-                   [--strictcsums] [--min-version <min-version>]
-                   [--midstream]
+usage: createst.py [-h] [--rules <rules>] [--output-path <output-path>]
+                   [--eventtype-only] [--allow-events [ALLOW_EVENTS]] [--strictcsums]
+                   [--midstream] [--min-version <min-version>] [--version <add-version>]
+                   [--cfg <path-to-suricata.yaml>] [--features <features>]
                    <test-name> <pcap-file>
 
 Create tests with a given PCAP. Execute the script from a valid Suricata source
@@ -210,13 +210,11 @@ positional arguments:
   <test-name>           Name of the test folder
   <pcap-file>           Path to the PCAP file
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
-  --rules <rules-path>
-                        Path to rules file (optional)
+  --rules <rules>       Path to rule file
   --output-path <output-path>
-                        Path to the folder where generated test.yaml should be
-                        put
+                        Path to the folder where generated test.yaml should be put
   --eventtype-only      Create filter blocks based on event types only
                         This means the subfields of the event in the eve log
                         will not be added to the test.yaml file
@@ -229,9 +227,12 @@ optional arguments:
   --midstream           Allow midstream session pickups
   --min-version <min-version>
                         Adds a global minimum required version
-  --version <version>   Adds a global version requirement
-  --cfg <suricata.yaml> Add a suricata.yaml to the test
-  --features [FEATS]    Required features (comma separated list)
+  --version <add-version>
+                        Adds a global suricata version
+  --cfg <path-to-suricata.yaml>
+                        Adds a suricata.yaml to the test
+  --features <features>
+                        Adds specified features
 ```
 
 ### Examples

--- a/createst.py
+++ b/createst.py
@@ -370,7 +370,7 @@ def parse_args():
         description="Create tests with a given PCAP. Execute the script"
                 " from a valid Suricata source directory.")
     parser.add_argument("test-name", metavar="<test-name>",
-                        help="Name of the test folder")
+                        help="Name of the test folder. Add `ips` to run test in IPS mode.")
     parser.add_argument("pcap", metavar="<pcap-file>",
                         help="Path to the PCAP file")
     parser.add_argument("--rules", metavar="<rules>",


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata-verify/pull/1955

Incorporating Shivani's suggestions:
- Shorten the explanation about adding `ips` to the test name in the help text, so it can fit one line.
- update the `README` text that refers to the help text shown by `createst`.
(As the README is sort of documentation, though, I've kept longer explanations for options that were not so straightforward in their meaning or usage)

## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/7039