### PR TITLE
exceptions: add checks for new stats counters - v1

### DIFF
--- a/tests/exception-policy-applayer-01/test.yaml
+++ b/tests/exception-policy-applayer-01/test.yaml
@@ -57,8 +57,8 @@ checks:
       count: 1
       match:
         event_type: stats
-        stats.app_layer.error.exception_policy.drop_flow: 1
-        stats.app_layer.error.exception_policy.pass_flow: 0
+        stats.exception_policy.app_layer.error.drop_flow: 1
+        stats.exception_policy.app_layer.error.pass_flow: 0
   - filter:
       min-version: 8
       count: 1

--- a/tests/exception-policy-applayer-03/test.yaml
+++ b/tests/exception-policy-applayer-03/test.yaml
@@ -69,8 +69,8 @@ checks:
     count: 1
     match:
       event_type: stats
-      stats.app_layer.error.exception_policy.pass_packet: 1
-      stats.app_layer.error.exception_policy.drop_packet: 0
+      stats.exception_policy.app_layer.error.pass_packet: 1
+      stats.exception_policy.app_layer.error.drop_packet: 0
 - filter:
     min-version: 8
     count: 1

--- a/tests/exception-policy-defrag-01/test.yaml
+++ b/tests/exception-policy-defrag-01/test.yaml
@@ -43,6 +43,6 @@ checks:
       count: 1
       match:
         event_type: stats
-        stats.defrag.memcap_exception_policy.drop_packet: 1
-        stats.defrag.memcap_exception_policy.pass_packet: 0
+        stats.exception_policy.defrag.memcap.drop_packet: 1
+        stats.exception_policy.defrag.memcap.pass_packet: 0
 

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-01/suricata.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-01/suricata.yaml
@@ -26,4 +26,10 @@ outputs:
         - drop:
             alerts: yes
             flows: all
+        - stats
+
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes
 

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-01/test.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-01/test.yaml
@@ -42,3 +42,9 @@ checks:
         event_type: flow
         flow.exception_policy[0].target: "stream_midstream"
         flow.exception_policy[0].policy: "drop_flow"
+  - filter:
+      min-version: 8
+      count: 1
+      match:
+        event_type: stats
+        stats.exception_policy.tcp.midstream.drop_flow: 1

--- a/tests/exception-policy-midstream-01/test.yaml
+++ b/tests/exception-policy-midstream-01/test.yaml
@@ -23,7 +23,7 @@ checks:
       count: 1
       match:
         event_type: stats
-        stats.tcp.midstream_exception_policy.pass_flow: 9
+        stats.exception_policy.tcp.midstream.pass_flow: 9
   - filter:
       min-version: 8
       count: 1

--- a/tests/exception-policy-midstream-02/test.yaml
+++ b/tests/exception-policy-midstream-02/test.yaml
@@ -35,7 +35,7 @@ checks:
       count: 1
       match:
         event_type: stats
-        stats.tcp.midstream_exception_policy.drop_flow: 1
+        stats.exception_policy.tcp.midstream.drop_flow: 1
   - filter:
       min-version: 8
       count: 1

--- a/tests/exception-policy-midstream-04/test.yaml
+++ b/tests/exception-policy-midstream-04/test.yaml
@@ -24,7 +24,7 @@ checks:
     count: 1
     match:
       event_type: stats
-      stats.tcp.midstream_exception_policy.pass_flow: 2
+      stats.exception_policy.tcp.midstream.pass_flow: 2
 - filter:
     min-version: 8
     count: 1

--- a/tests/exception-policy-midstream-05/test.yaml
+++ b/tests/exception-policy-midstream-05/test.yaml
@@ -23,7 +23,7 @@ checks:
       count: 1
       match:
         event_type: stats
-        stats.tcp.midstream_exception_policy.bypass: 1
+        stats.exception_policy.tcp.midstream.bypass: 1
   - filter:
       min-version: 8
       count: 1

--- a/tests/exception-policy-midstream-06/test.yaml
+++ b/tests/exception-policy-midstream-06/test.yaml
@@ -21,7 +21,7 @@ checks:
       count: 1
       match:
         event_type: stats
-        stats.tcp.midstream_exception_policy.drop_flow: 1
+        stats.exception_policy.tcp.midstream.drop_flow: 1
   - filter:
       min-version: 8
       count: 1

--- a/tests/exception-policy-simulated-flow-memcap/test.yaml
+++ b/tests/exception-policy-simulated-flow-memcap/test.yaml
@@ -37,8 +37,8 @@ checks:
       count: 1
       match:
         event_type: stats
-        stats.flow.memcap_exception_policy.drop_packet: 1
-        stats.flow.memcap_exception_policy.pass_packet: 0
+        stats.exception_policy.flow.memcap.drop_packet: 1
+        stats.exception_policy.flow.memcap.pass_packet: 0
   - filter:
       min-version: 8
       count: 1

--- a/tests/exception-policy-stream-reassembly-memcap-06/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-06/test.yaml
@@ -52,7 +52,7 @@ checks:
       count: 1
       match:
         event_type: stats
-        stats.tcp.reassembly_exception_policy.pass_packet: 1
+        stats.exception_policy.tcp.reassembly.pass_packet: 1
   - filter:
       min-version: 8
       count: 1

--- a/tests/exception-policy-stream-ssn-memcap-01/test.yaml
+++ b/tests/exception-policy-stream-ssn-memcap-01/test.yaml
@@ -56,7 +56,7 @@ checks:
       count: 1
       match:
         event_type: stats
-        stats.tcp.ssn_memcap_exception_policy.drop_flow: 1
+        stats.exception_policy.tcp.ssn_memcap.drop_flow: 1
   - filter:
       min-version: 8
       count: 1


### PR DESCRIPTION
Using more search-friendly stats counters for exception_policy counters.

Related to
Task #7185

Describe changes:
- in this one, stats counters for `exception_policy` to its own object, that now has all exception policies. I've only left the individual app-layer proto ones still under `.stats.app_layer.error` since it seemed to make more sense than creating another very verbose entry under `stats.exception_policy`

## Ticket

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/7185