### PR TITLE
detect: add test for ldap.responses.result_code - v1

### DIFF
--- a/tests/detect-ldap-result/README.md
+++ b/tests/detect-ldap-result/README.md
@@ -1,0 +1,5 @@
+Test ldap.responses.result_code keyword.
+
+PCAP from ../ldap-search/ldap.pcap
+
+Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7532

--- a/tests/detect-ldap-result/test.rules
+++ b/tests/detect-ldap-result/test.rules
@@ -1,0 +1,1 @@
+alert tcp any any -> any any (msg:"Test LDAP result code"; ldap.responses.result_code:unavailable; sid:1;)

--- a/tests/detect-ldap-result/test.yaml
+++ b/tests/detect-ldap-result/test.yaml
@@ -1,0 +1,18 @@
+requires:
+  min-version: 8
+
+args:
+  - -k none
+  - --set stream.midstream=true
+
+pcap: ../ldap-unsolicited/ldap.pcap
+
+checks:
+  - filter:
+      count: 1
+      match:
+        pcap_cnt: 2
+        event_type: alert
+        ldap.responses[0].operation: extended_response
+        ldap.responses[0].extended_response.result_code: "unavailable"
+        alert.signature_id: 1


### PR DESCRIPTION
Ticket: [#7532](https://redmine.openinfosecfoundation.org/issues/7532)

Description:
- Add S-V test for  ``ldap.responses.result_code`` keyword

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7532
Suricata PR: https://github.com/OISF/suricata/pull/12555
