### PR TITLE
output: Permit output tests for failure case

### DIFF
--- a/tests/bug-5198/test.yaml
+++ b/tests/bug-5198/test.yaml
@@ -1,9 +1,11 @@
 pcap: ../eve-flow-vlan/input.pcap
 
 requires:
-  min-version: 7
-  features:
-    - FIX_FOR_BUG_5836
+  min-version: 8
+
+skip:
+  - uid: 0
+    msg: "Test requires non-root user"
 
 setup:
   # Create a log directory without write permission


### PR DESCRIPTION
Remove the restriction for bug-5198.

Issue: 7447


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
