### PR TITLE
ssh: adds test with lua and hassh

### DIFF
--- a/tests/ssh-lua-hassh/test-ssh-resp.lua
+++ b/tests/ssh-lua-hassh/test-ssh-resp.lua
@@ -1,0 +1,16 @@
+local ssh = require("suricata.ssh")
+
+function init (args)
+   ssh.enable_hassh()
+   return {}
+end
+
+function match(args)
+   local tx = ssh.get_tx()
+   local h = tx:server_hassh()
+   print(h)
+   if h == "6832f1ce43d4397c2c0a3e2f8c94334e" then
+      return 1
+   end
+   return 0
+end

--- a/tests/ssh-lua-hassh/test-ssh.lua
+++ b/tests/ssh-lua-hassh/test-ssh.lua
@@ -1,0 +1,16 @@
+local ssh = require("suricata.ssh")
+
+function init (args)
+   ssh.enable_hassh()
+   return {}
+end
+
+function match(args)
+   local tx = ssh.get_tx()
+   local h = tx:client_hassh()
+   print(h)
+   if h == "2dd6531c7e89d3c925db9214711be76a" then
+      return 1
+   end
+   return 0
+end

--- a/tests/ssh-lua-hassh/test.rules
+++ b/tests/ssh-lua-hassh/test.rules
@@ -1,0 +1,2 @@
+alert ssh:request_finished any any -> any any (msg:"TEST SSH LUA"; lua:test-ssh.lua; sid:1; rev:1;)
+alert ssh:response_finished any any -> any any (msg:"TEST SSH LUA"; lua:test-ssh-resp.lua; sid:2; rev:1;)

--- a/tests/ssh-lua-hassh/test.yaml
+++ b/tests/ssh-lua-hassh/test.yaml
@@ -1,0 +1,18 @@
+pcap: ../ssh-hassh/input.pcap
+
+requires:
+  min-version: 8
+
+args:
+  - -k none --set default-rule-path=. --simulate-ips
+  #we could do --set app-layer.protocols.ssh.hassh=yes
+
+checks:
+  - filter:
+      count: 1
+      match:
+        alert.signature_id: 1
+  - filter:
+      count: 1
+      match:
+        alert.signature_id: 2


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7603

#2471 without needs["ssh.hassh"] but `ssh.enable_hassh()`