### PR TITLE
transform/test: from_base64 tests using set_error

### DIFF
--- a/tests/from_base64-04/README.md
+++ b/tests/from_base64-04/README.md
@@ -1,0 +1,4 @@
+Tests for the from_base64 with input that cannot be base64-decoded.
+
+The "set_error" transform option is used so content that cannot be
+base64-decoded can be detected.

--- a/tests/from_base64-04/test.rules
+++ b/tests/from_base64-04/test.rules
@@ -1,0 +1,6 @@
+# input pcap contains a query to http://home.regit.org/?arg=dGhpc2lzYXRlc3QK
+# "dGhpc2lzYXRlc3QK" is "thisisatest\n"
+alert tcp any any -> any any (msg:"from_base64: no-decode [mode rfc4648]"; flow:to_server,established;  http.uri; content:"/?arg="; from_base64: set_error; absent;  sid:1; rev:1;)
+alert tcp any any -> any any (msg:"from_base64: no-decode with or_else [mode rfc4648]"; flow:to_server,established;  http.uri; content:"/?arg="; from_base64: set_error; absent: or_else; content: "foobar";  sid:2; rev:1;)
+alert http any any -> any any (msg:"from_base64: decode with or_else [mode rfc4648]"; http.uri; content:"/?arg=dGhpc2lzYXRlc3QK"; from_base64: offset 10; absent: or_else; content:"sisatest"; sid:3; rev:1;)
+alert http any any -> any any (msg:"from_base64: no-decode with content check"; file.data; content:"To Linux and beyond"; from_base64: set_error; content:"This will not match"; sid:4; rev:1;)

--- a/tests/from_base64-04/test.yaml
+++ b/tests/from_base64-04/test.yaml
@@ -13,7 +13,7 @@ checks:
          event_type: alert
          alert.signature_id: 1
   - filter:
-      count: 1
+      count: 0
       match:
          event_type: alert
          alert.signature_id: 2
@@ -23,17 +23,7 @@ checks:
          event_type: alert
          alert.signature_id: 3
   - filter:
-      count: 1
+      count: 0
       match:
          event_type: alert
          alert.signature_id: 4
-  - filter:
-      count: 1
-      match:
-         event_type: alert
-         alert.signature_id: 5
-  - filter:
-      count: 1
-      match:
-         event_type: alert
-         alert.signature_id: 6


### PR DESCRIPTION
These tests use the set_error transform option to signal buffers that cannot be base64-decoded.

The absent keyword detects the signaling on a buffer that can't be decoded; absent with the or_else option is used when a buffer can be decoded.


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
