### PR TITLE
detect: add test for mime email keywords - v1

### DIFF
--- a/tests/detect-mime-email/README.md
+++ b/tests/detect-mime-email/README.md
@@ -1,0 +1,8 @@
+# Test Description
+Test mime email keywords
+
+## PCAP
+From ../mime/mime-dec-parse-full-msg-test02/input.pcap
+
+## Redmine Ticket
+https://redmine.openinfosecfoundation.org/issues/7592

--- a/tests/detect-mime-email/test.rules
+++ b/tests/detect-mime-email/test.rules
@@ -1,0 +1,1 @@
+alert smtp any any -> any any (msg:"Test mime email from"; email.from; content:"toto <toto@gmail.com>"; sid:1;)

--- a/tests/detect-mime-email/test.yaml
+++ b/tests/detect-mime-email/test.yaml
@@ -1,0 +1,15 @@
+requires:
+  min-version: 8
+
+pcap: ../mime/mime-dec-parse-full-msg-test02/input.pcap
+
+args:
+  - -k none --set stream.inline=true
+
+checks:
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      email.from: toto <toto@gmail.com>
+      alert.signature_id: 1


### PR DESCRIPTION
Ticket: [7592](https://redmine.openinfosecfoundation.org/issues/7592)

Description:
- Add S-V test for mime email keywords

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7592

Suricata PR:
