### PR TITLE
detect: add test for email.message_id keyword - v2

### DIFF
--- a/tests/detect-email-date/suricata.yaml
+++ b/tests/detect-email-date/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filename: eve.json
+      types:
+        - alert:
+            tagged-packets: yes
+        - smtp:
+            custom: [date]    # for 'date' logging information
+        - drop:
+            alerts: yes      # log alerts that caused drops
+            flows: all       # start or all: 'start' logs only a single drop
+        - stats
+        - flow
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes
+
+action-order:
+  - pass
+  - drop
+  - reject
+  - alert
+
+exception-policy: ignore

--- a/tests/detect-email-date/test.yaml
+++ b/tests/detect-email-date/test.yaml
@@ -11,6 +11,11 @@ checks:
     count: 1
     match:
       event_type: alert
-      email.date: Fri, 21 Apr 2023 05:10:36 +0000
       pcap_cnt: 13
       alert.signature_id: 1
+- filter:
+    count: 1
+    match:
+      event_type: smtp
+      email.date: Fri, 21 Apr 2023 05:10:36 +0000
+      pcap_cnt: 13

--- a/tests/detect-email-msg-id/README.md
+++ b/tests/detect-email-msg-id/README.md
@@ -1,0 +1,8 @@
+# Test Description
+Test mime email.message_id keyword
+
+## PCAP
+From ../bug-1045/smtpsuricataflowbitsFN.pcap
+
+## Redmine Ticket
+https://redmine.openinfosecfoundation.org/issues/7593

--- a/tests/detect-email-msg-id/suricata.yaml
+++ b/tests/detect-email-msg-id/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filename: eve.json
+      types:
+        - alert:
+            tagged-packets: yes
+        - smtp:
+            custom: [message-id]    # for 'message-id' logging information
+        - drop:
+            alerts: yes      # log alerts that caused drops
+            flows: all       # start or all: 'start' logs only a single drop
+        - stats
+        - flow
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes
+
+action-order:
+  - pass
+  - drop
+  - reject
+  - alert
+
+exception-policy: ignore

--- a/tests/detect-email-msg-id/test.rules
+++ b/tests/detect-email-msg-id/test.rules
@@ -1,0 +1,1 @@
+alert smtp any any -> any any (msg:"Test mime email message id"; email.message_id; content:"<alpine.DEB.2.00.1311261630120.9535@sd-26634.dedibox.fr>"; startswith; endswith; bsize:56; sid:1;)

--- a/tests/detect-email-msg-id/test.yaml
+++ b/tests/detect-email-msg-id/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  min-version: 8
+
+pcap: ../bug-1045/smtpsuricataflowbitsFN.pcap
+
+args:
+  - -k none --set stream.inline=true
+
+checks:
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      pcap_cnt: 13
+      alert.signature_id: 1
+- filter:
+    count: 1
+    match:
+      event_type: smtp
+      email.message_id: <alpine.DEB.2.00.1311261630120.9535@sd-26634.dedibox.fr>
+      pcap_cnt: 13

--- a/tests/detect-email-subject/suricata.yaml
+++ b/tests/detect-email-subject/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filename: eve.json
+      types:
+        - alert:
+            tagged-packets: yes
+        - smtp:
+            custom: [subject]    # for 'subject' logging information
+        - drop:
+            alerts: yes      # log alerts that caused drops
+            flows: all       # start or all: 'start' logs only a single drop
+        - stats
+        - flow
+  - stats:
+       enabled: yes
+       filename: stats.log
+       append: yes
+
+action-order:
+  - pass
+  - drop
+  - reject
+  - alert
+
+exception-policy: ignore

--- a/tests/detect-email-subject/test.yaml
+++ b/tests/detect-email-subject/test.yaml
@@ -13,3 +13,9 @@ checks:
       event_type: alert
       pcap_cnt: 13
       alert.signature_id: 1
+- filter:
+    count: 1
+    match:
+      event_type: smtp
+      pcap_cnt: 13
+      email.subject: This is a test email


### PR DESCRIPTION
Ticket: [7593](https://redmine.openinfosecfoundation.org/issues/7593)

Description:
- Add S-V test for MIME ``email.message_id`` keyword

Changes:
- use extended mode to log fields ``date``, ``subject`` and ``message_id``

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7593

Suricata PR: https://github.com/OISF/suricata/pull/12919
Previous PR: https://github.com/OISF/suricata-verify/pull/2400