### PR TITLE
detect: backport test for midstream

### DIFF
--- a/tests/bug-7552/bug-7552-01/test.yaml
+++ b/tests/bug-7552/bug-7552-01/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 7
 
 args:
   - -k none --set stream.midstream=true


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7552

Backport of https://github.com/OISF/suricata-verify/pull/2320

The other test is not back ported as it uses ldap which is only in 8
