### PR TITLE
detect/prefilter: backport checks u8 prefilter with more modes

### DIFF
--- a/tests/detect-itype-prefilter/test.yaml
+++ b/tests/detect-itype-prefilter/test.yaml
@@ -13,19 +13,16 @@ checks:
         event_type: alert
         alert.signature_id: 2
   - filter:
-      min-version: 8.0.1
       count: 150
       match:
         event_type: alert
         alert.signature_id: 3
   - filter:
-      min-version: 8.0.1
       count: 75
       match:
         event_type: alert
         alert.signature_id: 4
   - filter:
-      min-version: 8.0.1
       count: 75
       match:
         event_type: alert


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7866

After https://github.com/OISF/suricata-verify/pull/2625