### PR TITLE
test/from_base64: Use transform with default values

### DIFF
--- a/tests/from_base64-04/README.md
+++ b/tests/from_base64-04/README.md
@@ -1,0 +1,1 @@
+from_base64 transform tests with default arguments

--- a/tests/from_base64-04/test.rules
+++ b/tests/from_base64-04/test.rules
@@ -1,0 +1,1 @@
+alert smtp any any -> any any (msg:"Decode User value";frame:smtp.command_line; from_base64; content:"galunt"; sid:1;)

--- a/tests/from_base64-04/test.yaml
+++ b/tests/from_base64-04/test.yaml
@@ -1,0 +1,22 @@
+requires:
+  min-version: 8.0.1
+
+pcap: ../smtp-long-DATA-line/input.pcap
+
+args:
+  - -k none
+
+checks:
+  - filter:
+      count: 1
+      match:
+         event_type: alert
+         alert.signature_id: 1
+         frame.payload: "WjJGc2RXNTANCg=="
+
+  - filter:
+      count: 1
+      match:
+         event_type: alert
+         alert.signature_id: 1
+         frame.payload: "WjJGc2RXNTA="


### PR DESCRIPTION
This test uses default values for the parameters accepted by from_base64:
- bytes
- offset
- decode type

Issue: 7853


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket:
