### PR TITLE
Remove obsolete requires 7416 v1

### DIFF
--- a/tests/datarep-01/test.yaml
+++ b/tests/datarep-01/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - src/datasets.c
-
 args:
  - -k none
 

--- a/tests/datarep-02/test.yaml
+++ b/tests/datarep-02/test.yaml
@@ -1,12 +1,5 @@
 pcap: ../datarep-01/input.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-    - HAVE_NSS
-  files:
-    - src/datasets.c
-
 args:
  - -k none
 

--- a/tests/datarep-03-bad-reputation/test.yaml
+++ b/tests/datarep-03-bad-reputation/test.yaml
@@ -1,9 +1,4 @@
 requires:
-  features:
-    - HAVE_NSS
-  files:
-    - src/datasets.c
-
   # No pcap required.
   pcap: false
 

--- a/tests/datasets-01/test.yaml
+++ b/tests/datasets-01/test.yaml
@@ -1,9 +1,5 @@
 pcap: ../flowbit-oring/input.pcap
 
-requires:
-  files:
-    - src/datasets.c
-
 args:
   - --data-dir=${OUTPUT_DIR}
 

--- a/tests/datasets-02-load/test.yaml
+++ b/tests/datasets-02-load/test.yaml
@@ -1,11 +1,5 @@
 pcap: ../flowbit-oring/input.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - src/datasets.c
-
 args:
  - -k none
 

--- a/tests/datasets-03-set/test.yaml
+++ b/tests/datasets-03-set/test.yaml
@@ -1,11 +1,5 @@
 pcap: ../datasets-05-state/input.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - src/datasets.c
-
 args:
  - -k none
 

--- a/tests/datasets-04-http-dns/test.yaml
+++ b/tests/datasets-04-http-dns/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - src/datasets.c
-
 args:
  - -k none
 

--- a/tests/datasets-05-state/test.yaml
+++ b/tests/datasets-05-state/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - src/datasets.c
-
 args:
   - --data-dir=${OUTPUT_DIR}
 

--- a/tests/datasets-06-state-long/test.yaml
+++ b/tests/datasets-06-state-long/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - src/datasets.c
-
 args:
   - --data-dir=${OUTPUT_DIR}
 

--- a/tests/datasets-07-state-ip/test.yaml
+++ b/tests/datasets-07-state-ip/test.yaml
@@ -1,11 +1,5 @@
 pcap: ../datasets-05-state/input.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - src/detect-ipaddr.c
-
 args:
   - --data-dir=${OUTPUT_DIR}
 

--- a/tests/datasets-08-state-ipv6/test.yaml
+++ b/tests/datasets-08-state-ipv6/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - src/detect-ipaddr.c
-
 args:
   - --no-random --data-dir=${OUTPUT_DIR}
 

--- a/tests/datasets-09-load/test.yaml
+++ b/tests/datasets-09-load/test.yaml
@@ -1,11 +1,5 @@
 pcap: ../flowbit-oring/input.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - src/detect-ipaddr.c
-
 args:
  - -k none
 

--- a/tests/datasets-1m-StringSets/test.yaml
+++ b/tests/datasets-1m-StringSets/test.yaml
@@ -1,11 +1,5 @@
 pcap: ../flowbit-oring/input.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - src/datasets.c
-
 args:
  - -k none
 

--- a/tests/datasets-invalid-encoding/test.yaml
+++ b/tests/datasets-invalid-encoding/test.yaml
@@ -1,7 +1,3 @@
-requires:
-  files:
-    - src/datasets.c
-
 pcap: ../flowbit-oring/input.pcap
 
 args:

--- a/tests/datasets-pcrexform/test.yaml
+++ b/tests/datasets-pcrexform/test.yaml
@@ -1,9 +1,5 @@
 requires:
   min-version: 6
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - src/datasets.c
 
 args:
  - -k none  --no-random --data-dir=${OUTPUT_DIR}

