### PR TITLE
detect: add test for LDAP attribute keywords - v1

### DIFF
--- a/tests/detect-ldap-attribute/README.md
+++ b/tests/detect-ldap-attribute/README.md
@@ -1,0 +1,5 @@
+Test ldap.request.attribute_type keyword.
+
+PCAP from ../ldap-search/ldap.pcap
+
+Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7533

--- a/tests/detect-ldap-attribute/README.md
+++ b/tests/detect-ldap-attribute/README.md
@@ -1,4 +1,4 @@
-Test ldap.request.attribute_type keyword.
+Test ldap.request.attribute_type and ldap.responses.attribute_type keywords.
 
 PCAP from ../ldap-search/ldap.pcap
 

--- a/tests/detect-ldap-attribute/test.rules
+++ b/tests/detect-ldap-attribute/test.rules
@@ -1,0 +1,2 @@
+alert ldap any any -> any any (msg:"Test request attribute type"; ldap.request.attribute_type; content:"*"; sid:1;)
+alert ldap any any -> any any (msg:"Test request attribute type"; ldap.request.attribute_type; content:"+"; sid:2;)

--- a/tests/detect-ldap-attribute/test.rules
+++ b/tests/detect-ldap-attribute/test.rules
@@ -1,2 +1,4 @@
 alert ldap any any -> any any (msg:"Test request attribute type"; ldap.request.attribute_type; content:"*"; sid:1;)
 alert ldap any any -> any any (msg:"Test request attribute type"; ldap.request.attribute_type; content:"+"; sid:2;)
+alert ldap any any -> any any (msg:"Test responses attribute type"; ldap.responses.attribute_type; content:"objectClass"; sid:3;)
+alert ldap any any -> any any (msg:"Test responses attribute type"; ldap.responses.attribute_type; content:"dc"; sid:4;)

--- a/tests/detect-ldap-attribute/test.yaml
+++ b/tests/detect-ldap-attribute/test.yaml
@@ -1,0 +1,23 @@
+requires:
+  min-version: 8
+
+pcap: ../ldap-search/ldap.pcap
+
+args:
+  - -k none --set stream.inline=true
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ldap.request.operation: search_request
+        ldap.request.search_request.attributes[0]: "*"
+        alert.signature_id: 1
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ldap.request.operation: search_request
+        ldap.request.search_request.attributes[1]: +
+        alert.signature_id: 2

--- a/tests/detect-ldap-attribute/test.yaml
+++ b/tests/detect-ldap-attribute/test.yaml
@@ -21,3 +21,17 @@ checks:
         ldap.request.operation: search_request
         ldap.request.search_request.attributes[1]: +
         alert.signature_id: 2
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ldap.responses[0].operation: search_result_entry
+        ldap.responses[0].search_result_entry.attributes[0].type: objectClass
+        alert.signature_id: 3
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ldap.responses[0].operation: search_result_entry
+        ldap.responses[0].search_result_entry.attributes[1].type: dc
+        alert.signature_id: 4


### PR DESCRIPTION
Ticket: [#7533](https://redmine.openinfosecfoundation.org/issues/7533)

Description:
- Add S-V test for  `ldap.request.attribute_type` and `ldap.responses.attribute_type` keywords.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7533

Suricata PR: https://github.com/OISF/suricata/pull/12708