### PR TITLE
tests/pgsql: add check for redacted password msg - v2

### DIFF
--- a/tests/pgsql/pgsql-pwd-output-disabled/test.yaml
+++ b/tests/pgsql/pgsql-pwd-output-disabled/test.yaml
@@ -62,6 +62,17 @@ checks:
       proto: TCP
       src_ip: 192.168.1.102
       src_port: 41662
+# check to ensure there's no empty request (Bug #7647)
+- filter:
+    min-version: 8
+    count: 1
+    match:
+      dest_ip: 192.168.1.74
+      dest_port: 5432
+      event_type: pgsql
+      pcap_cnt: 12
+      pgsql.response.message: authentication_ok
+      pgsql.request.password_redacted: true
 - filter:
     count: 1
     match:


### PR DESCRIPTION
Bug #7647

## Ticket

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/7647

Previous PR:  https://github.com/OISF/suricata-verify/pull/2468

Changes:
- check for `"password_redacted": true` instead, following Suricata PR changes