### PR TITLE
tests: add rule type check for icmp_id - v1

### DIFF
--- a/tests/rules/icmp_id/test.rules
+++ b/tests/rules/icmp_id/test.rules
@@ -1,0 +1,1 @@
+alert icmp any any -> any any (msg:"Testing icmp_id"; icmp_id:2; sid:1;)

--- a/tests/rules/icmp_id/test.yaml
+++ b/tests/rules/icmp_id/test.yaml
@@ -1,0 +1,15 @@
+requires:
+    min-version: 8.0
+    pcap: false
+
+args:
+    - --engine-analysis
+
+checks:
+- filter:
+    filename: rules.json
+    count: 1
+    match:
+      id: 1
+      lists.packet.matches[0].name: "icmp_id"
+      lists.packet.matches[0].id.number: 2


### PR DESCRIPTION
Adding SV tests for icmp_id keyword
 
Related to:
Ticket: #6360

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/6360

Suricata PR: https://github.com/OISF/suricata/pull/11945