### PR TITLE
ssh: deprecate ssh.softwareversion keyword

### DIFF
--- a/tests/ssh-banner-lt7/test.rules
+++ b/tests/ssh-banner-lt7/test.rules
@@ -1,0 +1,2 @@
+# ssh.softwareversion is deprecated in favor of ssh.software this is just to check if it still works
+alert ssh any any -> any any (ssh.softwareversion:OpenSSH_7.4; sid:2;)

--- a/tests/ssh-banner-lt7/test.yaml
+++ b/tests/ssh-banner-lt7/test.yaml
@@ -1,3 +1,8 @@
+requires:
+  lt-version: 7
+
+pcap: ../ssh-banner-only/input.pcap
+
 args:
  - -k none
 
@@ -12,12 +17,7 @@ checks:
         ssh.client.software_version: "OpenSSH_for_Windows_7.7"
         ssh.server.software_version: "OpenSSH_7.4"
   - filter:
-      count: 2
+      count: 1
       match:
         event_type: alert
-        alert.signature_id: 1
-  - filter:
-      count: 2
-      match:
-        event_type: alert
-        alert.signature_id: 3
+        alert.signature_id: 2

--- a/tests/ssh-banner-only/test.rules
+++ b/tests/ssh-banner-only/test.rules
@@ -1,4 +1,2 @@
 alert ssh any any -> any any (ssh.software; content:"OpenSSH"; sid:1;)
-# ssh.softwareversion is deprecated in favor of ssh.software this is just to check if it still works
-alert ssh any any -> any any (ssh.softwareversion:OpenSSH_7.4; sid:2;)
 alert ssh any any -> any any (ssh.proto; content:"2"; sid:3;)


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/2377

#1928 with deprecation only in 8