--- a/tests/datasets/datarep-bad-datarep-string/test.yaml
+++ b/tests/datasets/datarep-bad-datarep-string/test.yaml
@@ -1,11 +1,5 @@
 pcap: ../../flowbit-oring/input.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - src/datasets.c
-
 args:
  - -k none
 

--- a/tests/datasets/datarep-bad-datarep-value/test.yaml
+++ b/tests/datasets/datarep-bad-datarep-value/test.yaml
@@ -1,11 +1,5 @@
 pcap: ../../flowbit-oring/input.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - src/datasets.c
-
 args:
  - -k none
 

--- a/tests/detect-bytemath-add-04/test.yaml
+++ b/tests/detect-bytemath-add-04/test.yaml
@@ -1,9 +1,5 @@
 pcap: ../detect-bytemath-01/input.pcap
 
-requires:
-   files:
-       - src/detect-bytemath.c
-
 checks:
   - filter:
       count: 1

--- a/tests/detect-bytemath-div-01/test.yaml
+++ b/tests/detect-bytemath-div-01/test.yaml
@@ -1,9 +1,5 @@
 pcap: ../detect-bytemath-01/input.pcap
 
-requires:
-   files:
-       - src/detect-bytemath.c
-
 checks:
   - filter:
       count: 0

--- a/tests/detect-bytemath-sub-03/test.yaml
+++ b/tests/detect-bytemath-sub-03/test.yaml
@@ -1,8 +1,5 @@
 pcap: ../detect-bytemath-01/input.pcap
 
-requires:
-   files:
-       - src/detect-bytemath.c
 
 checks:
   - filter:

--- a/tests/detect-pcrexform-01/test.yaml
+++ b/tests/detect-pcrexform-01/test.yaml
@@ -1,8 +1,3 @@
-requires:
-
-  files:
-    - src/detect-transform-pcrexform.c
-
 checks:
   - filter:
       count: 1

--- a/tests/detect-pcrexform-02/test.yaml
+++ b/tests/detect-pcrexform-02/test.yaml
@@ -1,10 +1,5 @@
 pcap: ../detect-pcrexform-01/input.pcap
 
-requires:
-
-  files:
-    - src/detect-transform-pcrexform.c
-
 exit-code: 1
 
 checks:

--- a/tests/detect-pcrexform-04/test.yaml
+++ b/tests/detect-pcrexform-04/test.yaml
@@ -1,9 +1,5 @@
 pcap: ../detect-pcrexform-01/input.pcap
 
-requires:
-
-  files:
-    - src/detect-transform-pcrexform.c
 
 exit-code: 1
 

--- a/tests/detect-pcrexform-05/test.yaml
+++ b/tests/detect-pcrexform-05/test.yaml
@@ -1,10 +1,5 @@
 pcap: ../detect-pcrexform-01/input.pcap
 
-requires:
-
-  files:
-    - src/detect-transform-pcrexform.c
-
 checks:
   - filter:
       count: 1

--- a/tests/detect-pcrexform-06/test.yaml
+++ b/tests/detect-pcrexform-06/test.yaml
@@ -1,10 +1,5 @@
 pcap: ../detect-pcrexform-01/input.pcap
 
-requires:
-
-  files:
-    - src/detect-transform-pcrexform.c
-
 checks:
   - filter:
       count: 0

--- a/tests/eve-metadata-01-alert/test.yaml
+++ b/tests/eve-metadata-01-alert/test.yaml
@@ -1,8 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - src/output-json-metadata.c
 args:
 - --set stream.midstream=true
 

--- a/tests/eve-metadata-02-pass/test.yaml
+++ b/tests/eve-metadata-02-pass/test.yaml
@@ -1,10 +1,5 @@
 pcap: ../eve-metadata-01-alert/80000000-037-PTP_Example_IPv4_HTTP_Session-PUBLIC-tp-01-TEST1.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - src/output-json-metadata.c
 args:
 - --set stream.midstream=true
 

