### PR TITLE
detect: add test for LDAP attribute keywords - v2

### DIFF
--- a/tests/detect-ldap-attribute/detect-ldap-attribute-01/README.md
+++ b/tests/detect-ldap-attribute/detect-ldap-attribute-01/README.md
@@ -1,4 +1,4 @@
-Test ldap.request.attribute_type keyword.
+Test ldap.request.attribute_type and ldap.responses.attribute_type keywords.
 
 PCAP from ../../ldap-search/ldap.pcap
 

--- a/tests/detect-ldap-attribute/detect-ldap-attribute-01/README.md
+++ b/tests/detect-ldap-attribute/detect-ldap-attribute-01/README.md
@@ -1,0 +1,5 @@
+Test ldap.request.attribute_type keyword.
+
+PCAP from ../../ldap-search/ldap.pcap
+
+Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7533

--- a/tests/detect-ldap-attribute/detect-ldap-attribute-01/README.md
+++ b/tests/detect-ldap-attribute/detect-ldap-attribute-01/README.md
@@ -1,4 +1,5 @@
-Test ldap.request.attribute_type and ldap.responses.attribute_type keywords.
+Test ldap.request.attribute_type, ldap.responses.attribute_type
+and ldap.responses.attributes keywords.
 
 PCAP from ../../ldap-search/ldap.pcap
 

