### PR TITLE
detect: add test for ldap operation keywords - v6

### DIFF
--- a/tests/detect-ldap-operation/README.md
+++ b/tests/detect-ldap-operation/README.md
@@ -1,0 +1,5 @@
+Test ldap.request.operation, ldap.responses.operation and ldap.responses.count keywords.
+
+PCAP from ../ldap-search/ldap.pcap
+
+Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7453

--- a/tests/detect-ldap-operation/test.rules
+++ b/tests/detect-ldap-operation/test.rules
@@ -1,0 +1,16 @@
+alert tcp any any -> any any (msg:"Test search request number argument"; ldap.request.operation:3; sid:1;)
+alert tcp any any -> any any (msg:"Test search request str argument"; ldap.request.operation:search_request; sid:2;)
+alert tcp any any -> any any (msg:"Test search result entry"; ldap.responses.operation:search_result_entry; sid:3;)
+alert tcp any any -> any any (msg:"Test search result done"; ldap.responses.operation:search_result_done; sid:4;)
+alert tcp any any -> any any (msg:"Test search result done at index 1"; ldap.responses.operation:search_result_done,1; sid:5;)
+alert tcp any any -> any any (msg:"Test search result done at any index"; ldap.responses.operation:search_result_done,any; sid:6;)
+alert tcp any any -> any any (msg:"Test search result done at last index"; ldap.responses.operation:search_result_done,-1; sid:7;)
+alert tcp any any -> any any (msg:"Test number of LDAP responses is 2"; ldap.responses.count:2; sid:8;)
+alert tcp any any -> any any (msg:"Test number of LDAP responses is greater than 0"; ldap.responses.count:>0; sid:9;)
+
+# The following signatures do not match:
+
+alert tcp any any -> any any (msg:"Test search result done at index 0"; ldap.responses.operation:search_result_done,0; sid:10;)
+alert tcp any any -> any any (msg:"Test number of LDAP responses is 10"; ldap.responses.count:10; sid:11;)
+alert tcp any any -> any any (msg:"Test number of LDAP responses is greater than 2"; ldap.responses.count:>2; sid:12;)
+alert tcp any any -> any any (msg:"Test all LDAP responses are search_result_done"; ldap.responses.operation:search_result_done,all; sid:13;)

--- a/tests/detect-ldap-operation/test.yaml
+++ b/tests/detect-ldap-operation/test.yaml
@@ -1,0 +1,90 @@
+requires:
+  min-version: 8
+
+pcap: ../ldap-search/ldap.pcap
+
+args:
+  - -k none --set stream.inline=true
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        pcap_cnt: 4
+        ldap.request.operation: search_request
+        alert.signature_id: 1
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        pcap_cnt: 4
+        ldap.request.operation: search_request
+        alert.signature_id: 2
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        pcap_cnt: 6
+        ldap.responses[0].operation: search_result_entry
+        alert.signature_id: 3
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        pcap_cnt: 8
+        ldap.responses[1].operation: search_result_done
+        alert.signature_id: 4
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        pcap_cnt: 8
+        ldap.responses[1].operation: search_result_done
+        alert.signature_id: 5
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        pcap_cnt: 8
+        ldap.responses[1].operation: search_result_done
+        alert.signature_id: 6
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        pcap_cnt: 8
+        ldap.responses[1].operation: search_result_done
+        alert.signature_id: 7
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        pcap_cnt: 8
+        alert.signature_id: 8
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 9
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+        alert.signature_id: 10
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+        pcap_cnt: 8
+        alert.signature_id: 11
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+        alert.signature_id: 12
+  - filter:
+      count: 0
+      match:
+        event_type: alert
+        alert.signature_id: 13


### PR DESCRIPTION
Ticket: [7453](https://redmine.openinfosecfoundation.org/issues/7453)

Description:
- Add S-V test for ldap operation keywords

Changes:
- add comment for signatures that should not match

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7453

Suricata PR: https://github.com/OISF/suricata/pull/12447
Previous PR: https://github.com/OISF/suricata-verify/pull/2243