--- a/tests/eve-metadata-03-noalert/test.yaml
+++ b/tests/eve-metadata-03-noalert/test.yaml
@@ -1,10 +1,5 @@
 pcap: ../eve-metadata-01-alert/80000000-037-PTP_Example_IPv4_HTTP_Session-PUBLIC-tp-01-TEST1.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - src/output-json-metadata.c
 args:
 - --set stream.midstream=true
 

--- a/tests/eve-metadata-04-flowvar/test.yaml
+++ b/tests/eve-metadata-04-flowvar/test.yaml
@@ -1,10 +1,5 @@
 pcap: ../eve-metadata-01-alert/80000000-037-PTP_Example_IPv4_HTTP_Session-PUBLIC-tp-01-TEST1.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - src/output-json-metadata.c
 args:
 - --set stream.midstream=true
 

--- a/tests/exception-policy-applayer-01/test.yaml
+++ b/tests/exception-policy-applayer-01/test.yaml
@@ -1,8 +1,6 @@
 requires:
   features:
     - DEBUG
-  files:
-    - src/util-exception-policy.c
 pcap: ../tls/tls-certs-alert/input.pcap
 args:
 - --simulate-ips

--- a/tests/exception-policy-stream-reassembly-memcap-01/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-01/test.yaml
@@ -2,8 +2,6 @@ requires:
   min-version: 7
   features:
     - DEBUG
-  files:
-    - src/util-exception-policy.c
 pcap: ../tls/tls-certs-alert/input.pcap
 args:
 - --simulate-ips

--- a/tests/exception-policy-stream-reassembly-memcap-02/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-02/test.yaml
@@ -1,8 +1,6 @@
 requires:
   features:
     - DEBUG
-  files:
-    - src/util-exception-policy.c
 pcap: ../tls/tls-certs-alert/input.pcap
 args:
 - --simulate-ips

--- a/tests/exception-policy-stream-reassembly-memcap-03/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-03/test.yaml
@@ -1,8 +1,6 @@
 requires:
   features:
     - DEBUG
-  files:
-    - src/util-exception-policy.c
 pcap: ../tls/tls-certs-alert/input.pcap
 args:
 - --simulate-ips

--- a/tests/exception-policy-stream-reassembly-memcap-04/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-04/test.yaml
@@ -2,8 +2,6 @@ requires:
   min-version: 7
   features:
     - DEBUG
-  files:
-    - src/util-exception-policy.c
 pcap: ../tls/tls-certs-alert/input.pcap
 args:
 - --simulate-ips

--- a/tests/exception-policy-stream-reassembly-memcap-05/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-05/test.yaml
@@ -2,8 +2,6 @@ requires:
   min-version: 7
   features:
     - DEBUG
-  files:
-    - src/util-exception-policy.c
 pcap: ../tls/tls-certs-alert/input.pcap
 args:
 - --simulate-ips

--- a/tests/exception-policy-stream-reassembly-memcap-06/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-06/test.yaml
@@ -1,8 +1,6 @@
 requires:
   features:
     - DEBUG
-  files:
-    - src/util-exception-policy.c
 pcap: ../tls/tls-certs-alert/input.pcap
 args:
 - --simulate-ips

--- a/tests/exception-policy-stream-ssn-memcap-01/test.yaml
+++ b/tests/exception-policy-stream-ssn-memcap-01/test.yaml
@@ -1,8 +1,6 @@
 requires:
   features:
     - DEBUG
-  files:
-    - src/util-exception-policy.c
 pcap: ../tls/tls-certs-alert/input.pcap
 args:
 - --simulate-ips

--- a/tests/filestore-alert-log/test.yaml
+++ b/tests/filestore-alert-log/test.yaml
@@ -3,9 +3,6 @@ pcap: ../filestore-filecontainer-http/filecontainer-http.pcap
 requires:
   features:
     - MAGIC
-    - HAVE_NSS
-  files:
-    - src/output-filestore.c
 
 checks:
 

--- a/tests/filestore-filecontainer-http/test.yaml
+++ b/tests/filestore-filecontainer-http/test.yaml
@@ -1,9 +1,6 @@
 requires:
   features:
-    - HAVE_NSS
     - MAGIC
