### PR TITLE
createst: Allow to exclude certain fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ options:
                         Adds a suricata.yaml to the test
   --features <features>
                         Adds specified features
+  --exclude-fields [EXCLUDE_FIELDS]
+                        Exclude specified fields from filter block
 ```
 
 ### Examples


### PR DESCRIPTION
Ticket: #4062

Link to redmine ticket: https://redmine.openinfosecfoundation.org/issues/4062

## Ticket
- This is a continuation of PR #997 by  @TharushiJay
-  exclude Non top-level fields fields
- updated readne
- previous pr #2110 
```
createst.py mytest mypcap --exclude-fields dest_port,tcp.ts_max_regions
```
Before:
```
 filter:
    count: 1
    match:
      app_proto: http
      dest_ip: 82.165.177.154
      event_type: flow
      flow.age: 0
      flow.alerted: false
      flow.bytes_toclient: 495
      flow.bytes_toserver: 425
      flow.pkts_toclient: 4
      flow.pkts_toserver: 6
      flow.reason: shutdown
      flow.state: closed
      proto: TCP
      src_ip: 10.16.1.11
      src_port: 54186
      tcp.ack: true
      tcp.fin: true
      tcp.psh: true
      tcp.state: closed
      tcp.syn: true
      tcp.tc_max_regions: 1
      tcp.tcp_flags: 1b
      tcp.tcp_flags_tc: 1b
      tcp.tcp_flags_ts: 1b
      tcp.ts_max_regions: 1
```
After:
```
filter:
    count: 1
    match:
      app_proto: http
      dest_ip: 82.165.177.154
      event_type: flow
      flow.age: 0
      flow.alerted: false
      flow.bytes_toclient: 495
      flow.bytes_toserver: 425
      flow.pkts_toclient: 4
      flow.pkts_toserver: 6
      flow.reason: shutdown
      flow.state: closed
      flow_id: 2019292059448498
      proto: TCP
      src_ip: 10.16.1.11
      src_port: 54186
      tcp.ack: true
      tcp.fin: true
      tcp.psh: true
      tcp.state: closed
      tcp.syn: true
      tcp.tc_max_regions: 1
      tcp.tcp_flags: 1b
      tcp.tcp_flags_tc: 1b
      tcp.tcp_flags_ts: 1b
      timestamp: 2016-07-13T22:42:07.011401+0000
```



