### PR TITLE
detect/integers: test enum with negated strings - v2

### DIFF
--- a/tests/websocket-ping/test.rules
+++ b/tests/websocket-ping/test.rules
@@ -1,0 +1,2 @@
+alert websocket any any -> any any (msg:"There is no pong opcode in this packet"; websocket.opcode:!pong; sid:1;)
+alert websocket any any -> any any (msg:"There is no ping opcode in this packet"; websocket.opcode:!ping; sid:2;)

--- a/tests/websocket-ping/test.yaml
+++ b/tests/websocket-ping/test.yaml
@@ -2,16 +2,18 @@ requires:
   min-version: 8
 
 args:
-- -k none
+- -k none --set stream.inline=true
 
 checks:
 - filter:
     count: 1
     match:
       event_type: websocket
-      websocket.opcode: ping
+      websocket.opcode: ping    # ping is not pong
+      pcap_cnt: 8
 - filter:
     count: 1
     match:
       event_type: websocket
-      websocket.opcode: pong
+      websocket.opcode: pong    # pong is not ping
+      pcap_cnt: 11


### PR DESCRIPTION
Ticket: [#7513](https://redmine.openinfosecfoundation.org/issues/7513)

Description:
- add test to check enum with negated strings

Changes:
- move tests to file ``websocket-ping``

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7513

Suricata PR:
Previous PR: https://github.com/OISF/suricata-verify/pull/2250 
