### PR TITLE
test/unknown: Use host order for ethtype check

### DIFF
--- a/tests/decode-unknown-2/test.yaml
+++ b/tests/decode-unknown-2/test.yaml
@@ -1,5 +1,3 @@
-requires:
-    min-version: 8
 
 args:
 - -k none
@@ -16,6 +14,16 @@ checks:
       decoder.unknown_ethertype: 1
   - filter:
       count: 1
+      min-version: 9
+      match:
+        event_type: anomaly
+        ether.ether_type: 64439
+        anomaly.type: decode
+        anomaly.event: decoder.ethernet.unknown_ethertype
+  - filter:
+      count: 1
+      min-version: 8
+      lt-version: 9
       match:
         event_type: anomaly
         ether.ether_type: 47099


### PR DESCRIPTION
Issue: 7855

Match the ethertype value using host order.


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7855
