### PR TITLE
tests: check exception policies flow output - v4

### DIFF
--- a/tests/exception-policy-applayer-01/test.yaml
+++ b/tests/exception-policy-applayer-01/test.yaml
@@ -59,3 +59,10 @@ checks:
         event_type: stats
         stats.app_layer.error.exception_policy.drop_flow: 1
         stats.app_layer.error.exception_policy.pass_flow: 0
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "app_layer_error"
+        flow.exception_policy.triggered[0].policy: "drop_flow"

--- a/tests/exception-policy-applayer-02/test.yaml
+++ b/tests/exception-policy-applayer-02/test.yaml
@@ -48,3 +48,10 @@ checks:
         event_type: stats
         stats.app_layer.error.tls.exception_policy.pass_packet: 1
         stats.app_layer.error.tls.exception_policy.drop_packet: 0
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "app_layer_error"
+        flow.exception_policy.triggered[0].policy: "pass_packet"

--- a/tests/exception-policy-applayer-03/test.yaml
+++ b/tests/exception-policy-applayer-03/test.yaml
@@ -71,3 +71,10 @@ checks:
       event_type: stats
       stats.app_layer.error.exception_policy.pass_packet: 1
       stats.app_layer.error.exception_policy.drop_packet: 0
+- filter:
+    min-version: 8
+    count: 1
+    match:
+      event_type: flow
+      flow.exception_policy.triggered[0].target: "app_layer_error"
+      flow.exception_policy.triggered[0].policy: "pass_packet"

--- a/tests/exception-policy-default-01/suricata.yaml
+++ b/tests/exception-policy-default-01/suricata.yaml
@@ -13,6 +13,7 @@ outputs:
             alerts: yes      # log alerts that caused drops
             flows: all       # start or all: 'start' logs only a single drop
         - stats
+        - flow
   - stats:
        enabled: yes
        filename: stats.log

--- a/tests/exception-policy-default-01/test.yaml
+++ b/tests/exception-policy-default-01/test.yaml
@@ -22,3 +22,10 @@ checks:
       match:
         event_type: tls
         tls.sni: example.com
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        not-has-key: flow.exception_policy.triggered[0].target
+        not-has-key: flow.exception_policy.triggered[0].policy

--- a/tests/exception-policy-default-02/test.yaml
+++ b/tests/exception-policy-default-02/test.yaml
@@ -12,3 +12,10 @@ checks:
       count: 1
       match:
         event_type: http
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_midstream"
+        flow.exception_policy.triggered[0].policy: "ignore"

--- a/tests/exception-policy-default-03/test.yaml
+++ b/tests/exception-policy-default-03/test.yaml
@@ -36,3 +36,10 @@ checks:
       count: 0
       match:
         event_type: http
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_midstream"
+        flow.exception_policy.triggered[0].policy: "drop_flow"

--- a/tests/exception-policy-default-04/test.yaml
+++ b/tests/exception-policy-default-04/test.yaml
@@ -23,3 +23,10 @@ checks:
       count: 0
       match:
         event_type: http
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_midstream"
+        flow.exception_policy.triggered[0].policy: "ignore"

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-01/test.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-01/test.yaml
@@ -35,3 +35,10 @@ checks:
       count: 0
       match:
         event_type: http
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_midstream"
+        flow.exception_policy.triggered[0].policy: "drop_flow"

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-02/test.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-02/test.yaml
@@ -25,3 +25,10 @@ checks:
       count: 0
       match:
         event_type: http
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_midstream"
+        flow.exception_policy.triggered[0].policy: "bypass"

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-03/test.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-03/test.yaml
@@ -25,3 +25,10 @@ checks:
       count: 1
       match:
         event_type: http
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_midstream"
+        flow.exception_policy.triggered[0].policy: "ignore"

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-04/test.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-04/test.yaml
@@ -26,3 +26,10 @@ checks:
       count: 1
       match:
         event_type: http
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_midstream"
+        flow.exception_policy.triggered[0].policy: "pass_flow"

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-05/test.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-05/test.yaml
@@ -20,3 +20,10 @@ checks:
       count: 0
       match:
         event_type: http
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_midstream"
+        flow.exception_policy.triggered[0].policy: "bypass"

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-06/test.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-06/test.yaml
@@ -36,3 +36,10 @@ checks:
         event_type: engine
         log_level: Warning
         engine.module: exception-policy
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_midstream"
+        flow.exception_policy.triggered[0].policy: "ignore"

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-07/test.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-07/test.yaml
@@ -36,3 +36,10 @@ checks:
         event_type: engine
         log_level: Warning
         engine.module: exception-policy
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_midstream"
+        flow.exception_policy.triggered[0].policy: "ignore"

--- a/tests/exception-policy-midstream-01/test.yaml
+++ b/tests/exception-policy-midstream-01/test.yaml
@@ -24,3 +24,10 @@ checks:
       match:
         event_type: stats
         stats.tcp.midstream_exception_policy.pass_flow: 9
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_midstream"
+        flow.exception_policy.triggered[0].policy: "pass_flow"

--- a/tests/exception-policy-midstream-02/test.yaml
+++ b/tests/exception-policy-midstream-02/test.yaml
@@ -36,3 +36,10 @@ checks:
       match:
         event_type: stats
         stats.tcp.midstream_exception_policy.drop_flow: 1
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: stream_midstream
+        flow.exception_policy.triggered[0].policy: drop_flow

--- a/tests/exception-policy-midstream-03/test.yaml
+++ b/tests/exception-policy-midstream-03/test.yaml
@@ -24,3 +24,10 @@ checks:
       match:
         event_type: http
         dest_port: 80
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_midstream"
+        flow.exception_policy.triggered[0].policy: "ignore"

