### PR TITLE
tests: workaround for urgp test

### DIFF
--- a/tests/tcp-urgp-07-oob-exceed-limit/test.yaml
+++ b/tests/tcp-urgp-07-oob-exceed-limit/test.yaml
@@ -5,6 +5,7 @@ args:
 - --set stream.reassembly.urgent.policy=oob
 - --set stream.reassembly.urgent.oob-limit-policy=drop
 - --simulate-ips
+- --set stats.interval=3600
 
 checks:
   - filter:


### PR DESCRIPTION
Slow runs lead to multiple stats records with the same data.


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
