### PR TITLE
tests/rules: add test for bug 5177 - v1

### DIFF
--- a/tests/rules/bug-5177/bug-5177.rules
+++ b/tests/rules/bug-5177/bug-5177.rules
@@ -1,0 +1,3 @@
+# rule 61 uses the new buffer and shouldn't get a warning issued, but it does
+alert http any any -> any any (http.request_line; content:"GET /index.html HTTP/1.0"; sid:61;)
+alert http any any -> any any (http_request_line; content:"GET /index.html HTTP/1.0"; sid:62;)

--- a/tests/rules/bug-5177/test.yaml
+++ b/tests/rules/bug-5177/test.yaml
@@ -1,0 +1,25 @@
+requires:
+    min-version: 7
+    pcap: false
+
+args:
+- --engine-analysis
+
+checks:
+    - filter:
+        # rule 61 uses the new buffer and shouldn't have a warning issued
+        filename: rules.json
+        count: 1
+        match:
+            id: 61
+            raw: "alert http any any -> any any (http.request_line; content:\"GET /index.html HTTP/1.0\"; sid:61;)"
+            warnings[0]: "pattern looks like it inspects HTTP, use http.request_line or http.method and http.uri instead for improved performance"
+            warnings[1]: "pattern looks like it inspects HTTP, use http.request_line or http.method and http.uri instead for improved performance"
+    - filter:
+        filename: rules.json
+        count: 1
+        match:
+            id: 62
+            raw: "alert http any any -> any any (http_request_line; content:\"GET /index.html HTTP/1.0\"; sid:62;)"
+            warnings[0]: "pattern looks like it inspects HTTP, use http.request_line or http.method and http.uri instead for improved performance"
+            warnings[1]: "pattern looks like it inspects HTTP, use http.request_line or http.method and http.uri instead for improved performance"


### PR DESCRIPTION
The engine analyzer issues the same warning about deprecated HTTP method usage for a rule using the new buffer and the old ones.

Bug #5177

Sharing the SV test to show the behavior. I can't see the output in other logs, but as the test shows, the warning is present in the engine analysis `rules.json` output.

## Ticket

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/5177