### PR TITLE
tests: update ips-state-1 test - v5

### DIFF
--- a/tests/ips-state-1/README.md
+++ b/tests/ips-state-1/README.md
@@ -5,9 +5,7 @@ be full passed with no alerts, while the TLS flow should be dropped.
 
 ## Current Observations
 
-- HTTP response packets are being logged as dropped, however the transaction is
-  logged suggesting the drop is only in logging only, but not actually
-  occurring.
+- HTTP flows are logged as `passed`, as expected.
 
-- All the TLS packets apear to be getting dropped, but `flow.action` is never
-  set to true.
+- All the TLS packets appear to be getting dropped, but `flow.action` is never
+  set to drop.

--- a/tests/ips-state-1/suricata.yaml
+++ b/tests/ips-state-1/suricata.yaml
@@ -1,0 +1,21 @@
+%YAML 1.1
+---
+
+vars:
+  address-groups:
+    HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
+    EXTERNAL_NET: "!$HOME_NET"
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert
+        - drop:
+            flows: all
+            alerts: true
+        - http
+        - tls
+        - flow

--- a/tests/ips-state-1/test.yaml
+++ b/tests/ips-state-1/test.yaml
@@ -8,8 +8,6 @@ checks:
 - filter:
     # We should see 2 http transactions as the pass rule should allow http
     # flows.
-    #
-    # This fails.
     count: 2
     match:
       event_type: http
@@ -28,12 +26,13 @@ checks:
       event_type: flow
       app_proto: http
       flow.alerted: false 
+      flow.action: pass
 
 - filter:
-    # We should see NO drops (or alerts) for http
+    # We should see NO drops for http
     count: 0
     match:
-      event_type: alert
+      event_type: drop
       app_proto: http
 
 - filter:


### PR DESCRIPTION
This test indicated that there were FP drops for HTTP transactions, leading the `http` events check to fail. This is no longer the case.

flow.action is still not set to drop for tls.

Previous PR: https://github.com/OISF/suricata-verify/pull/1794

Changes from previous PR:
- Following Philippe's guidance, I've backtracked and kept this simpler: only updating this test to reflect the fact that all checks in it now pass (no more FP for HTTP). I'll create a subsequent PR to showcase the `flow.action` not being updated for the TLS dropped flow
- added a `suricata.yaml` file to enable logging the `drop` events
- there was a duplicate check for no `alert` for the `http` app-proto. Changed one of those to check for `drop`

## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
