### PR TITLE
tests: complement test for issue 7241/7242 for 7 - v1

### DIFF
--- a/tests/bug-7241-02-pre8/README.md
+++ b/tests/bug-7241-02-pre8/README.md
@@ -1,0 +1,4 @@
+Test for issue 7272
+===================
+
+Test specifically for the features supported in Suricata 7.

--- a/tests/bug-7241-02-pre8/test.rules
+++ b/tests/bug-7241-02-pre8/test.rules
@@ -1,0 +1,2 @@
+drop tcp any any -> any any (flow:established; app-layer-protocol:!tls; sid:1;)
+drop tcp any any -> any any (flow:established; app-layer-protocol:!tls; prefilter; sid:2;)

--- a/tests/bug-7241-02-pre8/test.yaml
+++ b/tests/bug-7241-02-pre8/test.yaml
@@ -1,0 +1,20 @@
+requires:
+  min-version: 7
+
+pcap: ../tls/tls-random/input.pcap
+
+args:
+- -k none
+- --simulate-ips
+
+checks:
+- filter:
+    count: 0
+    match:
+      alert.signature_id: 1
+      event_type: alert
+- filter:
+    count: 0
+    match:
+      alert.signature_id: 2
+      event_type: alert

--- a/tests/rules/app-layer-protocol/test.rules
+++ b/tests/rules/app-layer-protocol/test.rules
@@ -1,0 +1,2 @@
+drop tcp any any -> any any (flow:established; app-layer-protocol:!tls; sid:1;)
+drop tcp any any -> any any (flow:established; app-layer-protocol:!tls; prefilter; sid:2;)

--- a/tests/rules/app-layer-protocol/test.yaml
+++ b/tests/rules/app-layer-protocol/test.yaml
@@ -1,0 +1,24 @@
+requires:
+    min-version: 7.0
+    pcap: false
+
+args:
+    - --engine-analysis
+    - --simulate-ips
+
+checks:
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 1
+      app_proto: "unknown"
+      not-has-key: "prefilter"
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 2
+      app_proto: "unknown"
+      prefilter.buffer: "packet"
+      prefilter.name: app-layer-protocol


### PR DESCRIPTION
https://github.com/OISF/suricata-verify/pull/2042 with addition of a commit for `engine-analysis` tests.

The `engine-analysis` checks don't fail with `main-7.0.x`, however - I'm not sure there's enough information in the output to differentiate between the changes.

