### PR TITLE
tests: allow unknown requirements for 7.0.x

### DIFF
--- a/tests/requires-7-unknown/README.md
+++ b/tests/requires-7-unknown/README.md
@@ -1,0 +1,3 @@
+Test that the new behavior in 8 for treating unknown requirements as
+unsatisfied can be disable in 7.0.8 and newer, but that this setting is not
+respected in 8.

--- a/tests/requires-7-unknown/test.rules
+++ b/tests/requires-7-unknown/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (content:"uid=0"; requires: foo bar; sid:9; rev:1;)

--- a/tests/requires-7-unknown/test.yaml
+++ b/tests/requires-7-unknown/test.yaml
@@ -1,0 +1,27 @@
+args:
+  # Suricata 8 doesn't respect this setting.
+  - --set ignore-unknown-requirements=true
+
+pcap: ../eve-metadata/testmyids.pcap
+
+checks:
+
+  - filter:
+      requires:
+        lt-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.detect.engines[0].rules_skipped: 0
+        stats.detect.engines[0].rules_loaded: 1
+        stats.detect.engines[0].rules_failed: 0
+
+  - filter:
+      requires:
+        min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.detect.engines[0].rules_skipped: 1
+        stats.detect.engines[0].rules_loaded: 0
+        stats.detect.engines[0].rules_failed: 0

--- a/tests/requires-unknown/README.md
+++ b/tests/requires-unknown/README.md
@@ -1,0 +1,4 @@
+Test that unknown requirements are treated as unsatisfied leading to the rule
+being skipped.
+
+Simple standalone test.

--- a/tests/requires-unknown/test.rules
+++ b/tests/requires-unknown/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (content:"uid=0"; requires: foo bar; sid:9; rev:1;)

--- a/tests/requires-unknown/test.yaml
+++ b/tests/requires-unknown/test.yaml
@@ -1,0 +1,14 @@
+requires:
+  min-version: 7.0.8
+
+pcap: ../eve-metadata/testmyids.pcap
+
+checks:
+
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        stats.detect.engines[0].rules_skipped: 1
+        stats.detect.engines[0].rules_loaded: 0
+        stats.detect.engines[0].rules_failed: 0


### PR DESCRIPTION
- **test: test setting to ignore unknown requirement**
  Test that the new behavior in 8 for treating unknown requirements as
  unsatisfied can be disable in 7.0.8 and newer, but that this setting is not
  respected in 8.
  

- **test: simple test for unknown requirements**
  