### PR TITLE
detect: add test for email.message_id keyword  - v1

### DIFF
--- a/tests/detect-email-msg-id/README.md
+++ b/tests/detect-email-msg-id/README.md
@@ -1,0 +1,8 @@
+# Test Description
+Test mime email.message_id keyword
+
+## PCAP
+From ../bug-1045/smtpsuricataflowbitsFN.pcap
+
+## Redmine Ticket
+https://redmine.openinfosecfoundation.org/issues/7593

--- a/tests/detect-email-msg-id/test.rules
+++ b/tests/detect-email-msg-id/test.rules
@@ -1,0 +1,1 @@
+alert smtp any any -> any any (msg:"Test mime email message id"; email.message_id; content:"<alpine.DEB.2.00.1311261630120.9535@sd-26634.dedibox.fr>"; startswith; endswith; bsize:56; sid:1;)

--- a/tests/detect-email-msg-id/test.yaml
+++ b/tests/detect-email-msg-id/test.yaml
@@ -1,0 +1,17 @@
+requires:
+  min-version: 8
+
+pcap: ../bug-1045/smtpsuricataflowbitsFN.pcap
+
+args:
+  - -k none --set stream.inline=true
+
+checks:
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      email.message_id: <alpine.DEB.2.00.1311261630120.9535@sd-26634.dedibox.fr>
+      pcap_cnt: 13
+      alert.signature_id: 1
+


### PR DESCRIPTION
Ticket: [7593](https://redmine.openinfosecfoundation.org/issues/7593)

Description:
- Add S-V test for MIME ``email.message_id`` keyword

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7593

Suricata PR: https://github.com/OISF/suricata/pull/12904
