### PR TITLE
tests: update bug-4571 tests related to ipv4/ipv6 over ipv6 to suri 7 - v1

### DIFF
--- a/tests/bug-4571-03-pre-8/README.md
+++ b/tests/bug-4571-03-pre-8/README.md
@@ -1,0 +1,13 @@
+# Test
+
+Check for proper engine behavior for IPv6 over IPv6 tunneling, including the
+setting of the parent flow in such cases.
+
+## Pcap
+
+Shared by reporter on Redmine ticket.
+
+## Ticket
+
+https://redmine.openinfosecfoundation.org/issues/7752
+https://redmine.openinfosecfoundation.org/issues/7777

--- a/tests/bug-4571-03-pre-8/suricata.yaml
+++ b/tests/bug-4571-03-pre-8/suricata.yaml
@@ -1,0 +1,28 @@
+%YAML 1.1
+---
+decoder:
+  ipv6:
+    ipip-ipv6:
+      track-parent-flow: true
+
+stats:
+  enabled: yes
+  interval: 8
+
+logging:
+  default-log-level: notice
+  default-output-filter:
+  outputs:
+  - console:
+      enabled: yes
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert
+        - drop:
+            alerts: yes
+        - flow

--- a/tests/bug-4571-03-pre-8/test.rules
+++ b/tests/bug-4571-03-pre-8/test.rules
@@ -1,0 +1,1 @@
+alert tcp any any -> any any (msg:"found"; content: "hello"; sid:1;)

--- a/tests/bug-4571-03-pre-8/test.yaml
+++ b/tests/bug-4571-03-pre-8/test.yaml
@@ -1,0 +1,42 @@
+requires:
+  min-version: 7.0.12
+
+pcap: ../bug-4571-03/ipv6_over_ipv6.pcap
+
+args:
+- -k none
+- --simulate-ips
+- --set stream.midstream=true
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 1
+        pkt_src: ipv6 tunnel
+        proto: TCP
+        src_ip: 2001:0db8:85a3:0000:0000:8a2e:0370:8334
+        dest_ip: 2001:0db8:85a3:0000:0000:8a2e:0370:8335
+        tunnel.src_ip: 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        tunnel.dest_ip: 2001:0db8:85a3:0000:0000:8a2e:0370:7335
+        tunnel.proto: IPv6
+  - filter:
+      count: 1
+      match:
+        event_type: flow
+        proto: TCP
+        src_ip: 2001:0db8:85a3:0000:0000:8a2e:0370:8334
+        dest_ip: 2001:0db8:85a3:0000:0000:8a2e:0370:8335
+        flow.alerted: true
+  - filter:
+      count: 1
+      match:
+        event_type: flow
+        proto: IPv6
+        src_ip: 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        dest_ip: 2001:0db8:85a3:0000:0000:8a2e:0370:7335
+  - filter:
+      count: 2
+      match:
+        event_type: flow

--- a/tests/bug-4571-03/test.yaml
+++ b/tests/bug-4571-03/test.yaml
@@ -32,6 +32,7 @@ checks:
   - filter:
       count: 1
       match:
+        event_type: flow
         proto: IPv6
         ip_v: 6
         src_ip: 2001:0db8:85a3:0000:0000:8a2e:0370:7334

--- a/tests/bug-4571-06-pre-8/README.md
+++ b/tests/bug-4571-06-pre-8/README.md
@@ -1,0 +1,11 @@
+# Test
+
+Check for proper engine behavior for IPv4 over IPv6 tunneling.
+
+## Pcap
+
+Shared by reporter on Redmine ticket.
+
+## Ticket
+
+https://redmine.openinfosecfoundation.org/issues/4571

--- a/tests/bug-4571-06-pre-8/suricata.yaml
+++ b/tests/bug-4571-06-pre-8/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+decoder:
+  ipv6:
+    ipip-ipv4:
+      track-parent-flow: true
+
+stats:
+  enabled: yes
+  interval: 8
+
+logging:
+  default-log-level: notice
+  default-output-filter:
+  outputs:
+  - console:
+      enabled: yes
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert
+        - drop:
+            alerts: yes
+        - flow

--- a/tests/bug-4571-06-pre-8/test.rules
+++ b/tests/bug-4571-06-pre-8/test.rules
@@ -1,0 +1,1 @@
+alert tcp any any -> any any (msg:"found"; content: "hello"; sid:1;)

--- a/tests/bug-4571-06-pre-8/test.yaml
+++ b/tests/bug-4571-06-pre-8/test.yaml
@@ -1,0 +1,39 @@
+requires:
+  min-version: 7.0.12
+
+pcap: ../bug-4571-06/ipv4_over_ipv6.pcap
+
+args:
+- -k none
+- --simulate-ips
+- --set stream.midstream=true
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 1
+        proto: TCP
+        pkt_src: ipv6 tunnel
+        src_ip: 10.1.0.1
+        dest_ip: 10.1.0.2
+        tunnel.src_ip: 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        tunnel.dest_ip: 2001:0db8:85a3:0000:0000:8a2e:0370:7335
+        tunnel.proto: IP-in-IP
+  - filter:
+      count: 1
+      match:
+        event_type: flow
+        proto: TCP
+        src_ip: 10.1.0.1
+        dest_ip: 10.1.0.2
+        flow.alerted: true
+  - filter:
+      count: 1
+      match:
+        event_type: flow
+        proto: IP-in-IP
+        src_ip: 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        dest_ip: 2001:0db8:85a3:0000:0000:8a2e:0370:7335
+        flow.alerted: false


### PR DESCRIPTION
While the bug is 7752, the tests for 4571 covered this case, so kept them.
- Created a separated test for pre-8
- Noticed that one of the checks in the 8 test was missing an event, so there's a commit for that, too.

## Ticket

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/7777 (backport ticket)
https://redmine.openinfosecfoundation.org/issues/7752