### PR TITLE
dns-reversed-udp-1: test that flow is reversed

### DIFF
--- a/tests/dns-reversed-udp-1/suricata.yaml
+++ b/tests/dns-reversed-udp-1/suricata.yaml
@@ -8,3 +8,4 @@ outputs:
         - dns:
             enabled: true
             version: 2
+        - flow:

--- a/tests/dns-reversed-udp-1/test.yaml
+++ b/tests/dns-reversed-udp-1/test.yaml
@@ -30,3 +30,12 @@ checks:
         dns.type: answer
         src_ip: "10.16.1.11"
         dest_ip: "10.16.1.1"
+
+  # This pcap has one packet, 10.16.1.1 -> 10.16.1.11, but Suricata
+  # should reverse that as it detect this as a DNS response.
+  - filter:
+      count: 1
+      match:
+        event_type: flow
+        src_ip: "10.16.1.11"
+        dest_ip: "10.16.1.1"


### PR DESCRIPTION
Test that because this is a DNS response, that the flow is reversed.
