### PR TITLE
tests/ftp: Add tests for ftp_reply_received keyword

### DIFF
--- a/tests/detect-ftp/ftp-reply-received-01/input.rules
+++ b/tests/detect-ftp/ftp-reply-received-01/input.rules
@@ -1,0 +1,2 @@
+alert ftp any any -> any any (msg: "Match on FTP reply received: yes"; flow:established; ftp.reply_received: yes; sid:1;)
+alert ftp any any -> any any (msg: "Match on FTP reply received: yes"; flow:established; ftp.reply_received: on; sid:2;)

--- a/tests/detect-ftp/ftp-reply-received-01/test.yaml
+++ b/tests/detect-ftp/ftp-reply-received-01/test.yaml
@@ -1,0 +1,20 @@
+requires:
+  version: 8
+
+pcap: ../../bug-3519/input.pcap
+
+checks:
+
+  - filter:
+      count: 7
+      match:
+        event_type: alert
+        ftp.reply_received: "yes"
+        alert.signature_id: 1
+
+  - filter:
+      count: 7
+      match:
+        event_type: alert
+        ftp.reply_received: "yes"
+        alert.signature_id: 2

--- a/tests/detect-ftp/ftp-reply-received-02/input.rules
+++ b/tests/detect-ftp/ftp-reply-received-02/input.rules
@@ -1,0 +1,2 @@
+alert ftp any any -> any any (msg: "Match on FTP reply-received NO"; ftp.reply_received: no; sid:1;)
+alert ftp any any -> any any (msg: "Match on FTP reply-received NO"; ftp.reply_received: off; sid:2;)

--- a/tests/detect-ftp/ftp-reply-received-02/test.yaml
+++ b/tests/detect-ftp/ftp-reply-received-02/test.yaml
@@ -1,0 +1,20 @@
+requires:
+  version: 8
+
+pcap: ../../ftp/ftp-too-long-response/ftp-too-long-response.pcap
+
+checks:
+
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ftp.reply_received: "no"
+        alert.signature_id: 1
+
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        ftp.reply_received: "no"
+        alert.signature_id: 2

--- a/tests/detect-ftp/ftp-reply-received-03/input.rules
+++ b/tests/detect-ftp/ftp-reply-received-03/input.rules
@@ -1,0 +1,3 @@
+alert ftp any any -> any any (msg: "Match on FTP reply received: yes"; flow:established; ftp.reply_received: yes yes; sid:1;)
+alert ftp any any -> any any (msg: "Match on FTP reply received: yes"; flow:established; ftp.reply_received: no no; sid:2;)
+alert ftp any any -> any any (msg: "Match on FTP reply received: yes"; flow:established; ftp.reply_received: suricata; sid:3;)

--- a/tests/detect-ftp/ftp-reply-received-03/test.yaml
+++ b/tests/detect-ftp/ftp-reply-received-03/test.yaml
@@ -1,0 +1,13 @@
+requires:
+  version: 8
+  pcap: false
+
+exit-code: 1
+
+args:
+  - --engine-analysis
+checks:
+
+  - shell:
+     args: grep "error parsing signature" suricata.log | wc -l | xargs
+     expect: 3


### PR DESCRIPTION
Add tests for the FTP keyword ftp.reply_received that alert on both values for reply_received -- "yes" and "no".


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
