### PR TITLE
tests/rules: add test for bug 5177 - v4

### DIFF
--- a/tests/rules/bug-5177/bug-5177.rules
+++ b/tests/rules/bug-5177/bug-5177.rules
@@ -1,0 +1,2 @@
+alert http any any -> any any (http.request_line; content:"GET /index.html HTTP/1.0"; sid:61;)
+alert http any any -> any any (http_request_line; content:"GET /index.html HTTP/1.0"; sid:62;)

--- a/tests/rules/bug-5177/test.yaml
+++ b/tests/rules/bug-5177/test.yaml
@@ -1,0 +1,24 @@
+requires:
+    min-version: 8
+    pcap: false
+
+args:
+- --engine-analysis
+
+checks:
+    - filter:
+        filename: rules.json
+        count: 1
+        match:
+            id: 61
+            raw: "alert http any any -> any any (http.request_line; content:\"GET /index.html HTTP/1.0\"; sid:61;)"
+            notes[0]: "pattern looks like it inspects HTTP, use http.request_line or http.method and http.uri instead for improved performance"
+            notes[1]: "pattern looks like it inspects HTTP, use http.request_line or http.method and http.uri instead for improved performance"
+    - filter:
+        filename: rules.json
+        count: 1
+        match:
+            id: 62
+            raw: "alert http any any -> any any (http_request_line; content:\"GET /index.html HTTP/1.0\"; sid:62;)"
+            notes[0]: "pattern looks like it inspects HTTP, use http.request_line or http.method and http.uri instead for improved performance"
+            notes[1]: "pattern looks like it inspects HTTP, use http.request_line or http.method and http.uri instead for improved performance"


### PR DESCRIPTION
The engine analyzer issues the same note about using new rule buffers regardless of the rule usage of new buffer or the old ones. This test is just to showcase this.

Bug #5177

Previous PR: https://github.com/OISF/suricata-verify/pull/2530

Changes from previous PR:
- change from `warnings` to `notes`
- rebase
- reword commit message

## Ticket

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/5177