### PR TITLE
detect: add test for email.to keyword  - v1

### DIFF
--- a/tests/detect-email-to/README.md
+++ b/tests/detect-email-to/README.md
@@ -1,0 +1,8 @@
+# Test Description
+Test mime email.to keyword
+
+## PCAP
+From ../mime/mime-dec-parse-full-msg-test02/input.pcap
+
+## Redmine Ticket
+https://redmine.openinfosecfoundation.org/issues/7596

--- a/tests/detect-email-to/test.rules
+++ b/tests/detect-email-to/test.rules
@@ -1,0 +1,1 @@
+alert smtp any any -> any any (msg:"Test mime email to"; email.to; content:"172.16.92.2@linuxbox"; startswith; endswith; bsize:20; sid:1;)

--- a/tests/detect-email-to/test.yaml
+++ b/tests/detect-email-to/test.yaml
@@ -1,0 +1,16 @@
+requires:
+  min-version: 8
+
+pcap: ../mime/mime-dec-parse-full-msg-test02/input.pcap
+
+args:
+  - -k none --set stream.inline=true
+
+checks:
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      email.to[0]: 172.16.92.2@linuxbox
+      pcap_cnt: 13
+      alert.signature_id: 1


### PR DESCRIPTION
Ticket: [7596](https://redmine.openinfosecfoundation.org/issues/7596)

Description:
- Add S-V test for MIME ``email.to`` keyword

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7596

Suricata PR: https://github.com/OISF/suricata/pull/12832