### PR TITLE
dataset: update engine module

### DIFF
--- a/tests/datasets-invalid-encoding/test.yaml
+++ b/tests/datasets-invalid-encoding/test.yaml
@@ -18,4 +18,4 @@ checks:
         log_level: "Error"
         event_type: "engine"
         engine.message.__find: "bad base64 encoding ua-seen"
-        engine.module: "datasets"
+        engine.module: "debug"


### PR DESCRIPTION
since moving the file reading to Rust and adding the common FatalErrorOnInit callback to util-debug.c, the module that finally does make the error message is "debug".
