### PR TITLE
tests: remove exit-code check for datasets-absolute-allowed

### DIFF
--- a/tests/datasets/datasets-absolute-allowed/test.yaml
+++ b/tests/datasets/datasets-absolute-allowed/test.yaml
@@ -3,11 +3,6 @@ pcap: ../../datasets/datasets-parent-path/one-packet.pcap
 args:
   - -vvv
 
-# Due to differences between user-mode and system-mode, these rules
-# will actually fail. Instead we're testing to make sure we got past
-# the check for absolute filenames.
-exit-code: 1
-
 checks:
   - filter:
       count: 1


### PR DESCRIPTION
With the commit in Suricata to skip adding localstatedir when a full path is provided, the S-V test does not exit with 1 anymore but rather with 0 since it succeeds.

Ticket: 7083


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7083
