### PR TITLE
tests: workaround for urgp tests

### DIFF
--- a/tests/tcp-urgp-06-oob-within-limit/test.yaml
+++ b/tests/tcp-urgp-06-oob-within-limit/test.yaml
@@ -3,6 +3,7 @@ requires:
 
 args:
 - --set stream.reassembly.urgent.policy=oob
+- --set stats.interval=3600
 
 checks:
   - filter:

--- a/tests/tcp-urgp-08-oob-exceed-limit-gap/test.yaml
+++ b/tests/tcp-urgp-08-oob-exceed-limit-gap/test.yaml
@@ -5,6 +5,7 @@ args:
 - --set stream.reassembly.urgent.policy=oob
 - --set stream.reassembly.urgent.oob-limit-policy=gap
 - --simulate-ips
+- --set stats.interval=3600
 
 checks:
   - filter:

--- a/tests/tcp-urgp-09-oob-exceed-limit-inline/test.yaml
+++ b/tests/tcp-urgp-09-oob-exceed-limit-inline/test.yaml
@@ -5,6 +5,7 @@ args:
 - --set stream.reassembly.urgent.policy=oob
 - --set stream.reassembly.urgent.oob-limit-policy=inline
 - --simulate-ips
+- --set stats.interval=3600
 
 checks:
   - filter:


### PR DESCRIPTION
Slow runs lead to multiple stats records with the same data.

Completes cb35ba0d74e1bd163071c3cea1abe509018cda4a