-  files:
-    - src/output-filestore.c
 
 checks:
 

--- a/tests/filestore-filecontainer-smb/test.yaml
+++ b/tests/filestore-filecontainer-smb/test.yaml
@@ -1,10 +1,6 @@
 requires:
   features:
-    - HAVE_NSS
     - MAGIC
-    - RUST
-  files:
-    - src/output-filestore.c
 
 checks:
 

--- a/tests/filestore-filecontainer-smb1-data-offset/test.yaml
+++ b/tests/filestore-filecontainer-smb1-data-offset/test.yaml
@@ -1,10 +1,6 @@
 requires:
   features:
-    - HAVE_NSS
     - MAGIC
-    - RUST
-  files:
-    - src/output-filestore.c
 
 checks:
   - filter:

--- a/tests/filestore-filecontainer-smb1-padding/test.yaml
+++ b/tests/filestore-filecontainer-smb1-padding/test.yaml
@@ -1,10 +1,6 @@
 requires:
   features:
-    - HAVE_NSS
     - MAGIC
-    - RUST
-  files:
-    - src/output-filestore.c
   min-version: 7
 
 args:

--- a/tests/filestore-v2.1-forced/test.yaml
+++ b/tests/filestore-v2.1-forced/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_NSS
-  files:
-    - src/output-filestore.c
-
 checks:
 
   - shell:

--- a/tests/filestore-v2.2-forced-with-open-files/test.yaml
+++ b/tests/filestore-v2.2-forced-with-open-files/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_NSS
-  files:
-    - src/output-filestore.c
-
 pcap: ../filestore-v2.1-forced/suricata-update-pdf.pcap
 
 checks:

--- a/tests/filestore-v2.3-fserror/test.yaml
+++ b/tests/filestore-v2.3-fserror/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_NSS
-  files:
-    - src/output-filestore.c
-
 skip:
   - uid: 0
     msg: "Test fails when run as root"

--- a/tests/filestore-v2.4-forced-with-meta/test.yaml
+++ b/tests/filestore-v2.4-forced-with-meta/test.yaml
@@ -1,10 +1,3 @@
-requires:
-  features:
-    - HAVE_NSS
-    - HAVE_LIBJANSSON
-  files:
-    - src/output-filestore.c
-
 pcap: ../filestore-v2.1-forced/suricata-update-pdf.pcap
 
 checks:

--- a/tests/filestore-v2.5-both-enabled/test.yaml
+++ b/tests/filestore-v2.5-both-enabled/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_NSS
-  files:
-    - src/output-filestore.c
-
 pcap: ../filestore-v2.1-forced/suricata-update-pdf.pcap
 
 # For this test we expect an exit code.

--- a/tests/filestore-v2.6-stream-depth/test.yaml
+++ b/tests/filestore-v2.6-stream-depth/test.yaml
@@ -1,9 +1,4 @@
 requires:
-  features:
-    - HAVE_LIBJANSSON
-    - HAVE_NSS
-  files:
-    - src/output-filestore.c
   min-version: 5.0.0
 
 args:

--- a/tests/filestore-v2.8-stream-depth/test.yaml
+++ b/tests/filestore-v2.8-stream-depth/test.yaml
@@ -1,8 +1,4 @@
 requires:
-  features:
-    - HAVE_NSS
-  files:
-    - src/output-filestore.c
   min-version: 6
 
 args:

--- a/tests/filestore-v2.9-stream-depth/test.yaml
+++ b/tests/filestore-v2.9-stream-depth/test.yaml
@@ -1,8 +1,4 @@
 requires:
-  features:
-    - HAVE_NSS
-  files:
-    - src/output-filestore.c
   min-version: 6
 
 args:

--- a/tests/ikev1-rules/test.yaml
+++ b/tests/ikev1-rules/test.yaml
@@ -1,8 +1,4 @@
 requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/ike/parser.rs
   min-version: 7.0.0
 
 checks:

