### PR TITLE
flowbits: add tests for invalid flowbit cmd combinations

### DIFF
--- a/tests/flowbits-invalid-01/suricata.yaml
+++ b/tests/flowbits-invalid-01/suricata.yaml
@@ -1,0 +1,12 @@
+%YAML 1.1
+---
+
+engine-analysis:
+  rules: yes
+
+logging:
+  outputs:
+    - file:
+        enabled: yes
+        filename: eve.json
+        type: json

--- a/tests/flowbits-invalid-01/test.rules
+++ b/tests/flowbits-invalid-01/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (msg: "Illegal flowbit set + isset combination"; http.method; content:"GET"; flowbits:set,fb1; flowbits:isset,fb1; sid:111;)

--- a/tests/flowbits-invalid-01/test.yaml
+++ b/tests/flowbits-invalid-01/test.yaml
@@ -1,0 +1,16 @@
+requires:
+  min-version: 8
+
+pcap: false
+
+exit-code: 1
+
+args:
+  - --engine-analysis
+
+checks:
+  - filter:
+      count: 1
+      match:
+        log_level: Error
+        engine.message: "invalid flowbit command combination in the same signature: set and isset"

--- a/tests/flowbits-invalid-02/suricata.yaml
+++ b/tests/flowbits-invalid-02/suricata.yaml
@@ -1,0 +1,12 @@
+%YAML 1.1
+---
+
+engine-analysis:
+  rules: yes
+
+logging:
+  outputs:
+    - file:
+        enabled: yes
+        filename: eve.json
+        type: json

--- a/tests/flowbits-invalid-02/test.rules
+++ b/tests/flowbits-invalid-02/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (msg: "Illegal flowbit unset + isnotset combination"; http.method; content:"GET"; flowbits:unset,fb1; flowbits:isnotset,fb1; sid:111;)

--- a/tests/flowbits-invalid-02/test.yaml
+++ b/tests/flowbits-invalid-02/test.yaml
@@ -1,0 +1,16 @@
+requires:
+  min-version: 8
+
+pcap: false
+
+exit-code: 1
+
+args:
+  - --engine-analysis
+
+checks:
+  - filter:
+      count: 1
+      match:
+        log_level: Error
+        engine.message: "invalid flowbit command combination in the same signature: unset and isnotset"

--- a/tests/flowbits-invalid-03/suricata.yaml
+++ b/tests/flowbits-invalid-03/suricata.yaml
@@ -1,0 +1,12 @@
+%YAML 1.1
+---
+
+engine-analysis:
+  rules: yes
+
+logging:
+  outputs:
+    - file:
+        enabled: yes
+        filename: eve.json
+        type: json

--- a/tests/flowbits-invalid-03/test.rules
+++ b/tests/flowbits-invalid-03/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (msg: "Illegal flowbit set + toggle combination"; http.method; content:"GET"; flowbits:set,fb1; flowbits:toggle,fb1; sid:111;)

--- a/tests/flowbits-invalid-03/test.yaml
+++ b/tests/flowbits-invalid-03/test.yaml
@@ -1,0 +1,16 @@
+requires:
+  min-version: 8
+
+pcap: false
+
+exit-code: 1
+
+args:
+  - --engine-analysis
+
+checks:
+  - filter:
+      count: 1
+      match:
+        log_level: Error
+        engine.message: "invalid flowbit command combination in the same signature: set and toggle"

--- a/tests/flowbits-invalid-04/suricata.yaml
+++ b/tests/flowbits-invalid-04/suricata.yaml
@@ -1,0 +1,12 @@
+%YAML 1.1
+---
+
+engine-analysis:
+  rules: yes
+
+logging:
+  outputs:
+    - file:
+        enabled: yes
+        filename: eve.json
+        type: json

--- a/tests/flowbits-invalid-04/test.rules
+++ b/tests/flowbits-invalid-04/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (msg: "Illegal flowbit isset + isnot combination"; http.method; content:"GET"; flowbits:isset,fb1; flowbits:isnotset,fb1; sid:111;)

--- a/tests/flowbits-invalid-04/test.yaml
+++ b/tests/flowbits-invalid-04/test.yaml
@@ -1,0 +1,16 @@
+requires:
+  min-version: 8
+
+pcap: false
+
+exit-code: 1
+
+args:
+  - --engine-analysis
+
+checks:
+  - filter:
+      count: 1
+      match:
+        log_level: Error
+        engine.message: "invalid flowbit command combination in the same signature: isset and isnotset"

--- a/tests/flowbits-invalid-05/suricata.yaml
+++ b/tests/flowbits-invalid-05/suricata.yaml
@@ -1,0 +1,12 @@
+%YAML 1.1
+---
+
+engine-analysis:
+  rules: yes
+
+logging:
+  outputs:
+    - file:
+        enabled: yes
+        filename: eve.json
+        type: json

--- a/tests/flowbits-invalid-05/test.rules
+++ b/tests/flowbits-invalid-05/test.rules
@@ -1,0 +1,1 @@
+alert http any any -> any any (msg: "Illegal flowbit set + unset combination"; http.method; content:"GET"; flowbits:set,fb1; flowbits:unset,fb1; sid:111;)

--- a/tests/flowbits-invalid-05/test.yaml
+++ b/tests/flowbits-invalid-05/test.yaml
@@ -1,0 +1,16 @@
+requires:
+  min-version: 8
+
+pcap: false
+
+exit-code: 1
+
+args:
+  - --engine-analysis
+
+checks:
+  - filter:
+      count: 1
+      match:
+        log_level: Error
+        engine.message: "invalid flowbit command combination in the same signature: set and unset"


### PR DESCRIPTION
## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine tickets:
- https://redmine.openinfosecfoundation.org/issues/7772
- https://redmine.openinfosecfoundation.org/issues/7773
- https://redmine.openinfosecfoundation.org/issues/7774
- https://redmine.openinfosecfoundation.org/issues/7817
- https://redmine.openinfosecfoundation.org/issues/7818

Previous PR: https://github.com/OISF/suricata-verify/pull/2602

Changes since v2:
- changed the output to include the commands 