--- a/tests/exception-policy-midstream-04/test.yaml
+++ b/tests/exception-policy-midstream-04/test.yaml
@@ -25,3 +25,10 @@ checks:
     match:
       event_type: stats
       stats.tcp.midstream_exception_policy.pass_flow: 2
+- filter:
+    min-version: 8
+    count: 1
+    match:
+      event_type: flow
+      flow.exception_policy.triggered[0].target: "stream_midstream"
+      flow.exception_policy.triggered[0].policy: "pass_flow"

--- a/tests/exception-policy-midstream-05/test.yaml
+++ b/tests/exception-policy-midstream-05/test.yaml
@@ -24,3 +24,10 @@ checks:
       match:
         event_type: stats
         stats.tcp.midstream_exception_policy.bypass: 1
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_midstream"
+        flow.exception_policy.triggered[0].policy: "bypass"

--- a/tests/exception-policy-midstream-06/test.yaml
+++ b/tests/exception-policy-midstream-06/test.yaml
@@ -22,3 +22,10 @@ checks:
       match:
         event_type: stats
         stats.tcp.midstream_exception_policy.drop_flow: 1
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_midstream"
+        flow.exception_policy.triggered[0].policy: "drop_flow"

--- a/tests/exception-policy-midstream-07/test.yaml
+++ b/tests/exception-policy-midstream-07/test.yaml
@@ -18,3 +18,10 @@ checks:
       count: 0
       match:
         event_type: smb
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_midstream"
+        flow.exception_policy.triggered[0].policy: "bypass"

--- a/tests/exception-policy-reject-action-01/test.yaml
+++ b/tests/exception-policy-reject-action-01/test.yaml
@@ -18,4 +18,10 @@ checks:
       match:
         event_type: flow
         flow.action: drop
-
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_midstream"
+        flow.exception_policy.triggered[0].policy: "reject"

--- a/tests/exception-policy-simulated-flow-memcap/test.yaml
+++ b/tests/exception-policy-simulated-flow-memcap/test.yaml
@@ -39,3 +39,10 @@ checks:
         event_type: stats
         stats.flow.memcap_exception_policy.drop_packet: 1
         stats.flow.memcap_exception_policy.pass_packet: 0
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_midstream"
+        flow.exception_policy.triggered[0].policy: "ignore"

--- a/tests/exception-policy-stream-reassembly-memcap-01/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-01/test.yaml
@@ -52,3 +52,10 @@ checks:
       match:
         event_type: stats
         stats.ips.drop_reason.stream_reassembly: 1
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_reassembly_memcap"
+        flow.exception_policy.triggered[0].policy: "drop_flow"

--- a/tests/exception-policy-stream-reassembly-memcap-02/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-02/test.yaml
@@ -32,3 +32,12 @@ checks:
         event_type: flow
         app_proto: tls
         flow.action: pass
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_reassembly_memcap"
+        flow.exception_policy.triggered[0].policy: "pass_flow"
+        flow.exception_policy.triggered[1].target: "app_layer_error"
+        flow.exception_policy.triggered[1].policy: "ignore"

--- a/tests/exception-policy-stream-reassembly-memcap-03/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-03/test.yaml
@@ -30,3 +30,10 @@ checks:
       match:
         event_type: flow
         flow.state: bypassed
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_reassembly_memcap"
+        flow.exception_policy.triggered[0].policy: "bypass"

--- a/tests/exception-policy-stream-reassembly-memcap-04/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-04/test.yaml
@@ -52,3 +52,10 @@ checks:
       match:
         event_type: stats
         stats.ips.drop_reason.stream_reassembly: 1
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_reassembly_memcap"
+        flow.exception_policy.triggered[0].policy: "drop_flow"

--- a/tests/exception-policy-stream-reassembly-memcap-05/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-05/test.yaml
@@ -53,3 +53,12 @@ checks:
       match:
         event_type: stats
         stats.ips.drop_reason.stream_reassembly: 1
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_reassembly_memcap"
+        flow.exception_policy.triggered[0].policy: "drop_packet"
+        flow.exception_policy.triggered[1].target: "app_layer_error"
+        flow.exception_policy.triggered[1].policy: "ignore"

--- a/tests/exception-policy-stream-reassembly-memcap-06/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-06/test.yaml
@@ -53,3 +53,12 @@ checks:
       match:
         event_type: stats
         stats.tcp.reassembly_exception_policy.pass_packet: 1
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_reassembly_memcap"
+        flow.exception_policy.triggered[0].policy: "pass_packet"
+        flow.exception_policy.triggered[1].target: "app_layer_error"
+        flow.exception_policy.triggered[1].policy: "ignore"

--- a/tests/exception-policy-stream-ssn-memcap-01/test.yaml
+++ b/tests/exception-policy-stream-ssn-memcap-01/test.yaml
@@ -57,3 +57,10 @@ checks:
       match:
         event_type: stats
         stats.tcp.ssn_memcap_exception_policy.drop_flow: 1
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: flow
+        flow.exception_policy.triggered[0].target: "stream_memcap"
+        flow.exception_policy.triggered[0].policy: "drop_flow"


### PR DESCRIPTION
Add checks for `flow.exception_policy.triggered` fields in the exception policies tests.

Related to
Task #6215

Previous PR: https://github.com/OISF/suricata-verify/pull/2332

Changes from previous PR:
- add checks for master-switch policy
- change EVE format to `exception_policy.triggered` to align with standard format chosen for the `exception_policy` stats counters

## Ticket

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/6215