### PR TITLE
tests/lua: simply return of empty needs

### DIFF
--- a/tests/datasets/datasets-lua-02/dataset-dns.lua
+++ b/tests/datasets/datasets-lua-02/dataset-dns.lua
@@ -4,8 +4,7 @@ local dns = require("suricata.dns")
 local logger = require("suricata.log")
 
 function init (args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function thread_init (args)

--- a/tests/dns-lua-rules/test-request.lua
+++ b/tests/dns-lua-rules/test-request.lua
@@ -1,8 +1,7 @@
 local dns = require("suricata.dns")
 
 function init (args)
-   local needs = {}
-   return needs
+   return {}
 end
 
 function count(t)

--- a/tests/dns-lua-rules/test-response.lua
+++ b/tests/dns-lua-rules/test-response.lua
@@ -1,8 +1,7 @@
 local dns = require("suricata.dns")
 
 function init (args)
-   local needs = {}
-   return needs
+   return {}
 end
 
 function count(t)

--- a/tests/dns-lua-rules/test-rrname.lua
+++ b/tests/dns-lua-rules/test-rrname.lua
@@ -1,8 +1,7 @@
 local dns = require("suricata.dns")
 
 function init (args)
-   local needs = {}
-   return needs
+   return {}
 end
 
 function match(args)

--- a/tests/lua-detect-http-01/test-request-headers-raw.lua
+++ b/tests/lua-detect-http-01/test-request-headers-raw.lua
@@ -3,8 +3,7 @@ local packet = require "suricata.packet"
 local http = require("suricata.http")
 
 function init (args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match(args)

--- a/tests/lua-detect-http-01/test-request-line.lua
+++ b/tests/lua-detect-http-01/test-request-line.lua
@@ -2,8 +2,7 @@
 local http = require("suricata.http")
 
 function init (args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match(args)

--- a/tests/lua-detect-http-01/test-response-body.lua
+++ b/tests/lua-detect-http-01/test-response-body.lua
@@ -2,8 +2,7 @@
 local http = require("suricata.http")
 
 function init (args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match(args)

--- a/tests/lua-detect-http-01/test-response-headers-raw.lua
+++ b/tests/lua-detect-http-01/test-response-headers-raw.lua
@@ -3,8 +3,7 @@ local packet = require "suricata.packet"
 local http = require("suricata.http")
 
 function init (args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match(args)

--- a/tests/lua-match-scrule/lua-scrule-action.lua
+++ b/tests/lua-match-scrule/lua-scrule-action.lua
@@ -1,8 +1,7 @@
 local rule = require("suricata.rule")
 
 function init(args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match(args)

--- a/tests/lua-match-scrule/lua-scrule-class.lua
+++ b/tests/lua-match-scrule/lua-scrule-class.lua
@@ -1,8 +1,7 @@
 local rule = require("suricata.rule")
 
 function init(args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match(args)

--- a/tests/lua-match-scrule/lua-scrule-ids.lua
+++ b/tests/lua-match-scrule/lua-scrule-ids.lua
@@ -1,8 +1,7 @@
 local rule = require("suricata.rule")
 
 function init(args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match(args)

--- a/tests/lua-match-scrule/lua-scrule-msg.lua
+++ b/tests/lua-match-scrule/lua-scrule-msg.lua
@@ -1,8 +1,7 @@
 local rule = require("suricata.rule")
 
 function init(args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match(args)

--- a/tests/lua/lua-base64/rule.lua
+++ b/tests/lua/lua-base64/rule.lua
@@ -8,8 +8,7 @@ local expected_base64_nopad = "d3d3LnN1cmljYXRhLWlkcy5vcmc"
 local input_base64_with_spaces = "d3 d3 Ln N1 cm lj YX Rh LW lk cy 5v cm c="
 
 function init (args)
-   local needs = {}
-   return needs
+   return {}
 end
 
 function match(args)

--- a/tests/lua/lua-hashlib/test-hashing.lua
+++ b/tests/lua/lua-hashlib/test-hashing.lua
@@ -8,8 +8,7 @@ local expected_sha1 = "00f495ffd50c8b5ef3645f61486dae496db0fe2e"
 local expected_md5 = "27170ec0609347c6a158bb5b694822a5"
 
 function init (args)
-   local needs = {}
-   return needs
+   return {}
 end
 
 local function tohex(str)

--- a/tests/lua/lua-packetlib-01/packet.lua
+++ b/tests/lua/lua-packetlib-01/packet.lua
@@ -2,8 +2,7 @@ local packet = require "suricata.packet"
 local logger = require "suricata.log"
 
 function init (args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match (args)

--- a/tests/lua/lua-packetlib-02-restricted-funcs-allowed/packet.lua
+++ b/tests/lua/lua-packetlib-02-restricted-funcs-allowed/packet.lua
@@ -2,8 +2,7 @@ local packet = require "suricata.packet"
 local logger = require("suricata.log")
 
 function init (args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match (args)

--- a/tests/lua/lua-packetlib-03/packet.lua
+++ b/tests/lua/lua-packetlib-03/packet.lua
@@ -2,8 +2,7 @@ local packet = require "suricata.packet"
 local logger = require("suricata.log")
 
 function init (args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match (args)

--- a/tests/lua/lua-packetlib-04-icmp-spdp/packet.lua
+++ b/tests/lua/lua-packetlib-04-icmp-spdp/packet.lua
@@ -2,8 +2,7 @@ local packet = require "suricata.packet"
 local logger = require("suricata.log")
 
 function init (args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match (args)

--- a/tests/lua/lua-packetlib-05-default-enabled/packet.lua
+++ b/tests/lua/lua-packetlib-05-default-enabled/packet.lua
@@ -2,8 +2,7 @@ local packet = require "suricata.packet"
 local logger = require("suricata.log")
 
 function init (args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match (args)

--- a/tests/lua/lua-tlslib-02/lua-tlsfunctions.lua
+++ b/tests/lua/lua-tlslib-02/lua-tlsfunctions.lua
@@ -1,9 +1,7 @@
 local tls = require("suricata.tls")
 
 function init (args)
-    local needs = {}
-    -- needs["tls"] = true
-    return needs
+    return {}
 end
 
 function match(args)

--- a/tests/pre8/lua-match-scrule/lua-scrule-action.lua
+++ b/tests/pre8/lua-match-scrule/lua-scrule-action.lua
@@ -1,6 +1,5 @@
 function init(args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match(args)

--- a/tests/pre8/lua-match-scrule/lua-scrule-class.lua
+++ b/tests/pre8/lua-match-scrule/lua-scrule-class.lua
@@ -1,6 +1,5 @@
 function init(args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match(args)

--- a/tests/pre8/lua-match-scrule/lua-scrule-ids.lua
+++ b/tests/pre8/lua-match-scrule/lua-scrule-ids.lua
@@ -1,6 +1,5 @@
 function init(args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match(args)

--- a/tests/pre8/lua-match-scrule/lua-scrule-msg.lua
+++ b/tests/pre8/lua-match-scrule/lua-scrule-msg.lua
@@ -1,6 +1,5 @@
 function init(args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match(args)

--- a/tests/tls/tls-ja3s-requires-off/test-ja3s-hash.lua
+++ b/tests/tls/tls-ja3s-requires-off/test-ja3s-hash.lua
@@ -1,6 +1,5 @@
 function init(args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match(args)

--- a/tests/tls/tls-ja3s-requires-off/test-ja3s-string.lua
+++ b/tests/tls/tls-ja3s-requires-off/test-ja3s-string.lua
@@ -1,6 +1,5 @@
 function init(args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match(args)

--- a/tests/tls/tls-ja3s-requires/test-ja3s-hash.lua
+++ b/tests/tls/tls-ja3s-requires/test-ja3s-hash.lua
@@ -1,6 +1,5 @@
 function init(args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match(args)

--- a/tests/tls/tls-ja3s-requires/test-ja3s-string.lua
+++ b/tests/tls/tls-ja3s-requires/test-ja3s-string.lua
@@ -1,6 +1,5 @@
 function init(args)
-    local needs = {}
-    return needs
+    return {}
 end
 
 function match(args)


### PR DESCRIPTION
Just "return {}". Makes it easier to extract what is actually being returned here for comparison with the documentation.
