### PR TITLE
tests: add keyword check to requires test

### DIFF
--- a/tests/requires-fail/README.md
+++ b/tests/requires-fail/README.md
@@ -1,3 +1,5 @@
 Similar to `../requires-ok` but does include one rule that will fail
 to load. This is to test that a bad rule after "skipped" rule fails
 out and is not recorded as skipped.
+
+Ticket: https://redmine.openinfosecfoundation.org/issues/6710

--- a/tests/requires-fail/test.rules
+++ b/tests/requires-fail/test.rules
@@ -14,4 +14,4 @@ alert udp any any -> any any (vxlan_vni:10; requires: version >= 10; sid:2;)
 alert http any any => any any (requires: version >= 10; sid:3;)
 alert tcp any any -> any any (frame:smtp.not_supported; requires: version >= 10; sid:4;)
 
-alert asdf any any -> any any (requires: version >= 6, foo bar; sid:102; rev:1;)
+alert asdf any any -> any any (requires: version >= 6; foo: bar; sid:102; rev:1;)

--- a/tests/requires-ok/test.rules
+++ b/tests/requires-ok/test.rules
@@ -4,8 +4,11 @@ alert http any any -> any any (msg:"TEST Suricata >= 7 and < 8"; content:"uid=0"
 # Rule for Suricata >= 7.0.3 but less than 8... Or >= 8.0.1
 alert http any any -> any any (content:"uid=0"; requires: version >= 7.0.3 < 8 | >= 8.0.1; sid:9; rev:1;)
 
-# Rule for Suricata >= 8.
-alert http any any -> any any (msg:"TEST Suricata >= 8"; content:"uid=0"; requires: version >= 8.0.0; sid:8; rev:1;)
+# Rule for Suricata >= 8, with pretty useless check for sid keyword.
+alert http any any -> any any (msg:"TEST Suricata >= 8"; content:"uid=0"; requires: version >= 8.0.0, keyword sid; sid:8; rev:1;)
+
+# Requires unknown keyword, should be marked as skipped.
+alert http any any -> any any (msg:"TEST Requires unknown keyword"; requires: version >= 8, keyword foobar; sid:100; rev:1;)
 
 # These rules have something invalid about them, but do follow the general rule
 # structure, so should be eliminated by the requires statement.

--- a/tests/requires-ok/test.yaml
+++ b/tests/requires-ok/test.yaml
@@ -50,7 +50,7 @@ checks:
       count: 1
       match:
         event_type: stats
-        stats.detect.engines[0].rules_skipped: 5
+        stats.detect.engines[0].rules_skipped: 6
         stats.detect.engines[0].rules_loaded: 2
         stats.detect.engines[0].rules_failed: 0
 
@@ -60,6 +60,6 @@ checks:
       count: 1
       match:
         event_type: stats
-        stats.detect.engines[0].rules_skipped: 6
+        stats.detect.engines[0].rules_skipped: 7
         stats.detect.engines[0].rules_loaded: 1
         stats.detect.engines[0].rules_failed: 0


### PR DESCRIPTION
Only for 8.0 for now.

requires-fail: With the change to unknown requires statements treated as
not meeting requirements, update the rule to use an unknown keyword to
make it fail out.

Ticket: #7403
