### PR TITLE
config/ftp: Test behavior w/invalid values

### DIFF
--- a/tests/ftp/ftp-invalid-config/README.md
+++ b/tests/ftp/ftp-invalid-config/README.md
@@ -1,0 +1,4 @@
+# Description
+
+Test FTP config parsing warning messages when there are invalid values.
+Cf https://redmine.openinfosecfoundation.org/issues/4082

--- a/tests/ftp/ftp-invalid-config/test.yaml
+++ b/tests/ftp/ftp-invalid-config/test.yaml
@@ -1,0 +1,20 @@
+requires:
+  min-version: 8
+pcap: false
+
+args:
+  - -T
+  - --set app-layer.protocols.ftp.memcap=suricata
+  - --set app-layer.protocols.ftp.max-tx=suricata
+  - --set app-layer.protocols.ftp.max-line-length=suricata
+
+checks:
+    - shell:
+        args: grep "Warning.*ftp.*Invalid value.*ftp.memcap" suricata.log | wc -l | xargs
+        expect: 1
+    - shell:
+        args: grep "Warning.*ftp.*Invalid value.*ftp.max-tx" suricata.log | wc -l | xargs
+        expect: 1
+    - shell:
+        args: grep "Warning.*ftp.*Invalid value.*ftp.max-line-length" suricata.log | wc -l | xargs
+        expect: 1


### PR DESCRIPTION
Issue: 4082

Test the FTP config logic when there are invalid values for
- memcap
- max-tx
- max-line-len

Ensure that a warning message is displayed


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
