### PR TITLE
tests: add flowbits engine-analysis test - v1

### DIFF
--- a/tests/rules/flowbit-engine-analysis/test.rules
+++ b/tests/rules/flowbit-engine-analysis/test.rules
@@ -1,0 +1,8 @@
+alert http any any -> any any (msg:"Setting flowbit fb1";content:"testmyids.com";http_header;flowbits:set,fb1;noalert;sid:1;rev:1;)
+alert http any any -> any any (msg:"Setting flowbit fb3";content:"wwnotginh";flowbits:set,fb5;sid:3;rev:1;)
+alert ip any any -> any any (msg:"Flowbit isset ored flowbits"; flowbits:isset,fb1; sid:1801;)
+alert ip any any -> any any (msg:"Is-Setting flowbit fb2, pkt rule";flowbits:isset,fb2;sid:1904;)
+alert http any any -> any any (msg:"Setting flowbit fb2, app_tx rule";http.uri;content:"something";flowbits:set,fb2;sid:1901;)
+alert http any any -> any any (msg:"Is-Setting flowbit fb2, stream rule";content:"something";flowbits:isset,fb2;sid:1902;)
+alert tcp-pkt any any -> any any (msg:"Is-Setting flowbit fb2, pkt rule";content:"something";flowbits:isset,fb2;sid:1903;)
+

--- a/tests/rules/flowbit-engine-analysis/test.yaml
+++ b/tests/rules/flowbit-engine-analysis/test.yaml
@@ -1,0 +1,60 @@
+requires:
+  min-version: 8
+  pcap: false
+args:
+- --engine-analysis
+
+checks:
+  - filter:
+      filename: rules.json
+      count: 1
+      match:
+        id: 1801
+        type: "pkt"
+        rule_state_dependant.rule_depends_on_sid: 1
+        rule_state_dependant.rule_depends_on_flowbit: "fb1"
+  - filter:
+      filename: rules.json
+      count: 1
+      match:
+        id: 1
+        type: "app_tx"
+        rule_state_dependant: false
+  - filter:
+      filename: rules.json
+      count: 1
+      match:
+        id: 3
+        type: "stream"
+        rule_state_dependant: false
+  - filter:
+      filename: rules.json
+      count: 1
+      match:
+        id: 1901
+        type: "app_tx"
+        rule_state_dependant: false
+  - filter:
+      filename: rules.json
+      count: 1
+      match:
+        id: 1902
+        type: "stream"
+        rule_state_dependant.rule_depends_on_sid: 1901
+        rule_state_dependant.rule_depends_on_flowbit: "fb2"
+  - filter:
+      filename: rules.json
+      count: 1
+      match:
+        id: 1903
+        type: "pkt"
+        rule_state_dependant.rule_depends_on_sid: 1901
+        rule_state_dependant.rule_depends_on_flowbit: "fb2"
+  - filter:
+      filename: rules.json
+      count: 1
+      match:
+        id: 1904
+        type: "pkt"
+        rule_state_dependant.rule_depends_on_sid: 1901
+        rule_state_dependant.rule_depends_on_flowbit: "fb2"


### PR DESCRIPTION
Especially to illustrate the engine-analysis report on flowbit rules statefulness changes based on another flowbit rule.

Related to
Task #7456

Suricata PR: https://github.com/OISF/suricata/pull/12311

## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/7456