--- a/tests/ikev1-transforms/test.yaml
+++ b/tests/ikev1-transforms/test.yaml
@@ -1,11 +1,6 @@
 pcap: ../ikev1-rules/ikev1-isakmp-main-mode.pcap
 
 requires:
-  features:
-    - HAVE_NSS
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/ike/parser.rs
   min-version: 7.0.0
 
 checks:

--- a/tests/ikev1/test.yaml
+++ b/tests/ikev1/test.yaml
@@ -1,10 +1,6 @@
 pcap: ../ikev1-rules/ikev1-isakmp-main-mode.pcap
 
 requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/ike/parser.rs
   min-version: 7.0.0
 
 checks:

--- a/tests/ja4-rules-disabled/test.yaml
+++ b/tests/ja4-rules-disabled/test.yaml
@@ -1,7 +1,5 @@
 requires:
   min-version: 7.0.6
-  files:
-    - rust/src/ja4.rs
 
 args:
   - -k none --set app-layer.protocols.tls.ja4-fingerprints=no

--- a/tests/mac-eve-multiple-disabled/test.yaml
+++ b/tests/mac-eve-multiple-disabled/test.yaml
@@ -1,7 +1,5 @@
 requires:
   min-version: 6.0.0
-  files:
-    - src/util-macset.c
 
 args:
   - -k none

--- a/tests/mac-eve-multiple/test.yaml
+++ b/tests/mac-eve-multiple/test.yaml
@@ -2,8 +2,6 @@ pcap: ../mac-eve-multiple-disabled/multi_mac.pcap
 
 requires:
   min-version: 6.0.0
-  files:
-    - src/util-macset.c
 
 args:
   - -k none

--- a/tests/mac-eve-single-disabled/test.yaml
+++ b/tests/mac-eve-single-disabled/test.yaml
@@ -1,7 +1,5 @@
 requires:
   min-version: 6.0.0
-  files:
-    - src/util-macset.c
 
 args:
   - -k none

--- a/tests/mac-eve-single/test.yaml
+++ b/tests/mac-eve-single/test.yaml
@@ -2,8 +2,6 @@ pcap: ../mac-eve-single-disabled/test.pcap
 
 requires:
   min-version: 6.0.0
-  files:
-    - src/util-macset.c
 
 args:
   - -k none

--- a/tests/mqtt-binary-message/test.yaml
+++ b/tests/mqtt-binary-message/test.yaml
@@ -1,11 +1,5 @@
 pcap: ../mqtt-pub-rules/mqtt5_pub_jpeg.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt-events-invalid-qos/test.yaml
+++ b/tests/mqtt-events-invalid-qos/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt-events-missing-connect/test.yaml
+++ b/tests/mqtt-events-missing-connect/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt-events-unassigned-msgtype/test.yaml
+++ b/tests/mqtt-events-unassigned-msgtype/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt-events-unintroduced/test.yaml
+++ b/tests/mqtt-events-unintroduced/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt-limit-1/test.yaml
+++ b/tests/mqtt-limit-1/test.yaml
@@ -1,11 +1,5 @@
 pcap: ../mqtt-limit-2/input.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt-limit-2/test.yaml
+++ b/tests/mqtt-limit-2/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt-limit-3/test.yaml
+++ b/tests/mqtt-limit-3/test.yaml
@@ -1,11 +1,5 @@
 pcap: ../mqtt-limit-2/input.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt-limit-log-fail/test.yaml
+++ b/tests/mqtt-limit-log-fail/test.yaml
@@ -2,8 +2,6 @@ pcap: ../mqtt-limit-2/input.pcap
 
 requires:
   min-version: 8
-  files:
-    - rust/src/mqtt/parser.rs
 
 args:
   - -k none

--- a/tests/mqtt-ping/test.yaml
+++ b/tests/mqtt-ping/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt-pub-rules/test.yaml
+++ b/tests/mqtt-pub-rules/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt-sub-rules/test.yaml
+++ b/tests/mqtt-sub-rules/test.yaml
@@ -1,11 +1,5 @@
 pcap: ../mqtt5-sub-userpass/input.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt-unsub-rules/test.yaml
