### PR TITLE
tls: assorted checks - v1

### DIFF
--- a/tests/tls/tls-eve-custom-fields/README.md
+++ b/tests/tls/tls-eve-custom-fields/README.md
@@ -1,0 +1,12 @@
+### Test
+
+Check that missing TLS custom fields are checked in test -- to test for
+JSON schema completion.
+
+### Pcap
+
+Reused from test `tls-store-02`.
+
+### Ticket
+
+https://redmine.openinfosecfoundation.org/issues/7287

--- a/tests/tls/tls-eve-custom-fields/suricata.yaml
+++ b/tests/tls/tls-eve-custom-fields/suricata.yaml
@@ -1,0 +1,12 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - tls:
+            ja4: on
+            custom: [subject, issuer, serial, fingerprint, sni, version, not_before, not_after, certificate, chain, subjectaltname, client, client_certificate, client_chain]

--- a/tests/tls/tls-eve-custom-fields/test.yaml
+++ b/tests/tls/tls-eve-custom-fields/test.yaml
@@ -1,0 +1,36 @@
+requires:
+    min-version: 8
+
+args:
+- -k none
+
+pcap: ../tls-store-02/tls-client-auth.pcap
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: tls
+        tls.subject: C=HU, ST=Budapest, L=Budapest, O=TLSClientAuthSampleServer, CN=SampleServer
+        tls.issuerdn: C=HU, ST=Budapest, L=Budapest, O=TLSClientAuthSampleCA, CN=SampleRoot
+        tls.subjectaltname[0]: localhost
+        tls.serial: 00:C7:D4:28:8B:80:E0:1E:25
+        tls.fingerprint: 06:39:f9:5d:fe:81:53:c4:9d:f0:ac:80:3e:2d:42:07:e8:96:de:09
+        tls.sni: localhost
+        tls.version: TLS 1.2
+        tls.notbefore: '2018-04-14T20:55:27'
+        tls.notafter: '2018-05-14T20:55:27'
+        tls.client.serial: 00:C7:D4:28:8B:80:E0:1E:27
+        tls.client.notbefore: '2018-04-14T20:55:27'
+        tls.client.notafter: '2018-05-14T20:55:27'
+  - filter:
+      count: 1
+      match:
+        event_type: tls
+        has-key: tls.certificate
+        has-key: tls.chain
+        has-key: tls.client.subject
+        has-key: tls.client.issuerdn
+        has-key: tls.client.fingerprint
+        has-key: tls.client.chain
+        has-key: tls.client.certificate

--- a/tests/tls/tls-subjectaltname/suricata.yaml
+++ b/tests/tls/tls-subjectaltname/suricata.yaml
@@ -1,0 +1,17 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            payload: no
+            payload-buffer-size: 4kb
+            payload-printable: no
+            packet: no
+            metadata: no
+        - tls:
+            custom: [subject, issuer, serial, fingerprint, sni, version, not_before, not_after, subjectaltname]

--- a/tests/tls/tls-subjectaltname/test.yaml
+++ b/tests/tls/tls-subjectaltname/test.yaml
@@ -10,3 +10,8 @@ checks:
     match:
       alert.signature_id: 1
       event_type: alert
+- filter:
+    count: 28
+    match:
+      event_type: tls
+      has-key: tls.subjectaltname


### PR DESCRIPTION
Add checks for TLS missing fields from JSON schema or from the output (`subjectaltname` was missing from logs, `certificate` and `chain` were missing from the schema)

## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
- https://redmine.openinfosecfoundation.org/issues/7287
- https://redmine.openinfosecfoundation.org/issues/7332