### PR TITLE
tests: showcase flow.action lack of update - v1

### DIFF
--- a/tests/flow-action-update-ips/README.md
+++ b/tests/flow-action-update-ips/README.md
@@ -1,0 +1,17 @@
+# Test
+
+This is a "fork" of `ips-state-1`, to showcase the `flow.action` update bug.
+
+## PCAP
+
+From `ips-state-1` test.
+
+This PCAP contains 3 flows.  2 are http and one is TLS. The HTTP flows should
+be full passed with no alerts, while the TLS flow should be dropped.
+
+## Current Observations
+
+- HTTP flows are passed as expected.
+
+- All the TLS packets appear to be getting dropped, but `flow.action` is never
+  set to drop.

--- a/tests/flow-action-update-ips/suricata.yaml
+++ b/tests/flow-action-update-ips/suricata.yaml
@@ -1,0 +1,21 @@
+%YAML 1.1
+---
+
+vars:
+  address-groups:
+    HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
+    EXTERNAL_NET: "!$HOME_NET"
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert
+        - drop:
+            flows: all
+            alerts: true
+        - http
+        - tls
+        - flow

--- a/tests/flow-action-update-ips/test.rules
+++ b/tests/flow-action-update-ips/test.rules
@@ -1,0 +1,2 @@
+pass tcp $HOME_NET any -> $EXTERNAL_NET 80 (sid:1;)
+drop ip any any -> any any (msg:"DROP ALL"; flow:stateless; sid:2;)

--- a/tests/flow-action-update-ips/test.yaml
+++ b/tests/flow-action-update-ips/test.yaml
@@ -1,0 +1,72 @@
+requires:
+  min-version: 6
+
+args:
+- -k none --simulate-ips
+
+pcap: ../ips-state-1/input.pcap
+
+checks:
+- filter:
+    # there are 39 packets in the tls flow, so this seems correct
+    count: 39
+    match:
+      event_type: drop
+- filter:
+    min-version: 7
+    count: 37
+    match:
+      event_type: alert
+      app_proto: tls
+- filter:
+    min-version: 7
+    count: 40
+    match:
+      event_type: alert
+- filter:
+    # There should be one tls flow that is alerted
+    # This currently fails - there is no flow.drop in the tls flow event
+    count: 1
+    match:
+      event_type: flow
+      dest_port: 443
+      flow.alerted: true
+      app_proto: tls
+      flow.action: drop
+
+- filter:
+    lt-version: 7
+    count: 36
+    match:
+      event_type: alert
+      app_proto: tls
+- filter:
+    lt-version: 7
+    count: 39
+    match:
+      event_type: alert
+
+# HTTP-related checks
+- filter:
+    # We should see 2 http transactions as the pass rule should allow http
+    # flows.
+    count: 2
+    match:
+      event_type: http
+
+- filter:
+    # There should be no alerts for http.
+    count: 0
+    match:
+      event_type: alert
+      app_proto: http
+
+- filter:
+    # There should be 2 http flow events without alerts.
+    count: 2
+    match:
+      event_type: flow
+      app_proto: http
+      flow.alerted: false 
+      flow.action: pass
+      


### PR DESCRIPTION
It seems that in certain cases as seen in this test, flow.action isn't updated, even if, say, all packets from the flow are dropped.

Maybe this is due to the rule not being applied directly to the flow, but to each packet individually. But considering we are using a flow keyword, it seems that the engine should pass over the drop action to `flow.action`, at least in the flow event.

Bug #6976

- This was started as part of https://github.com/OISF/suricata-verify/pull/1794, but Philippe suggested that I keet the changes separate, for ease of tracking the possible bug


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/6976