### PR TITLE
test/ftp: FTP command tests

### DIFF
--- a/tests/detect-ftp/ftp-command-01/input.rules
+++ b/tests/detect-ftp/ftp-command-01/input.rules
@@ -1,0 +1,6 @@
+alert ftp any any -> any any (msg: "Match on FTP command PASS"; flow:to_server; ftp.command; content:"PASS"; sid:1;)
+alert ftp any any -> any any (msg: "Match on FTP command USER"; flow:to_server; ftp.command; content:"USER"; sid:2;)
+alert ftp any any -> any any (msg: "Match on FTP command NLST"; flow:to_server; ftp.command; content:"NLST"; sid:3;)
+alert ftp any any -> any any (msg: "Match on FTP command PORT"; flow:to_server; ftp.command; content:"PORT"; sid:4;)
+alert ftp any any -> any any (msg: "Match on FTP command RETR"; flow:to_server; ftp.command; content:"RETR"; sid:5;)
+alert ftp any any -> any any (msg: "Match on FTP command QUIT"; flow:to_server; ftp.command; content:"QUIT"; sid:6;)

--- a/tests/detect-ftp/ftp-command-01/test.yaml
+++ b/tests/detect-ftp/ftp-command-01/test.yaml
@@ -1,0 +1,49 @@
+pcap: ../../bug-3519/input.pcap
+
+requires:
+  version: 8
+
+
+checks:
+
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ftp.command: PASS
+        alert.signature_id: 1
+
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ftp.command: USER
+        alert.signature_id: 2
+
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ftp.command: NLST
+        alert.signature_id: 3
+
+  - filter:
+      count: 2
+      match:
+        event_type: alert
+        ftp.command: PORT
+        alert.signature_id: 4
+
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ftp.command: RETR
+        alert.signature_id: 5
+
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ftp.command: QUIT
+        alert.signature_id: 6

--- a/tests/detect-ftp/ftp-command-02/input.rules
+++ b/tests/detect-ftp/ftp-command-02/input.rules
@@ -1,0 +1,7 @@
+# Wrong direction -- won't load
+alert ftp any any -> any any (flow:to_client; ftp.command; content:"PASS"; sid:10;)
+alert ftp any any -> any any (flow:to_client; ftp.command; content:"USER"; sid:20;)
+alert ftp any any -> any any (flow:to_client; ftp.command; content:"NLST"; sid:30;)
+alert ftp any any -> any any (flow:to_client; ftp.command; content:"PORT"; sid:40;)
+alert ftp any any -> any any (flow:to_client; ftp.command; content:"RETR"; sid:50;)
+alert ftp any any -> any any (flow:to_client; ftp.command; content:"QUIT"; sid:60;)

--- a/tests/detect-ftp/ftp-command-02/test.yaml
+++ b/tests/detect-ftp/ftp-command-02/test.yaml
@@ -1,0 +1,26 @@
+pcap: ../../bug-3519/input.pcap
+
+requires:
+  version: 8
+
+exit-code: 1
+
+checks:
+  - shell:
+      args: grep "rule 10 mixes keywords with conflicting directions" suricata.log | wc -l | xargs
+      expect: 1
+  - shell:
+      args: grep "rule 20 mixes keywords with conflicting directions" suricata.log | wc -l | xargs
+      expect: 1
+  - shell:
+      args: grep "rule 30 mixes keywords with conflicting directions" suricata.log | wc -l | xargs
+      expect: 1
+  - shell:
+      args: grep "rule 40 mixes keywords with conflicting directions" suricata.log | wc -l | xargs
+      expect: 1
+  - shell:
+      args: grep "rule 50 mixes keywords with conflicting directions" suricata.log | wc -l | xargs
+      expect: 1
+  - shell:
+      args: grep "rule 60 mixes keywords with conflicting directions" suricata.log | wc -l | xargs
+      expect: 1


### PR DESCRIPTION
Continuation of #2242 

Issue: 7502

Add test cases for the keyword ftp.command:
- Validate matches
- Validate keyword can't be used for server responses
Updates:
- Include signature ids in filter checks.

## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
