### PR TITLE
Firewall drop http request line

### DIFF
--- a/tests/firewall/ruletype-firewall-31-retrans-of-drop/test.yaml
+++ b/tests/firewall/ruletype-firewall-31-retrans-of-drop/test.yaml
@@ -76,9 +76,14 @@ checks:
       event_type: alert
       alert.signature_id: 206
 - filter:
-    count: 4
+    count: 6
     match:
       event_type: drop
+- filter:
+    count: 1
+    match:
+      event_type: drop
+      pcap_cnt: 4
 - filter:
     count: 1
     match:
@@ -92,7 +97,7 @@ checks:
     count: 1
     match:
       event_type: stats
-      stats.ips.accepted: 5
-      stats.ips.blocked: 4
+      stats.ips.accepted: 3
+      stats.ips.blocked: 6
       stats.ips.drop_reason.default_app_policy: 1
-      stats.ips.drop_reason.flow_drop: 3
+      stats.ips.drop_reason.flow_drop: 5


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/5739

@victorjulien why should we not drop packet 4 and 5 ?
They contain the request line with the not allowed method

This passes with https://github.com/OISF/suricata/pull/13047 or with this minimal diff
```diff
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1703,9 +1703,8 @@ static int HTPCallbackRequestStart(const htp_connp_t *connp, htp_tx_t *tx)
         }
         tx_ud->tx_data.file_tx = STREAM_TOSERVER | STREAM_TOCLIENT; // each http tx may xfer files
         htp_tx_set_user_data(tx, tx_ud);
-    } else {
-        tx_ud->tx_data.updated_ts = true;
     }
+    tx_ud->tx_data.updated_ts = true;
     SCReturnInt(HTP_STATUS_OK);
 }
```