### PR TITLE
detect/integers: test enum with negated strings - v1

### DIFF
--- a/tests/detect-uint-enum/README.md
+++ b/tests/detect-uint-enum/README.md
@@ -1,0 +1,7 @@
+Test for checking the working of function detect_parse_uint_enum
+when passing negated strings.
+
+
+PCAP from ../websocket-ping/input.pcap
+
+redmine ticket: https://redmine.openinfosecfoundation.org/issues/7513

--- a/tests/detect-uint-enum/test.rules
+++ b/tests/detect-uint-enum/test.rules
@@ -1,0 +1,2 @@
+alert websocket any any -> any any (msg:"There is no pong opcode in this packet"; websocket.opcode:!pong; sid:1;)
+alert websocket any any -> any any (msg:"There is no ping opcode in this packet"; websocket.opcode:!ping; sid:2;)

--- a/tests/detect-uint-enum/test.yaml
+++ b/tests/detect-uint-enum/test.yaml
@@ -1,0 +1,19 @@
+requires:
+ min-version: 8
+
+pcap: ../websocket-ping/input.pcap
+
+args:
+  - -k none --set stream.inline=true
+
+checks:
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      pcap_cnt: 8
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      pcap_cnt: 11


### PR DESCRIPTION
Ticket: [#7513](https://redmine.openinfosecfoundation.org/issues/7513)

Description:
- add test to check enum with negated strings

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7513

Suricata PR: https://github.com/OISF/suricata/pull/12453
