### PR TITLE
detect/files: backport nfs test over udp only to 8

### DIFF
--- a/tests/nfs-udp-only/test.yaml
+++ b/tests/nfs-udp-only/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.2
 
 pcap: ../issue-3277-nfsv2-filestore/nfsv2.pcap
 


### PR DESCRIPTION
## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/7974
