### PR TITLE
pgsql: update raw-stream-trigger test for suri-7

### DIFF
--- a/tests/pgsql/pgsql-7000-ids/test.yaml
+++ b/tests/pgsql/pgsql-7000-ids/test.yaml
@@ -1,5 +1,3 @@
-requires:
-   min-version: 8
 args:
 - -k none
 


### PR DESCRIPTION
Remove `min-version 8` from bug 7000/ 7001 test, related to triggering raw stream reassembly earlier.

Related to
Bug #7001

Expectation: the test should fail with `main-7.0.x` as suri 7 doesn't have this yet.

Suricata PR:  https://github.com/OISF/suricata/pull/11826

## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/7001
