### PR TITLE
tests: require ja3 feature on new bidir tests

### DIFF
--- a/tests/detect-bidir-ja3/test.yaml
+++ b/tests/detect-bidir-ja3/test.yaml
@@ -1,5 +1,7 @@
 requires:
   min-version: 8
+  features:
+    - HAVE_JA3
 
 pcap: ../tls/tls-certs-alert/input.pcap
 

--- a/tests/rules/detect-bidir-ja3-rule/test.yaml
+++ b/tests/rules/detect-bidir-ja3-rule/test.yaml
@@ -1,6 +1,8 @@
 requires:
   min-version: 8
   pcap: false
+  features:
+    - HAVE_JA3
 
 args:
  - --engine-analysis


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7461

https://github.com/OISF/suricata-verify/pull/2398 rebased