### PR TITLE
detect: add test for email.cc keyword - v3

### DIFF
--- a/tests/detect-email-cc/README.md
+++ b/tests/detect-email-cc/README.md
@@ -1,0 +1,8 @@
+# Test Description
+Test mime email.cc keyword
+
+## PCAP
+From ../smtp-to-comma/10.7.29.101_49898-178.63.41.150_25.pcap
+
+## Redmine Ticket
+https://redmine.openinfosecfoundation.org/issues/7588

--- a/tests/detect-email-cc/test.rules
+++ b/tests/detect-email-cc/test.rules
@@ -1,0 +1,1 @@
+alert smtp any any -> any any (msg:"Test mime email cc"; email.cc; content:"\"jam,abrakadabra.ch\" <mirjam@abrakadabra.ch>"; startswith; endswith; bsize:44; sid:1;)

--- a/tests/detect-email-cc/test.yaml
+++ b/tests/detect-email-cc/test.yaml
@@ -1,0 +1,16 @@
+requires:
+  min-version: 8
+
+pcap: ../smtp-to-comma/10.7.29.101_49898-178.63.41.150_25.pcap
+
+args:
+  - -k none --set stream.inline=true
+
+checks:
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      email.cc[0]: "\"jam,abrakadabra.ch\" <mirjam@abrakadabra.ch>"
+      pcap_cnt: 18
+      alert.signature_id: 1


### PR DESCRIPTION
Ticket: [7588](https://redmine.openinfosecfoundation.org/issues/7588)

Description:
- Add S-V test for MIME ``email.cc`` keyword

Changes:
- Just rebase

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7588

Suricata PR: 
Previous PR: https://github.com/OISF/suricata-verify/pull/2367
