### PR TITLE
tests: fix double stats record throwing test off

### DIFF
--- a/tests/elephant-flow-tracking/test.yaml
+++ b/tests/elephant-flow-tracking/test.yaml
@@ -1,5 +1,8 @@
 pcap: ../tcp-urgp-09-oob-exceed-limit-inline/tcp-urgent-1byte-66k.pcap
 
+args:
+- --set stats.interval=3600
+
 requires:
   min-version: 8
 


### PR DESCRIPTION
Set longer stats interval just like the test owning the pcap.


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