+++ b/tests/mqtt-unsub-rules/test.yaml
@@ -1,11 +1,5 @@
 pcap: ../mqtt5-unsub-userpass/input.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt31-pub-qos1/test.yaml
+++ b/tests/mqtt31-pub-qos1/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt31-pub-qos2/test.yaml
+++ b/tests/mqtt31-pub-qos2/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt31-pub-userpass-auto-clientid/test.yaml
+++ b/tests/mqtt31-pub-userpass-auto-clientid/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt31-pub-userpass/test.yaml
+++ b/tests/mqtt31-pub-userpass/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt31-sub-userpass/test.yaml
+++ b/tests/mqtt31-sub-userpass/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt31-unsub-qos1/test.yaml
+++ b/tests/mqtt31-unsub-qos1/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt31-unsub-qos2/test.yaml
+++ b/tests/mqtt31-unsub-qos2/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt31-unsub-userpass/test.yaml
+++ b/tests/mqtt31-unsub-userpass/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt311-pub-qos1/test.yaml
+++ b/tests/mqtt311-pub-qos1/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt311-pub-qos2/test.yaml
+++ b/tests/mqtt311-pub-qos2/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt311-pub-userpass-auto-clientid/test.yaml
+++ b/tests/mqtt311-pub-userpass-auto-clientid/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt311-pub-userpass/test.yaml
+++ b/tests/mqtt311-pub-userpass/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt311-sub-userpass/test.yaml
+++ b/tests/mqtt311-sub-userpass/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt311-unsub-qos1/test.yaml
+++ b/tests/mqtt311-unsub-qos1/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt311-unsub-qos2/test.yaml
+++ b/tests/mqtt311-unsub-qos2/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt311-unsub-userpass/test.yaml
+++ b/tests/mqtt311-unsub-userpass/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt5-excessiveproplen/test.yaml
+++ b/tests/mqtt5-excessiveproplen/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt5-pub-mosquittoprops/test.yaml
+++ b/tests/mqtt5-pub-mosquittoprops/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt5-pub-qos1/test.yaml
+++ b/tests/mqtt5-pub-qos1/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt5-pub-qos2/test.yaml
+++ b/tests/mqtt5-pub-qos2/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt5-pub-userpass-auto-clientid/test.yaml
+++ b/tests/mqtt5-pub-userpass-auto-clientid/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt5-pub-userpass/test.yaml
+++ b/tests/mqtt5-pub-userpass/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt5-sub-customauth/test.yaml
+++ b/tests/mqtt5-sub-customauth/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt5-sub-mosquittoprops/test.yaml
+++ b/tests/mqtt5-sub-mosquittoprops/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt5-sub-userpass/test.yaml
+++ b/tests/mqtt5-sub-userpass/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt5-unsub-qos1/test.yaml
+++ b/tests/mqtt5-unsub-qos1/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt5-unsub-qos2/test.yaml
+++ b/tests/mqtt5-unsub-qos2/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/mqtt5-unsub-userpass/test.yaml
+++ b/tests/mqtt5-unsub-userpass/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/mqtt/parser.rs
-
 args:
   - -k none
 

--- a/tests/nfs3-readdirplus/test.yaml
+++ b/tests/nfs3-readdirplus/test.yaml
@@ -1,7 +1,5 @@
 requires:
   min-version: 6.0
-  files:
-    - rust/src/nfs/nfs3.rs
 
 args:
 - -k none

--- a/tests/output-eve-anomaly-01/test.yaml
+++ b/tests/output-eve-anomaly-01/test.yaml
@@ -1,12 +1,5 @@
 pcap: ../output-eve-anomaly-packethdr/anomaly.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-
-  files:
-    - src/output-json-anomaly.c
-
 args:
   - -k none
 

--- a/tests/output-eve-anomaly-02/test.yaml
+++ b/tests/output-eve-anomaly-02/test.yaml
@@ -1,10 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-
-  files:
-    - src/output-json-anomaly.c
-
 args:
   - -k none
 

