### PR TITLE
tests/lua-gc-nil: set min-version to 8.0.4 - v2

### DIFF
--- a/tests/lua/lua-gc-nil/test.yaml
+++ b/tests/lua/lua-gc-nil/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9.0.0
+  min-version: 8.0.4
 
 args:
   - --set default-rule-path=${TEST_DIR}


### PR DESCRIPTION
Ticket: https://redmine.openinfosecfoundation.org/issues/8249
