### PR TITLE
detect: add test for email.x_mailer keyword - v1

### DIFF
--- a/tests/detect-email-x-mailer/README.md
+++ b/tests/detect-email-x-mailer/README.md
@@ -1,0 +1,8 @@
+# Test Description
+Test mime email.x_mailer keyword
+
+## PCAP
+From ../smtp-bug-5981/input.pcap
+
+## Redmine Ticket
+https://redmine.openinfosecfoundation.org/issues/7598

--- a/tests/detect-email-x-mailer/test.rules
+++ b/tests/detect-email-x-mailer/test.rules
@@ -1,0 +1,1 @@
+alert smtp any any -> any any (msg:"Test mime email x_mailer"; email.x_mailer; content:"Microsoft Office Outlook, Build 11.0.5510"; startswith; endswith; bsize:41; sid:1;)

--- a/tests/detect-email-x-mailer/test.yaml
+++ b/tests/detect-email-x-mailer/test.yaml
@@ -1,0 +1,16 @@
+requires:
+  min-version: 8
+
+pcap: ../smtp-bug-5981/input.pcap
+
+args:
+  - -k none --set stream.inline=true
+
+checks:
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      email.x_mailer: Microsoft Office Outlook, Build 11.0.5510
+      pcap_cnt: 21
+      alert.signature_id: 1


### PR DESCRIPTION
Ticket: [7598](https://redmine.openinfosecfoundation.org/issues/7598)

Description:
- Add S-V test for MIME ``email.x_mailer`` keyword

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7598

Suricata PR: https://github.com/OISF/suricata/pull/12906
