### PR TITLE
detect: add test for email.body_md5 keyword - v5

### DIFF
--- a/tests/detect-email-body_md5/README.md
+++ b/tests/detect-email-body_md5/README.md
@@ -1,0 +1,8 @@
+# Test Description
+Test mime email.body_md5 keyword
+
+## PCAP
+From ../bug-3616-smtp/input.pcap
+
+## Redmine Ticket
+https://redmine.openinfosecfoundation.org/issues/7587

--- a/tests/detect-email-body_md5/suricata.yaml
+++ b/tests/detect-email-body_md5/suricata.yaml
@@ -1,0 +1,49 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - smtp:
+            extended: yes # enable this for extended logging information
+            # this includes: bcc, message-id, subject, x_mailer, user-agent
+            # custom fields logging from the list:
+            #  reply-to, bcc, message-id, subject, x-mailer, user-agent, received,
+            #  x-originating-ip, in-reply-to, references, importance, priority,
+            #  sensitivity, organization, content-md5, date
+            #custom: [received, x-mailer, x-originating-ip, relays, reply-to, bcc]
+            # output md5 of fields: body, subject
+            # for the body you need to set app-layer.protocols.smtp.mime.body-md5
+            # to yes
+            md5: [body, subject]
+        - alert:
+            smtp: yes     # enable dumping of smtp fields
+
+
+app-layer:
+  protocols:
+    smtp:
+      enabled: yes
+      raw-extraction: no
+      # Configure SMTP-MIME Decoder
+      mime:
+        # Decode MIME messages from SMTP transactions
+        # (may be resource intensive)
+        # This field supersedes all others because it turns the entire
+        # process on or off
+        decode-mime: yes
+
+        # Decode MIME entity bodies (ie. Base64, quoted-printable, etc.)
+        decode-base64: yes
+        decode-quoted-printable: yes
+
+        # Maximum bytes per header data value stored in the data structure
+        # (default is 2000)
+        header-value-depth: 2000
+
+        # Set to yes to compute the md5 of the mail body. You will then
+        # be able to journalize it.
+        body-md5: yes

--- a/tests/detect-email-body_md5/test.rules
+++ b/tests/detect-email-body_md5/test.rules
@@ -1,0 +1,1 @@
+alert smtp any any -> any any (msg:"Test mime email body_md5"; email.body_md5; content:"ed00c81b85fa455d60e19f1230977134"; sid:1;)

--- a/tests/detect-email-body_md5/test.yaml
+++ b/tests/detect-email-body_md5/test.yaml
@@ -1,0 +1,19 @@
+requires:
+  min-version: 8
+
+pcap: ../bug-3616-smtp/input.pcap
+
+args:
+  - -k none --set stream.inline=true
+
+checks:
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      alert.signature_id: 1
+- filter:
+    count: 1
+    match:
+      event_type: smtp
+      email.body_md5: "ed00c81b85fa455d60e19f1230977134"

--- a/tests/detect-email-received/suricata.yaml
+++ b/tests/detect-email-received/suricata.yaml
@@ -6,24 +6,7 @@ outputs:
       enabled: yes
       filename: eve.json
       types:
-        - alert:
-            tagged-packets: yes
         - smtp:
             custom: [received]    # for 'received' logging information
-        - drop:
-            alerts: yes      # log alerts that caused drops
-            flows: all       # start or all: 'start' logs only a single drop
-        - stats
-        - flow
-  - stats:
-       enabled: yes
-       filename: stats.log
-       append: yes
-
-action-order:
-  - pass
-  - drop
-  - reject
-  - alert
-
-exception-policy: ignore
+        - alert:
+            smtp: yes     # enable dumping of smtp fields

--- a/tests/detect-email-received/test.yaml
+++ b/tests/detect-email-received/test.yaml
@@ -13,18 +13,8 @@ checks:
 - filter:
     count: 1
     match:
-      event_type: smtp
-      email.received[0]: "from client.local (client.local [10.0.0.1]) by smtp.relay1.com with ESMTP id relay1abc; Thu, 10 Apr 2025 12:00:00 -0000"
-- filter:
-    count: 1
-    match:
       event_type: alert
       alert.signature_id: 2
-- filter:
-    count: 1
-    match:
-      event_type: smtp
-      email.received[1]: "from smtp.relay1.com (smtp.relay1.com [10.0.0.10]) by smtp.relay2.com with ESMTP id relay2xyz; Thu, 10 Apr 2025 12:01:00 -0000"
 - filter:
     count: 1
     match:
@@ -34,4 +24,6 @@ checks:
     count: 1
     match:
       event_type: smtp
+      email.received[0]: "from client.local (client.local [10.0.0.1]) by smtp.relay1.com with ESMTP id relay1abc; Thu, 10 Apr 2025 12:00:00 -0000"
+      email.received[1]: "from smtp.relay1.com (smtp.relay1.com [10.0.0.10]) by smtp.relay2.com with ESMTP id relay2xyz; Thu, 10 Apr 2025 12:01:00 -0000"
       email.received[2]: "from smtp.relay2.com (smtp.relay2.com [10.0.0.20]) by smtp.destination.com with ESMTP id final123; Thu, 10 Apr 2025 12:02:00 -0000"


### PR DESCRIPTION
Ticket: [7587](https://redmine.openinfosecfoundation.org/issues/7587)

Description:
- Add S-V test for MIME ``email.body_md5`` keyword

Changes:
- rebase

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/7587

Suricata PR:
Previous PR: https://github.com/OISF/suricata-verify/pull/2462

