### PR TITLE
detect/integers: test enum with negated strings - v3

### DIFF
--- a/tests/websocket-ping/test.rules
+++ b/tests/websocket-ping/test.rules
@@ -1,0 +1,5 @@
+alert websocket any any -> any any (msg:"There is no text opcode in this packet"; websocket.opcode:!text; sid:1;)
+alert websocket any any -> any any (msg:"There is no ping opcode in this packet"; websocket.opcode:!ping; sid:2;)
+
+# should not match for pcap_cnt 11
+alert websocket any any -> any any (msg:"There is no pong opcode in this packet"; websocket.opcode:!pong; sid:3;)

--- a/tests/websocket-ping/test.yaml
+++ b/tests/websocket-ping/test.yaml
@@ -2,7 +2,7 @@ requires:
   min-version: 8
 
 args:
-- -k none
+- -k none --set stream.inline=true
 
 checks:
 - filter:
@@ -15,3 +15,24 @@ checks:
     match:
       event_type: websocket
       websocket.opcode: pong
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      alert.signature_id: 1
+      websocket.opcode: ping
+      pcap_cnt: 8
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      alert.signature_id: 2
+      websocket.opcode: pong
+      pcap_cnt: 11
+- filter:
+    count: 0
+    match:
+      event_type: alert
+      alert.signature_id: 3
+      websocket.opcode: pong
+      pcap_cnt: 11


### PR DESCRIPTION
Ticket: [#7513](https://redmine.openinfosecfoundation.org/issues/7513)

Description:
- add test to check enum with negated strings

Changes:
- add checks for ``event_type: alert``: [line 18](https://github.com/OISF/suricata-verify/pull/2271/commits/79979a2395e250c0cc57a8cf440e58d4a78d6c69#diff-708936184cbaaa7686681956a7dc9817d819214c267ae35ce70bf96e07d5d365R18), [line 25](https://github.com/OISF/suricata-verify/pull/2271/commits/79979a2395e250c0cc57a8cf440e58d4a78d6c69#diff-708936184cbaaa7686681956a7dc9817d819214c267ae35ce70bf96e07d5d365R25)
- add check for rule that should not alert: [line 32](https://github.com/OISF/suricata-verify/pull/2271/commits/79979a2395e250c0cc57a8cf440e58d4a78d6c69#diff-708936184cbaaa7686681956a7dc9817d819214c267ae35ce70bf96e07d5d365R32)
- use `!text` instead of `!pong`: [line 1](https://github.com/OISF/suricata-verify/pull/2271/commits/79979a2395e250c0cc57a8cf440e58d4a78d6c69#diff-aabb0f6e9029da0f2481aa14a826d8aede3803095721f3d3944ed717e66906ddR1)
- add rule that should not alert: [line 5](https://github.com/OISF/suricata-verify/pull/2271/commits/79979a2395e250c0cc57a8cf440e58d4a78d6c69#diff-aabb0f6e9029da0f2481aa14a826d8aede3803095721f3d3944ed717e66906ddR5)

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7513

Suricata PR: https://github.com/OISF/suricata/pull/12516
Previous PR: https://github.com/OISF/suricata-verify/pull/2257 