--- a/tests/output-eve-anomaly-03/test.yaml
+++ b/tests/output-eve-anomaly-03/test.yaml
@@ -1,12 +1,5 @@
 pcap: ../output-eve-anomaly-02/input.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-
-  files:
-    - src/output-json-anomaly.c
-
 args:
   - -k none
 

--- a/tests/output-eve-anomaly-packethdr/test.yaml
+++ b/tests/output-eve-anomaly-packethdr/test.yaml
@@ -1,10 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-
-  files:
-    - src/output-json-anomaly.c
-
 args:
   - -k none
 

--- a/tests/output-eve-ftp/test.yaml
+++ b/tests/output-eve-ftp/test.yaml
@@ -1,12 +1,5 @@
 pcap: ../bug-3519/input.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-
-  files:
-    - src/output-json-ftp.c
-
 checks:
   - filter:
       count: 8

--- a/tests/output-eve-rdp-01/test.yaml
+++ b/tests/output-eve-rdp-01/test.yaml
@@ -1,11 +1,5 @@
 pcap: ../rdp-protocol/RDP-003.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/rdp/parser.rs
-
 checks:
 
   - filter:

--- a/tests/rdp-protocol/test.yaml
+++ b/tests/rdp-protocol/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/rdp/parser.rs
-
 checks:
 
   # Check if rdp is detected and some protocol specific details are in the output

--- a/tests/rfb-protocol-3.3/test.yaml
+++ b/tests/rfb-protocol-3.3/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/rfb/parser.rs
-
 checks:
 
   - filter:

--- a/tests/rfb-protocol-3.7/test.yaml
+++ b/tests/rfb-protocol-3.7/test.yaml
@@ -1,11 +1,5 @@
 pcap: ../rfb-rules/00-vnc-openwall-3.7.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/rfb/parser.rs
-
 checks:
 
   - filter:

--- a/tests/rfb-protocol-3.8/test.yaml
+++ b/tests/rfb-protocol-3.8/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/rfb/parser.rs
-
 checks:
 
   - filter:

--- a/tests/rfb-rules/test.yaml
+++ b/tests/rfb-rules/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-  files:
-    - rust/src/rfb/parser.rs
-
 checks:
 
   - filter:

--- a/tests/smb1-01/test.yaml
+++ b/tests/smb1-01/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-    - RUST
-  files:
-    - rust/src/smb/smb.rs
 args:
 - --set stream.midstream=true
 

--- a/tests/smb1-02/test.yaml
+++ b/tests/smb1-02/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-    - RUST
-  files:
-    - rust/src/smb/smb.rs
 args:
 - --set stream.reassembly.depth=0
 

--- a/tests/smb1-03-midstream/test.yaml
+++ b/tests/smb1-03-midstream/test.yaml
@@ -1,9 +1,4 @@
 requires:
-  features:
-    - HAVE_LIBJANSSON
-    - RUST
-  files:
-    - rust/src/smb/smb.rs
   min-version: 5.0.0
 
 args:

--- a/tests/smb2-01/test.yaml
+++ b/tests/smb2-01/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-    - RUST
-  files:
-    - rust/src/smb/smb.rs
 args:
 - --set stream.reassembly.depth=0
 - -k none

--- a/tests/smb2-02/test.yaml
+++ b/tests/smb2-02/test.yaml
@@ -1,11 +1,5 @@
 pcap: ../smb2-03-rule/smb2.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-    - RUST
-  files:
-    - rust/src/smb/smb.rs
 args:
 - --set stream.reassembly.depth=0
 

--- a/tests/smb2-03-rule/test.yaml
+++ b/tests/smb2-03-rule/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-    - RUST
-  files:
-    - rust/src/smb/smb.rs
 args:
 - --set stream.reassembly.depth=0
 

--- a/tests/smb2-04/test.yaml
+++ b/tests/smb2-04/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-    - RUST
-  files:
-    - rust/src/smb/smb.rs
 args:
 - --set stream.reassembly.depth=0
 - --set stream.midstream=true

