### PR TITLE
README/help: add info on IPS mode tests creation - v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Or to run a single test:
 
 - Create a directory that is the name of the new test.
 
+  If you want a test to be run in IPS mode, add `ips` to the test name.
+  This will make the `--simulate-ips` command-line argument be passed when
+  the test is run.
+
 - Copy a single pcap file into the test directory. It must end in
   ".pcap".
 

--- a/README.md
+++ b/README.md
@@ -197,10 +197,10 @@ This needs to be run from a valid Suricata source directory.
 
 ### Usage
 ```
-usage: createst.py [-h] [--output-path <output-path>] [--eventtype-only]
-                   [--allow-events [ALLOW_EVENTS]] [--rules <rules-file>]
-                   [--strictcsums] [--min-version <min-version>]
-                   [--midstream]
+usage: createst.py [-h] [--rules <rules>] [--output-path <output-path>]
+                   [--eventtype-only] [--allow-events [ALLOW_EVENTS]] [--strictcsums]
+                   [--midstream] [--min-version <min-version>] [--version <add-version>]
+                   [--cfg <path-to-suricata.yaml>] [--features <features>]
                    <test-name> <pcap-file>
 
 Create tests with a given PCAP. Execute the script from a valid Suricata source
@@ -210,13 +210,11 @@ positional arguments:
   <test-name>           Name of the test folder
   <pcap-file>           Path to the PCAP file
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
-  --rules <rules-path>
-                        Path to rules file (optional)
+  --rules <rules>       Path to rule file
   --output-path <output-path>
-                        Path to the folder where generated test.yaml should be
-                        put
+                        Path to the folder where generated test.yaml should be put
   --eventtype-only      Create filter blocks based on event types only
                         This means the subfields of the event in the eve log
                         will not be added to the test.yaml file
@@ -229,9 +227,12 @@ optional arguments:
   --midstream           Allow midstream session pickups
   --min-version <min-version>
                         Adds a global minimum required version
-  --version <version>   Adds a global version requirement
-  --cfg <suricata.yaml> Add a suricata.yaml to the test
-  --features [FEATS]    Required features (comma separated list)
+  --version <add-version>
+                        Adds a global suricata version
+  --cfg <path-to-suricata.yaml>
+                        Adds a suricata.yaml to the test
+  --features <features>
+                        Adds specified features
 ```
 
 ### Examples


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata-verify/pull/1965

Describe changes:
- it's not a straightforward process to use the test name alternative with createst, so I've removed that association from the README and createst help text.
- remove mention to unrelated ticket from 540b1a5a6fad675bebc85efdfb3b0a1b1dae141b

## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/7039