### PR TITLE
pgsql: update bug-6983 tests - v1

### DIFF
--- a/tests/pgsql/pgsql-bug-6983-ids/README.md
+++ b/tests/pgsql/pgsql-bug-6983-ids/README.md
@@ -1,6 +1,7 @@
 # Description
 
-Tests that alerts for the pgsql app-proto will include pgsql app-proto metadata.
+Tests that alerts for the pgsql app-proto will not include pgsql app-proto metadata
+if this setting is disabled in the configuration file.
 
 ## PCAP
 

--- a/tests/pgsql/pgsql-bug-6983-ids/suricata.yaml
+++ b/tests/pgsql/pgsql-bug-6983-ids/suricata.yaml
@@ -10,7 +10,9 @@ outputs:
         - pgsql:
             enabled: yes
             passwords: yes
-        - alert
+        - alert:
+            enabled: yes
+            metadata: no
 
 app-layer:
   protocols:

--- a/tests/pgsql/pgsql-bug-6983-ids/test.yaml
+++ b/tests/pgsql/pgsql-bug-6983-ids/test.yaml
@@ -16,10 +16,5 @@ checks:
     match:
       event_type: alert
       alert.signature_id: 1
-- filter:
-    min-version: 8
-    count: 1
-    match:
-      event_type: alert
-      flow.pkts_toserver: 10
-      flow.pkts_toclient: 10
+      not-has-key: flow
+      not-has-key: pgsql

--- a/tests/pgsql/pgsql-bug-6983-ips/test.yaml
+++ b/tests/pgsql/pgsql-bug-6983-ips/test.yaml
@@ -13,7 +13,15 @@ checks:
     match:
       event_type: pgsql
 - filter:
+    # in ips mode, as this rule inspects the stream only (no pgsql keywords), we end up getting two alerts instead of one
     count: 2
     match:
       event_type: alert
       alert.signature_id: 1
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      alert.signature_id: 1
+      pgsql.request.simple_query: "select * from rules where sid = 2021701;"
+      pgsql.response.field_count: 10


### PR DESCRIPTION
Add app-layer fields to pgsql alerts.

Related to
Bug #7066

To accompany the backport PR for https://redmine.openinfosecfoundation.org/issues/7066

For the `pgsql` metadata to appear in `ids` mode we still need to backport [ticket 7001](https://redmine.openinfosecfoundation.org/issues/7001). The solution I found was to include the metadata for the `ips` mode test, and leave the `ids` mode test  to check that we honor the disabling of this configuration option.

## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/7066

Suricata PR: https://github.com/OISF/suricata/pull/11681