### PR TITLE
ssh: adds test for lua

### DIFF
--- a/tests/ssh-lua-rules/suricata.yaml
+++ b/tests/ssh-lua-rules/suricata.yaml
@@ -1,0 +1,4 @@
+%YAML 1.1
+---
+
+include: ../../etc/suricata-4.0.3.yaml

--- a/tests/ssh-lua-rules/test-ssh.lua
+++ b/tests/ssh-lua-rules/test-ssh.lua
@@ -1,0 +1,18 @@
+local ssh = require("suricata.ssh")
+
+function init (args)
+   local needs = {}
+   return needs
+end
+
+function match(args)
+   local tx = ssh.get_tx()
+   local proto = tx:server_proto()
+   if proto == "2.0" then
+      local soft = tx:server_software()
+      if soft == "OpenSSH_7.4" then
+         return 1
+      end
+   end
+   return 0
+end

--- a/tests/ssh-lua-rules/test.rules
+++ b/tests/ssh-lua-rules/test.rules
@@ -1,0 +1,1 @@
+alert ssh:response_banner_done any any -> any any (msg:"TEST SSH LUA"; lua:test-ssh.lua; sid:1; rev:1;)

--- a/tests/ssh-lua-rules/test.yaml
+++ b/tests/ssh-lua-rules/test.yaml
@@ -1,0 +1,15 @@
+pcap: ../ssh-banner-only/input.pcap
+
+requires:
+  min-version: 8
+
+args:
+  - --set security.lua.allow-rules=true -k none
+
+checks:
+  - filter:
+      count: 1
+      match:
+        alert.signature_id: 1
+        # we do not have a toclient packet after server data is acked
+        pkt_src: "stream (flow timeout)"


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7607

#2445 with
- using hook indicating direction `response_banner_done` instead of just `banner_done`
- no debug print in lua
- checking only one alert, that happens at flow timeout