### PR TITLE
runner: respect CARGO env var when building eve validator

### DIFF
--- a/run.py
+++ b/run.py
@@ -1158,8 +1158,9 @@ def build_eve_validator():
     env = os.environ.copy()
     if "CARGO_BUILD_TARGET" in env:
         del env["CARGO_BUILD_TARGET"]
+    cargo = env.get("CARGO", "cargo")
     subprocess.check_call(
-            "cargo build --release", cwd=os.path.join(TOPDIR, "eve-validator"),
+            "{} build --release".format(cargo), cwd=os.path.join(TOPDIR, "eve-validator"),
             shell=True, env=env)
 
 def main():


### PR DESCRIPTION
For cases where "cargo" does not exist, but "cargo-1.82" does.

Ticket: #7877
