### PR TITLE
tests/ftp: Completion codes are now integers

### DIFF
--- a/tests/output-eve-ftp/test.yaml
+++ b/tests/output-eve-ftp/test.yaml
@@ -49,7 +49,7 @@ checks:
         ftp.command: PASS
         ftp.command_data: anonymous
         ftp.reply: ['Login successful.']
-        ftp.completion_code: ['230']
+        ftp.completion_code: [230]
 
   - filter:
       count: 1


### PR DESCRIPTION
Change the test to reflect integer -- instead of string -- completion codes.


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: [4082](https://redmine.openinfosecfoundation.org/issues/4082)
