### PR TITLE
transform/base64: Test error case

### DIFF
--- a/tests/from_base64-01/test.rules
+++ b/tests/from_base64-01/test.rules
@@ -6,3 +6,5 @@ alert http any any -> any any (msg:"from_base64: bytes, offset #1 [mode rfc4648]
 alert http any any -> any any (msg:"from_base64: offset #3, mode rfc2045 - will succeed"; http.uri; content:"/?arg=dGhpc2lzYXRlc3QK"; from_base64: offset 6, mode rfc2045 ; content:"thisisatest"; sid:4; rev:1;)
 alert http any any -> any any (msg:"from_base64: offset #3, mode rfc4648 - will succeed"; http.uri; content:"/?arg=dGhpc2lzYXRlc3QK"; from_base64: offset 6, mode rfc4648 ; content:"thisisatest"; sid:5; rev:1;)
 alert http any any -> any any (msg:"from_base64: offset #4, mode strict - will succeed"; http.uri; content:"/?arg=dGhpc2lzYXRlc3QK"; from_base64: offset 6, mode strict ; content:"thisisatest"; sid:6; rev:1;)
+alert http any any -> any any (msg:"from_base64: error condition on non-b64 content"; file.data; content:"To Linux and beyond"; from_base64: set_error; content:"BASE64_ECODE_BUF"; sid:7; rev:1;)
+alert http any any -> any any (msg:"from_base64: error condition not set on b64 content"; http.uri; content:"/?arg=dGhpc2lzYXRlc3QK"; from_base64: offset 6, mode strict, set_error ; content:!"BASE64_ECODE_BUF"; content:"thisisatest";  sid:8; rev:1;)

--- a/tests/from_base64-01/test.yaml
+++ b/tests/from_base64-01/test.yaml
@@ -32,3 +32,18 @@ checks:
       match:
          event_type: alert
          alert.signature_id: 5
+  - filter:
+      count: 1
+      match:
+         event_type: alert
+         alert.signature_id: 6
+  - filter:
+      count: 1
+      match:
+         event_type: alert
+         alert.signature_id: 7
+  - filter:
+      count: 1
+      match:
+         event_type: alert
+         alert.signature_id: 8


### PR DESCRIPTION
Issue: 7114

Add test cases using the "set_error" keyword
- Content that can't be base64 decoded (ensure error buffer is set)
- Content that can be base64 decoded (ensure error buffer not set)


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:  https://redmine.openinfosecfoundation.org/issues/7114
