### PR TITLE
tests: showcase flow.action lack of update - v2

### DIFF
--- a/tests/flow-action-update-ips-01/README.md
+++ b/tests/flow-action-update-ips-01/README.md
@@ -1,0 +1,17 @@
+# Test
+
+This is a "fork" of `ips-state-1`, to showcase the `flow.action` update bug.
+
+## PCAP
+
+From `ips-state-1` test.
+
+This PCAP contains 3 flows. 2 are http and one is TLS. The HTTP flows should
+be full passed with no alerts, while the TLS flow should be dropped.
+
+## Current Observations
+
+- HTTP flows are passed as expected.
+
+- All the TLS packets appear to be getting dropped, but `flow.action` is never
+  set to drop.

--- a/tests/flow-action-update-ips-01/suricata.yaml
+++ b/tests/flow-action-update-ips-01/suricata.yaml
@@ -1,0 +1,21 @@
+%YAML 1.1
+---
+
+vars:
+  address-groups:
+    HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
+    EXTERNAL_NET: "!$HOME_NET"
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert
+        - drop:
+            flows: all
+            alerts: true
+        - http
+        - tls
+        - flow

--- a/tests/flow-action-update-ips-01/test.rules
+++ b/tests/flow-action-update-ips-01/test.rules
@@ -1,0 +1,2 @@
+pass tcp $HOME_NET any -> $EXTERNAL_NET 80 (sid:1;)
+drop ip any any -> any any (msg:"DROP ALL"; flow:stateless; sid:2;)

--- a/tests/flow-action-update-ips-01/test.yaml
+++ b/tests/flow-action-update-ips-01/test.yaml
@@ -1,0 +1,72 @@
+requires:
+  min-version: 6
+
+args:
+- -k none --simulate-ips
+
+pcap: ../ips-state-1/input.pcap
+
+checks:
+- filter:
+    # there are 39 packets in the tls flow, so this seems correct
+    count: 39
+    match:
+      event_type: drop
+- filter:
+    min-version: 7
+    count: 37
+    match:
+      event_type: alert
+      app_proto: tls
+- filter:
+    min-version: 7
+    count: 40
+    match:
+      event_type: alert
+- filter:
+    # There should be one tls flow that is alerted
+    # This currently fails - there is no flow.drop in the tls flow event
+    count: 1
+    match:
+      event_type: flow
+      dest_port: 443
+      flow.alerted: true
+      app_proto: tls
+      flow.action: drop
+
+- filter:
+    lt-version: 7
+    count: 36
+    match:
+      event_type: alert
+      app_proto: tls
+- filter:
+    lt-version: 7
+    count: 39
+    match:
+      event_type: alert
+
+# HTTP-related checks
+- filter:
+    # We should see 2 http transactions as the pass rule should allow http
+    # flows.
+    count: 2
+    match:
+      event_type: http
+
+- filter:
+    # There should be no alerts for http.
+    count: 0
+    match:
+      event_type: alert
+      app_proto: http
+
+- filter:
+    # There should be 2 http flow events without alerts.
+    count: 2
+    match:
+      event_type: flow
+      app_proto: http
+      flow.alerted: false 
+      flow.action: pass
+      

--- a/tests/rules/flow-action-update-ips-02/README.md
+++ b/tests/rules/flow-action-update-ips-02/README.md
@@ -1,0 +1,4 @@
+# Test
+
+This is a "fork" of `ips-state-1`, to document how the engine interprets the test
+rules.

--- a/tests/rules/flow-action-update-ips-02/suricata.yaml
+++ b/tests/rules/flow-action-update-ips-02/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+vars:
+  address-groups:
+    HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
+    EXTERNAL_NET: "!$HOME_NET"
+
+engine-analysis:
+  rules: yes

--- a/tests/rules/flow-action-update-ips-02/test.rules
+++ b/tests/rules/flow-action-update-ips-02/test.rules
@@ -1,0 +1,2 @@
+pass tcp $HOME_NET any -> $EXTERNAL_NET 80 (sid:1;)
+drop ip any any -> any any (msg:"DROP ALL"; flow:stateless; sid:2;)

--- a/tests/rules/flow-action-update-ips-02/test.yaml
+++ b/tests/rules/flow-action-update-ips-02/test.yaml
@@ -1,0 +1,67 @@
+requires:
+  pcap: false
+
+args:
+- --simulate-ips
+- --engine-analysis
+
+checks:
+- filter:
+    filename: rules.json
+    count: 1
+    min-version: 7
+    match:
+      raw: "pass tcp $HOME_NET any -> $EXTERNAL_NET 80 (sid:1;)"
+      id: 1
+      requirements: []
+      type: "like_ip_only"
+      flags[0]: "sp_any"
+      flags[1]: "noalert"
+      flags[2]: "toserver"
+      flags[3]: "toclient"
+- filter:
+    filename: rules.json
+    count: 1
+    min-version: 7
+    match:
+      id: 2
+      raw: "drop ip any any -> any any (msg:\"DROP ALL\"; flow:stateless; sid:2;)"
+      requirements[0]: flow
+      type: "pkt"
+      flags[0]: "src_any"
+      flags[1]: "dst_any"
+      flags[2]: "sp_any"
+      flags[3]: "dp_any"
+      flags[4]: "toserver"
+      flags[5]: "toclient"
+      pkt_engines[0].name: "packet"
+      pkt_engines[0].is_mpm: false
+      lists.packet.matches[0].name: "flow"
+- filter:
+    filename: rules.json
+    count: 1
+    lt-version: 7
+    match:
+      raw: "pass tcp $HOME_NET any -> $EXTERNAL_NET 80 (sid:1;)"
+      id: 1
+      requirements: []
+      flags[0]: "sp_any"
+      flags[1]: "toserver"
+      flags[2]: "toclient"
+- filter:
+    filename: rules.json
+    count: 1
+    lt-version: 7
+    match:
+      id: 2
+      raw: "drop ip any any -> any any (msg:\"DROP ALL\"; flow:stateless; sid:2;)"
+      requirements[0]: flow
+      flags[0]: "src_any"
+      flags[1]: "dst_any"
+      flags[2]: "sp_any"
+      flags[3]: "dp_any"
+      flags[4]: "toserver"
+      flags[5]: "toclient"
+      pkt_engines[0].name: "packet"
+      pkt_engines[0].is_mpm: false
+      lists.packet.matches[0].name: "flow"


### PR DESCRIPTION
It seems that in certain cases as seen in this test, flow.action isn't updated, even if, say, all packets from the flow are dropped.

Maybe this is due to the rule not being applied directly to the flow, but to each packet individually. But considering we are using a flow keyword, it seems that the engine should pass over the drop action to flow.action, at least in the flow event.

Bug #6976

Previous PR https://github.com/OISF/suricata-verify/pull/1975

Changes from previous PR:
- add a test with `engine-analysis`

## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/6976