### PR TITLE
detect: add test for LDAPDN keywords - v4

### DIFF
--- a/tests/detect-ldap-dn/README.md
+++ b/tests/detect-ldap-dn/README.md
@@ -1,4 +1,5 @@
-Test ldap.request.dn keyword.
+Test ldap.request.dn and
+ldap.responses.dn keywords.
 
 PCAP from ../ldap-search/ldap.pcap
 

--- a/tests/detect-ldap-dn/README.md
+++ b/tests/detect-ldap-dn/README.md
@@ -1,0 +1,5 @@
+Test ldap.request.dn keyword.
+
+PCAP from ../ldap-search/ldap.pcap
+
+Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7471

--- a/tests/detect-ldap-dn/test.rules
+++ b/tests/detect-ldap-dn/test.rules
@@ -1,1 +1,2 @@
 alert ldap any any -> any any (msg:"Test ldap request dn"; ldap.request.dn; content:"dc=example,dc=com"; startswith; endswith; sid:1;)
+alert ldap any any -> any any (msg:"Test ldap responses dn"; ldap.responses.dn; content:"dc=example,dc=com"; startswith; endswith; sid:2;)

--- a/tests/detect-ldap-dn/test.rules
+++ b/tests/detect-ldap-dn/test.rules
@@ -1,0 +1,1 @@
+alert ldap any any -> any any (msg:"Test ldap request dn"; ldap.request.dn; content:"dc=example,dc=com"; startswith; endswith; sid:1;)

--- a/tests/detect-ldap-dn/test.yaml
+++ b/tests/detect-ldap-dn/test.yaml
@@ -15,3 +15,11 @@ checks:
         ldap.request.operation: search_request
         ldap.request.search_request.base_object: dc=example,dc=com
         alert.signature_id: 1
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        pcap_cnt: 6
+        ldap.responses[0].operation: search_result_entry
+        ldap.responses[0].search_result_entry.base_object: dc=example,dc=com
+        alert.signature_id: 2

--- a/tests/detect-ldap-dn/test.yaml
+++ b/tests/detect-ldap-dn/test.yaml
@@ -1,0 +1,17 @@
+requires:
+  min-version: 8
+
+pcap: ../ldap-search/ldap.pcap
+
+args:
+  - -k none --set stream.inline=true
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        pcap_cnt: 4
+        ldap.request.operation: search_request
+        ldap.request.search_request.base_object: dc=example,dc=com
+        alert.signature_id: 1


### PR DESCRIPTION
Ticket: [#7471](https://redmine.openinfosecfoundation.org/issues/7471)

Description:
- Add S-V test for ``ldap.request.dn`` and ``ldap.responses.dn`` keywords

Changes:
- Rebase

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7471

Suricata PR: https://github.com/OISF/suricata/pull/12634
Previous PR: https://github.com/OISF/suricata-verify/pull/2278