--- a/tests/smb2-05/test.yaml
+++ b/tests/smb2-05/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-    - RUST
-  files:
-    - rust/src/smb/smb.rs
 args:
 - --set stream.reassembly.depth=0
 - --set stream.midstream=true

--- a/tests/smb2-06/test.yaml
+++ b/tests/smb2-06/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-    - RUST
-  files:
-    - rust/src/smb/smb.rs
 args:
 - --set stream.reassembly.depth=0
 - --set stream.midstream=true

--- a/tests/smb2-07/test.yaml
+++ b/tests/smb2-07/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-    - RUST
-  files:
-    - rust/src/smb/smb.rs
 args:
 - --set stream.reassembly.depth=0
 - --set stream.midstream=true

--- a/tests/smb2-08-rule/test.yaml
+++ b/tests/smb2-08-rule/test.yaml
@@ -1,12 +1,5 @@
 pcap: ../smb2-03-rule/smb2.pcap
 
-requires:
-  features:
-    - HAVE_LIBJANSSON
-    - RUST
-  files:
-    - rust/src/smb/smb.rs
-    - src/detect-smb-ntlmssp.c
 args:
 - --set stream.reassembly.depth=0
 

--- a/tests/smb3-01/test.yaml
+++ b/tests/smb3-01/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-    - RUST
-  files:
-    - rust/src/smb/smb.rs
 args:
 - --set stream.reassembly.depth=0
 - --set stream.midstream=true

--- a/tests/smb3-02-midstream/test.yaml
+++ b/tests/smb3-02-midstream/test.yaml
@@ -1,9 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-    - RUST
-  files:
-    - rust/src/smb/smb.rs
 args:
 - --set stream.reassembly.depth=0
 - --set stream.midstream=true

--- a/tests/smb3-03-midstream/test.yaml
+++ b/tests/smb3-03-midstream/test.yaml
@@ -1,9 +1,4 @@
 requires:
-  features:
-    - HAVE_LIBJANSSON
-    - RUST
-  files:
-    - rust/src/smb/smb.rs
   min-version: 5.0.0
 args:
 - --set stream.reassembly.depth=0

--- a/tests/smtp-raw-extraction/test.yaml
+++ b/tests/smtp-raw-extraction/test.yaml
@@ -1,9 +1,5 @@
 requires:
   min-version: 5.0.0
-  features:
-    - HAVE_NSS
-  files:
-    - src/output-filestore.c
 
 checks:
 

--- a/tests/snmp-v2c-get/test.yaml
+++ b/tests/snmp-v2c-get/test.yaml
@@ -1,10 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-    - RUST
-  files:
-    - rust/src/snmp/snmp.rs
-
 args:
   - -k none
 

--- a/tests/snmp-v3-encrypted/test.yaml
+++ b/tests/snmp-v3-encrypted/test.yaml
@@ -1,10 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-    - RUST
-  files:
-    - rust/src/snmp/snmp.rs
-
 args:
   - -k none
 

--- a/tests/snmp-v3-unauth/test.yaml
+++ b/tests/snmp-v3-unauth/test.yaml
@@ -1,10 +1,3 @@
-requires:
-  features:
-    - HAVE_LIBJANSSON
-    - RUST
-  files:
-    - rust/src/snmp/snmp.rs
-
 args:
   - -k none
 

--- a/tests/tcp-fastopen-10-syn-data-ignore/test.yaml
+++ b/tests/tcp-fastopen-10-syn-data-ignore/test.yaml
@@ -1,7 +1,3 @@
-requires:
-  files:
-    - src/output-eve-stream.c
-
 args:
 - --simulate-ips
 #- --set stream.midstream=true

--- a/tests/tcp-fastopen-11-reject-syn-data/test.yaml
+++ b/tests/tcp-fastopen-11-reject-syn-data/test.yaml
@@ -1,7 +1,3 @@
-requires:
-  files:
-    - src/output-eve-stream.c
-
 args:
 - --simulate-ips
 - --runmode=single


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7416

Should I go one step further and remove the functionality in the code to have requires on file names ?