### PR TITLE
tests: remove exit-code check for datasets-absolute-allowed on Surica…

### DIFF
--- a/tests/datasets/datasets-absolute-allowed-post8-winonly/README.md
+++ b/tests/datasets/datasets-absolute-allowed-post8-winonly/README.md
@@ -1,0 +1,2 @@
+Test that the configuration option to allow absolute dataset filenames
+in rules works.

--- a/tests/datasets/datasets-absolute-allowed-post8-winonly/suricata.yaml
+++ b/tests/datasets/datasets-absolute-allowed-post8-winonly/suricata.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+---
+
+datasets:
+  rules:
+    allow-absolute-filenames: true
+
+logging:
+  outputs:
+    - file:
+        enabled: yes
+        filename: eve.json
+        type: json

--- a/tests/datasets/datasets-absolute-allowed-post8-winonly/test.rules
+++ b/tests/datasets/datasets-absolute-allowed-post8-winonly/test.rules
@@ -1,0 +1,3 @@
+alert dns any any -> any any (dns.query; dataset: isnotset, dns-seen, type string, state C:\Windows\Temp\dns-seen.txt; sid:1; rev:1;)
+alert dns any any -> any any (dns.query; dataset: isnotset, dns-seen-save, type string, save C:\Windows\Temp\dns-seen-save.txt; sid:2; rev:1;)
+alert dns any any -> any any (dns.query; dataset: isnotset, dns-seen-parent, type string, state C:\Windows\Temp\..\Temp\dns-seen.txt; sid:3; rev:1;)

--- a/tests/datasets/datasets-absolute-allowed-post8-winonly/test.yaml
+++ b/tests/datasets/datasets-absolute-allowed-post8-winonly/test.yaml
@@ -1,0 +1,22 @@
+pcap: ../../datasets/datasets-parent-path/one-packet.pcap
+
+requires:
+  min-version: 8
+  lambda: sys.platform == "win32"
+
+args:
+  - -vvv
+
+checks:
+  - filter:
+      count: 1
+      match:
+        engine.message: "Allowing absolute filename for dataset rule: C:\Windows\Temp\dns-seen.txt"
+  - filter:
+      count: 1
+      match:
+        engine.message: "Allowing absolute filename for dataset rule: C:\Windows\Temp\dns-seen-save.txt"
+  - filter:
+      count: 1
+      match:
+        engine.message: "Allowing absolute filename for dataset rule: C:\Windows\Temp\..\Temp\dns-seen.txt"

--- a/tests/datasets/datasets-absolute-allowed-post8/README.md
+++ b/tests/datasets/datasets-absolute-allowed-post8/README.md
@@ -1,0 +1,2 @@
+Test that the configuration option to allow absolute dataset filenames
+in rules works.

--- a/tests/datasets/datasets-absolute-allowed-post8/suricata.yaml
+++ b/tests/datasets/datasets-absolute-allowed-post8/suricata.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+---
+
+datasets:
+  rules:
+    allow-absolute-filenames: true
+
+logging:
+  outputs:
+    - file:
+        enabled: yes
+        filename: eve.json
+        type: json

--- a/tests/datasets/datasets-absolute-allowed-post8/test.rules
+++ b/tests/datasets/datasets-absolute-allowed-post8/test.rules
@@ -1,0 +1,3 @@
+alert dns any any -> any any (dns.query; dataset: isnotset, dns-seen, type string, state /tmp/dns-seen.txt; sid:1; rev:1;)
+alert dns any any -> any any (dns.query; dataset: isnotset, dns-seen-save, type string, save /tmp/dns-seen-save.txt; sid:2; rev:1;)
+alert dns any any -> any any (dns.query; dataset: isnotset, dns-seen-parent, type string, state /tmp/../tmp/dns-seen.txt; sid:3; rev:1;)

--- a/tests/datasets/datasets-absolute-allowed-post8/test.yaml
+++ b/tests/datasets/datasets-absolute-allowed-post8/test.yaml
@@ -1,15 +1,12 @@
 pcap: ../../datasets/datasets-parent-path/one-packet.pcap
 
+# this needs at least Suricata 8 and based on the absolute path will not work on Windows
 requires:
-  lt-version: 8
+  min-version: 8
+  lambda: sys.platform != "win32"
 
 args:
   - -vvv
-
-# Due to differences between user-mode and system-mode, these rules
-# will actually fail. Instead we're testing to make sure we got past
-# the check for absolute filenames.
-exit-code: 1
 
 checks:
   - filter:


### PR DESCRIPTION
With the commit in Suricata to skip adding localstatedir when a full path is provided, the S-V test does not exit with 1 anymore but rather with 0 since it succeeds.

This commits updates the previous test to run with Suricata prior to verison 8 and a dedicated copy of the test to work with Suricata 8 without the need to check the exit code anymore, since it's 0.


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7083
