### PR TITLE
detect: add test for email.url keyword - v1

### DIFF
--- a/tests/detect-email-url/README.md
+++ b/tests/detect-email-url/README.md
@@ -1,0 +1,8 @@
+# Test Description
+Test mime email.url keyword.
+
+## PCAP
+From ../smtp-extract-url-schemes/input.pcap
+
+## Redmine Ticket
+https://redmine.openinfosecfoundation.org/issues/7597

--- a/tests/detect-email-url/test.rules
+++ b/tests/detect-email-url/test.rules
@@ -1,0 +1,2 @@
+alert smtp any any -> any any (msg:"Test mime email url"; email.url; content:"test-site.org/blah/123/"; startswith; endswith; bsize:23; sid:1;)
+alert smtp any any -> any any (msg:"Test mime email url"; email.url; content:"google.com"; startswith; endswith; bsize:10; sid:2;)

--- a/tests/detect-email-url/test.yaml
+++ b/tests/detect-email-url/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  min-version: 8
+
+pcap: ../smtp-extract-url-schemes/input.pcap
+
+args:
+  - -k none --set stream.inline=true
+
+checks:
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      email.url[0]: "test-site.org/blah/123/"
+      alert.signature_id: 1
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      email.url[1]: "google.com"
+      alert.signature_id: 2


### PR DESCRIPTION
Ticket: [#7597](https://redmine.openinfosecfoundation.org/issues/7597)


Description:
- Add S-V test for MIME ``email.url`` keyword

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7597

Suricata PR: https://github.com/OISF/suricata/pull/13000
