### PR TITLE
tests: Updates for 6555

### DIFF
--- a/tests/eve-overlap-payload-01/test.yaml
+++ b/tests/eve-overlap-payload-01/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7.0.7
 
 args:
 - -k none

--- a/tests/eve-overlap-payload-02-policy-oldlinux/test.yaml
+++ b/tests/eve-overlap-payload-02-policy-oldlinux/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7.0.7
 
 args:
 - -k none

--- a/tests/eve-overlap-payload-03-ips/test.yaml
+++ b/tests/eve-overlap-payload-03-ips/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7.0.7
 
 args:
 - -k none

--- a/tests/eve-overlap-payload-04-partial-overlap/test.yaml
+++ b/tests/eve-overlap-payload-04-partial-overlap/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7.0.7
 
 
 args:

--- a/tests/eve-overlap-payload-05-gap/test.yaml
+++ b/tests/eve-overlap-payload-05-gap/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7.0.7
 
 
 args:

--- a/tests/eve-payload-01-tcp-exact-overlap/test.yaml
+++ b/tests/eve-payload-01-tcp-exact-overlap/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7.0.7
 
 args:
 - -k none

--- a/tests/eve-payload-02-tcp-exact-overlap-policy-oldlinux/test.yaml
+++ b/tests/eve-payload-02-tcp-exact-overlap-policy-oldlinux/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7.0.7
 
 args:
 - -k none

--- a/tests/eve-payload-03-tcp-exact-overlap-ips/test.yaml
+++ b/tests/eve-payload-03-tcp-exact-overlap-ips/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7.0.7
 
 args:
 - -k none

--- a/tests/eve-payload-04-partial-overlap/test.yaml
+++ b/tests/eve-payload-04-partial-overlap/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7.0.7
 
 
 args:

--- a/tests/eve-payload-05-tcp-data-gap/test.yaml
+++ b/tests/eve-payload-05-tcp-data-gap/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7.0.7
 
 
 args:

--- a/tests/eve-payload-06-tcp-data-leading-gap/test.yaml
+++ b/tests/eve-payload-06-tcp-data-leading-gap/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7.0.7
 
 
 args:

--- a/tests/eve-payload-07-http-gap/test.yaml
+++ b/tests/eve-payload-07-http-gap/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7.0.7
 
 pcap: ../http-gap-beyond-body/input.pcap
 
@@ -14,6 +14,7 @@ checks:
       alert.signature_id: 1
 - filter:
     count: 1
+    min-version: 8
     match:
       event_type: alert
       alert.signature_id: 1
@@ -21,6 +22,14 @@ checks:
       payload_length: 40
 - filter:
     count: 1
+    min-version: 7.0.7
+    match:
+      event_type: alert
+      alert.signature_id: 1
+      payload_printable: "GET /1 HTTP/1.0\r\nUser-Agent: Mozilla\r\n\r\n"
+- filter:
+    count: 1
+    min-version: 8
     match:
       event_type: alert
       alert.signature_id: 1
@@ -28,6 +37,14 @@ checks:
       payload_length: 80
 - filter:
     count: 1
+    min-version: 7.0.7
+    match:
+      event_type: alert
+      alert.signature_id: 1
+      payload_printable: "GET /1 HTTP/1.0\r\nUser-Agent: Mozilla\r\n\r\nGET /2 HTTP/1.0\r\nUser-Agent: Mozilla\r\n\r\n"
+- filter:
+    count: 1
+    min-version: 8
     match:
       event_type: alert
       alert.signature_id: 1
@@ -35,11 +52,26 @@ checks:
       payload_length: 120
 - filter:
     count: 1
+    min-version: 7.0.7
+    match:
+      event_type: alert
+      alert.signature_id: 1
+      payload_printable: "GET /1 HTTP/1.0\r\nUser-Agent: Mozilla\r\n\r\nGET /2 HTTP/1.0\r\nUser-Agent: Mozilla\r\n\r\nGET /3 HTTP/1.0\r\nUser-Agent: Mozilla\r\n\r\n"
+- filter:
+    count: 1
+    min-version: 8
     match:
       event_type: alert
       alert.signature_id: 2
       payload_printable: "HTTP/1.0 200 OK\r\nDate: Mon, 31 Aug 2009 20:25:50 GMT\r\nServer: Apache\r\nConnection: close\r\nContent-Type: text/html\r\nContent-Length: 12\r\n\r\n"
       payload_length: 136
+- filter:
+    count: 1
+    min-version: 7.0.7
+    match:
+      event_type: alert
+      alert.signature_id: 2
+      payload_printable: "HTTP/1.0 200 OK\r\nDate: Mon, 31 Aug 2009 20:25:50 GMT\r\nServer: Apache\r\nConnection: close\r\nContent-Type: text/html\r\nContent-Length: 12\r\n\r\n"
 - filter:
     count: 1
     match:
@@ -48,6 +80,7 @@ checks:
       payload_printable: "HTTP/1.0 200 OK\r\nDate: Mon, 31 Aug 2009 20:25:50 GMT\r\nServer: Apache\r\nConnection: close\r\nContent-Type: text/html\r\nContent-Length: 12\r\n\r\n[127 bytes missing]AAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 - filter:
     count: 1
+    min-version: 8
     match:
       event_type: alert
       alert.signature_id: 4

--- a/tests/smb2-frames-gap-payload-logging-02/test.yaml
+++ b/tests/smb2-frames-gap-payload-logging-02/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7.0.7
 
 args:
 - --set stream.midstream=true

--- a/tests/smb2-frames-gap-payload-logging/test.yaml
+++ b/tests/smb2-frames-gap-payload-logging/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7.0.7
 
 args:
 - --set stream.midstream=true


### PR DESCRIPTION
This commit provides updates needed for issue 6555. Previously, the gap handling was restricted to master; 6555 adds those changes to main-7.0.x

Most of the changes are to extend the version; the eve-payload-07-http-gap tests adds version-based checks as a new output value payload_length is not available in main-7.0.x


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6155
