### PR TITLE
snmp: add test when snmp is disabled

### DIFF
--- a/tests/snmp-disabled/README.md
+++ b/tests/snmp-disabled/README.md
@@ -1,0 +1,5 @@
+Test when snmp is disabled
+
+Pcap reused
+
+Ticket https://redmine.openinfosecfoundation.org/issues/7820

--- a/tests/snmp-disabled/suricata.yaml
+++ b/tests/snmp-disabled/suricata.yaml
@@ -1,0 +1,15 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - flow
+
+app-layer:
+  protocols:
+    snmp:
+      enabled: no

--- a/tests/snmp-disabled/test.yaml
+++ b/tests/snmp-disabled/test.yaml
@@ -1,0 +1,11 @@
+args:
+  - -k none
+
+pcap: ../snmp-v2c-get/SNMPv2c_get_requests.pcap
+
+checks:
+ - filter:
+     count: 0
+     match:
+       event_type: flow
+       app_proto: snmp


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7820

#2604  clean history

Do not try to log snmp if we do not enable it, but check that we do not see snmp flows