--- a/tests/detect-ldap-attribute/detect-ldap-attribute-01/test.rules
+++ b/tests/detect-ldap-attribute/detect-ldap-attribute-01/test.rules
@@ -2,3 +2,7 @@ alert ldap any any -> any any (msg:"Test request attribute type"; ldap.request.a
 alert ldap any any -> any any (msg:"Test request attribute type"; ldap.request.attribute_type; content:"+"; sid:2;)
 alert ldap any any -> any any (msg:"Test responses attribute type"; ldap.responses.attribute_type; content:"objectClass"; sid:3;)
 alert ldap any any -> any any (msg:"Test responses attribute type"; ldap.responses.attribute_type; content:"dc"; sid:4;)
+
+alert ldap any any -> any any (msg:"Test responses attribute type and value"; ldap.responses.attributes; content:"objectClass=top"; sid:5;)
+alert ldap any any -> any any (msg:"Test responses attribute type and value"; ldap.responses.attributes; content:"objectClass=domain"; sid:6;)
+alert ldap any any -> any any (msg:"Test responses attribute type and value"; ldap.responses.attributes; content:"dc=example"; sid:7;)

--- a/tests/detect-ldap-attribute/detect-ldap-attribute-01/test.rules
+++ b/tests/detect-ldap-attribute/detect-ldap-attribute-01/test.rules
@@ -1,0 +1,2 @@
+alert ldap any any -> any any (msg:"Test request attribute type"; ldap.request.attribute_type; content:"*"; sid:1;)
+alert ldap any any -> any any (msg:"Test request attribute type"; ldap.request.attribute_type; content:"+"; sid:2;)

--- a/tests/detect-ldap-attribute/detect-ldap-attribute-01/test.rules
+++ b/tests/detect-ldap-attribute/detect-ldap-attribute-01/test.rules
@@ -1,2 +1,4 @@
 alert ldap any any -> any any (msg:"Test request attribute type"; ldap.request.attribute_type; content:"*"; sid:1;)
 alert ldap any any -> any any (msg:"Test request attribute type"; ldap.request.attribute_type; content:"+"; sid:2;)
+alert ldap any any -> any any (msg:"Test responses attribute type"; ldap.responses.attribute_type; content:"objectClass"; sid:3;)
+alert ldap any any -> any any (msg:"Test responses attribute type"; ldap.responses.attribute_type; content:"dc"; sid:4;)

--- a/tests/detect-ldap-attribute/detect-ldap-attribute-01/test.yaml
+++ b/tests/detect-ldap-attribute/detect-ldap-attribute-01/test.yaml
@@ -1,0 +1,23 @@
+requires:
+  min-version: 8
+
+pcap: ../../ldap-search/ldap.pcap
+
+args:
+  - -k none --set stream.inline=true
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ldap.request.operation: search_request
+        ldap.request.search_request.attributes[0]: "*"
+        alert.signature_id: 1
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ldap.request.operation: search_request
+        ldap.request.search_request.attributes[1]: +
+        alert.signature_id: 2

--- a/tests/detect-ldap-attribute/detect-ldap-attribute-01/test.yaml
+++ b/tests/detect-ldap-attribute/detect-ldap-attribute-01/test.yaml
@@ -35,3 +35,27 @@ checks:
         ldap.responses[0].operation: search_result_entry
         ldap.responses[0].search_result_entry.attributes[1].type: dc
         alert.signature_id: 4
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ldap.responses[0].operation: search_result_entry
+        ldap.responses[0].search_result_entry.attributes[0].type: objectClass
+        ldap.responses[0].search_result_entry.attributes[0].values[0]: top
+        alert.signature_id: 5
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ldap.responses[0].operation: search_result_entry
+        ldap.responses[0].search_result_entry.attributes[0].type: objectClass
+        ldap.responses[0].search_result_entry.attributes[0].values[1]: domain
+        alert.signature_id: 6
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ldap.responses[0].operation: search_result_entry
+        ldap.responses[0].search_result_entry.attributes[1].type: dc
+        ldap.responses[0].search_result_entry.attributes[1].values[0]: example
+        alert.signature_id: 7

--- a/tests/detect-ldap-attribute/detect-ldap-attribute-01/test.yaml
+++ b/tests/detect-ldap-attribute/detect-ldap-attribute-01/test.yaml
@@ -21,3 +21,17 @@ checks:
         ldap.request.operation: search_request
         ldap.request.search_request.attributes[1]: +
         alert.signature_id: 2
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ldap.responses[0].operation: search_result_entry
+        ldap.responses[0].search_result_entry.attributes[0].type: objectClass
+        alert.signature_id: 3
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ldap.responses[0].operation: search_result_entry
+        ldap.responses[0].search_result_entry.attributes[1].type: dc
+        alert.signature_id: 4

--- a/tests/detect-ldap-attribute/detect-ldap-attribute-02/README.md
+++ b/tests/detect-ldap-attribute/detect-ldap-attribute-02/README.md
@@ -1,0 +1,5 @@
+Test ldap.request.attributes keyword.
+
+PCAP from ../../ldap-add/ldap.pcap
+
+Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7533

--- a/tests/detect-ldap-attribute/detect-ldap-attribute-02/test.rules
+++ b/tests/detect-ldap-attribute/detect-ldap-attribute-02/test.rules
@@ -1,0 +1,3 @@
+alert ldap any any -> any any (msg:"Test request attribute type and value"; ldap.request.attributes; content:"objectClass=top"; sid:1;)
+alert ldap any any -> any any (msg:"Test request attribute type and value"; ldap.request.attributes; content:"objectClass=domain"; sid:2;)
+alert ldap any any -> any any (msg:"Test request attribute type and value"; ldap.request.attributes; content:"dc=example"; sid:3;)

--- a/tests/detect-ldap-attribute/detect-ldap-attribute-02/test.yaml
+++ b/tests/detect-ldap-attribute/detect-ldap-attribute-02/test.yaml
@@ -1,0 +1,33 @@
+requires:
+  min-version: 8
+
+pcap: ../../ldap-add/ldap.pcap
+
+args:
+  - -k none --set stream.inline=true
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ldap.request.operation: add_request
+        ldap.request.add_request.attributes[0].name: objectClass
+        ldap.request.add_request.attributes[0].values[0]: top
+        alert.signature_id: 1
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ldap.request.operation: add_request
+        ldap.request.add_request.attributes[0].name: objectClass
+        ldap.request.add_request.attributes[0].values[1]: domain
+        alert.signature_id: 2
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ldap.request.operation: add_request
+        ldap.request.add_request.attributes[1].name: dc
+        ldap.request.add_request.attributes[1].values[0]: example
+        alert.signature_id: 3


### PR DESCRIPTION
Ticket: [#7533](https://redmine.openinfosecfoundation.org/issues/7533)

Description:
- Add S-V test for  `ldap.request.attribute_type` , `ldap.responses.attribute_type`, ldap.request.attributes` and `ldap.responses.attributes` keywords.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7533

Suricata PR:
Previous PR: https://github.com/OISF/suricata-verify/pull/2331