### PR TITLE
misc: cleanup requires inside checks - v1

### DIFF
--- a/run.py
+++ b/run.py
@@ -461,6 +461,9 @@ def rule_is_version_compatible(rulefile, suri_version):
 class FileCompareCheck:
 
     def __init__(self, config, directory, cwd):
+        for key in config:
+            if key not in ["requires", "filename", "expected"]:
+                raise Exception("Unexpected key in file-compare check: {}".format(key))
         self.config = config
         self.directory = directory
         self.cwd = cwd

--- a/run.py
+++ b/run.py
@@ -483,6 +483,9 @@ class FileCompareCheck:
 class ShellCheck:
 
     def __init__(self, config, env, suricata_config, output_dir, test_dir):
+        for key in config:
+            if key not in ["requires", "args", "expect"]:
+                raise Exception("Unexpected key in shell check: {}".format(key))
         self.config = config
         self.env = env
         self.suricata_config = suricata_config
@@ -490,19 +493,10 @@ class ShellCheck:
         self.script_cwd = test_dir
 
     def run(self):
-        shell_args = {}
         if not self.config or "args" not in self.config:
             raise TestError("shell check missing args")
-        req_version = self.config.get("version")
-        min_version = self.config.get("min-version")
-        lt_version = self.config.get("lt-version")
-        if req_version is not None:
-            shell_args["version"] = req_version
-        if min_version is not None:
-            shell_args["min-version"] = min_version
-        if lt_version is not None:
-            shell_args["lt-version"] = lt_version
-        check_requires(shell_args, self.suricata_config, self.script_cwd)
+        requires = self.config.get("requires", {})
+        check_requires(requires, self.suricata_config, self.script_cwd)
 
         try:
             if WIN32:

--- a/run.py
+++ b/run.py
@@ -533,6 +533,9 @@ class StatsCheck:
 class FilterCheck:
 
     def __init__(self, config, outdir, suricata_config, test_version, script_cwd=None):
+        for key in config:
+            if key not in ["count", "match", "filename", "requires"]:
+                raise Exception("Unexpected key in filter check: {}".format(key))
         self.config = config
         self.outdir = outdir
         self.suricata_config = suricata_config
@@ -542,19 +545,7 @@ class FilterCheck:
 
     def run(self):
         requires = self.config.get("requires", {})
-        req_version = self.config.get("version")
-        min_version = self.config.get("min-version")
-        lt_version = self.config.get("lt-version")
-        if req_version is not None:
-            requires["version"] = req_version
-        if min_version is not None:
-            requires["min-version"] = min_version
-        if lt_version is not None:
-            requires["lt-version"] = lt_version
         check_filter_test_version_compat(requires, self.test_version)
-        feature = self.config.get("feature")
-        if feature is not None:
-            requires["features"] = [feature]
         check_requires(requires, self.suricata_config, self.script_cwd)
 
         if "filename" in self.config:

--- a/tests/alert-max/alert-max-append-higher-priority-drop-5180-01/test.yaml
+++ b/tests/alert-max/alert-max-append-higher-priority-drop-5180-01/test.yaml
@@ -9,8 +9,9 @@ pcap: ../alert-max-append-higher-priority/input.pcap
 checks:
 # Sub-test 1
 - filter:
-    lt-version: 8.0.4
-    gt-version: 8.0.4
+    requires:
+      lt-version: 8.0.4
+      gt-version: 8.0.4
     count: 1
     match:
       event_type: alert
@@ -20,8 +21,9 @@ checks:
       verdict.action: drop
 # Sub-test 2
 - filter:
-    lt-version: 8.0.4
-    gt-version: 8.0.4
+    requires:
+      lt-version: 8.0.4
+      gt-version: 8.0.4
     count: 1
     match:
       event_type: alert
@@ -31,10 +33,11 @@ checks:
       verdict.action: drop
 # Sub-test 3
 - filter:
-    # suricata 7 doesn't show this alert.
-    # if we don't drop the flow, it matches against the stream
-    # (pkt_srt: stream (flow timeout))
-    min-version: 8.0.4
+    requires:
+      # suricata 7 doesn't show this alert.
+      # if we don't drop the flow, it matches against the stream
+      # (pkt_srt: stream (flow timeout))
+      min-version: 8.0.4
     count: 1
     match:
       event_type: alert
@@ -44,18 +47,20 @@ checks:
       verdict.action: drop
 # Sub-test 4
 - filter:
-    # suricata 8 doesn't show this alert
-    lt-version: 8.0
+    requires:
+      # suricata 8 doesn't show this alert
+      lt-version: 8.0
     count: 1
     match:
       event_type: alert
       alert.signature_id: 4
 # Sub-test 5
 - filter:
-    # suricata 7 doesn't show this alert.
-    # if we don't drop the flow, it matches against the stream
-    # (pkt_srt: stream (flow timeout))
-    lt-version: 8.0
+    requires:
+      # suricata 7 doesn't show this alert.
+      # if we don't drop the flow, it matches against the stream
+      # (pkt_srt: stream (flow timeout))
+      lt-version: 8.0
     count: 0
     match:
       event_type: alert
@@ -65,7 +70,8 @@ checks:
       verdict.action: drop
 # Sub-test 6
 - filter:
-    min-version: 8.0.4
+    requires:
+      min-version: 8.0.4
     count: 0
     match:
       event_type: alert
@@ -78,8 +84,9 @@ checks:
       alert.signature_id: 5
 # Sub-test 8
 - filter:
-    lt-version: 8.0.4
-    gt-version: 8.0.4
+    requires:
+      lt-version: 8.0.4
+      gt-version: 8.0.4
     count: 1
     match:
       event_type: drop
@@ -94,9 +101,10 @@ checks:
       flow.action: drop
 # Sub-test 10
 - filter:
-    # as suricata 7 won't have a match for sid 3,
-    # the overflow check fails for 7
-    min-version: 8.0.4
+    requires:
+      # as suricata 7 won't have a match for sid 3,
+      # the overflow check fails for 7
+      min-version: 8.0.4
     count: 1
     match:
       event_type: stats
@@ -108,7 +116,8 @@ checks:
       stats.ips.drop_reason.rules: 1
 # Sub-test 11
 - filter:
-    lt-version: 8.0
+    requires:
+      lt-version: 8.0
     count: 1
     match:
       event_type: stats

--- a/tests/alert-max/alert-max-append-higher-priority-drop-5180-02/test.yaml
+++ b/tests/alert-max/alert-max-append-higher-priority-drop-5180-02/test.yaml
@@ -7,16 +7,18 @@ args:
 checks:
 # Subtest 1
 - filter:
-    lt-version: 8.0.4
-    gt-version: 8.0.4
+    requires:
+      lt-version: 8.0.4
+      gt-version: 8.0.4
     count: 0
     match:
       event_type: alert
       alert.signature_id: 1
 # Subtest 2
 - filter:
-    lt-version: 8.0.4
-    gt-version: 8.0.4
+    requires:
+      lt-version: 8.0.4
+      gt-version: 8.0.4
     count: 1
     match:
       event_type: alert
@@ -26,8 +28,9 @@ checks:
       verdict.action: drop
 # Subtest 3
 - filter:
-    lt-version: 8.0.4
-    gt-version: 8.0.4
+    requires:
+      lt-version: 8.0.4
+      gt-version: 8.0.4
     count: 1
     match:
       event_type: alert
@@ -38,16 +41,18 @@ checks:
 # Subtest 4
 # Matches, but not enough space in packet alert queue
 - filter:
-    lt-version: 8.0.4
-    gt-version: 8.0.4
+    requires:
+      lt-version: 8.0.4
+      gt-version: 8.0.4
     count: 0
     match:
       event_type: alert
       alert.signature_id: 4
 # Subtest 5
 - filter:
-    lt-version: 8.0.4
-    gt-version: 8.0.4
+    requires:
+      lt-version: 8.0.4
+      gt-version: 8.0.4
     count: 1
     match:
       event_type: alert
@@ -58,16 +63,18 @@ checks:
 # Subtest 6
 # Matches, but not enough space in packet alert queue
 - filter:
-    lt-version: 8.0.4
-    gt-version: 8.0.4
+    requires:
+      lt-version: 8.0.4
+      gt-version: 8.0.4
     count: 0
     match:
       event_type: alert
       alert.signature_id: 6
 # Subtest 7
 - filter:
-    lt-version: 8.0.4
-    gt-version: 8.0.4
+    requires:
+      lt-version: 8.0.4
+      gt-version: 8.0.4
     count: 1
     match:
       event_type: drop
@@ -75,8 +82,9 @@ checks:
       drop.reason: rules
 # Subtest 8
 - filter:
-    lt-version: 8.0.4
-    gt-version: 8.0.4
+    requires:
+      lt-version: 8.0.4
+      gt-version: 8.0.4
     count: 1
     match:
       event_type: drop
@@ -84,16 +92,18 @@ checks:
       drop.reason: "flow drop"
 # Subtest 9
 - filter:
-    lt-version: 8.0.4
-    gt-version: 8.0.4
+    requires:
+      lt-version: 8.0.4
+      gt-version: 8.0.4
     count: 1
     match:
       event_type: flow
       flow.action: "drop"
 # Subtest 10
 - filter:
-    lt-version: 8.0.4
-    gt-version: 8.0.4
+    requires:
+      lt-version: 8.0.4
+      gt-version: 8.0.4
     count: 1
     match:
       event_type: stats

--- a/tests/alert-max/alert-max-append-higher-priority-drop-5180-03/test.yaml
+++ b/tests/alert-max/alert-max-append-higher-priority-drop-5180-03/test.yaml
@@ -7,8 +7,9 @@ args:
 checks:
 # Sub-test 1
 - filter:
-    lt-version: 8.0.4
-    gt-version: 8.0.4
+    requires:
+      lt-version: 8.0.4
+      gt-version: 8.0.4
     count: 1
     match:
       event_type: alert
@@ -17,8 +18,9 @@ checks:
       verdict.action: drop
 # Sub-test 2
 - filter:
-    lt-version: 8.0.4
-    gt-version: 8.0.4
+    requires:
+      lt-version: 8.0.4
+      gt-version: 8.0.4
     count: 1
     match:
       event_type: alert
@@ -27,8 +29,9 @@ checks:
       verdict.action: drop
 # Sub-test 3
 - filter:
-    # as with drop-5180-01 test, 7.0.x doesn't show this alert
-    min-version: 8.0.4
+    requires:
+      # as with drop-5180-01 test, 7.0.x doesn't show this alert
+      min-version: 8.0.4
     count: 1
     match:
       event_type: alert
@@ -37,8 +40,9 @@ checks:
       verdict.action: drop
 # Sub-test 4
 - filter:
-    # as with drop-5180-01 test, 7.0.x shows this alert
-    lt-version: 8.0
+    requires:
+      # as with drop-5180-01 test, 7.0.x shows this alert
+      lt-version: 8.0
     count: 1
     match:
       event_type: alert
@@ -51,9 +55,10 @@ checks:
       alert.signature_id: 5
 # Sub-test 6
 - filter:
-    min-version: 8.0.4
-    lt-version: 8.0.4
-    gt-version: 8.0.4
+    requires:
+      min-version: 8.0.4
+      lt-version: 8.0.4
+      gt-version: 8.0.4
     count: 1
     match:
       event_type: drop
@@ -66,7 +71,8 @@ checks:
       flow.action: drop
 # Sub-test 8
 - filter:
-    min-version: 8.0.4
+    requires:
+      min-version: 8.0.4
     count: 1
     match:
       event_type: stats
@@ -78,7 +84,8 @@ checks:
       stats.ips.drop_reason.rules: 1
 # Sub-test 9
 - filter:
-    lt-version: 8.0
+    requires:
+      lt-version: 8.0
     count: 1
     match:
       event_type: stats

--- a/tests/app-layer-template/test.yaml
+++ b/tests/app-layer-template/test.yaml
@@ -4,7 +4,8 @@ args:
 
 checks:
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       dest_ip: 10.16.1.10

--- a/tests/bittorrent-dht/test.yaml
+++ b/tests/bittorrent-dht/test.yaml
@@ -296,7 +296,8 @@ checks:
       src_ip: 190.0.0.1
       src_port: 40000
 - filter:
-    min-version: 8
+    requires:
+      min-version: 8
     count: 1
     match:
       bittorrent_dht.request.id: 6162636465666768696a30313233343536373839
@@ -312,7 +313,8 @@ checks:
       src_port: 20000
       ip_v: 4
 - filter:
-    min-version: 8
+    requires:
+      min-version: 8
     count: 1
     match:
       anomaly.app_proto: bittorrent-dht

--- a/tests/bug-1449-01/test.yaml
+++ b/tests/bug-1449-01/test.yaml
@@ -5,14 +5,16 @@ checks:
         event_type: alert
         alert.signature_id: 2220017
   - filter:
-      lt-version: 8
+      requires:
+        lt-version: 8
       count: 1
       match:
         event_type: smtp
         smtp.helo: bug.client
         email.status: PARSE_ERROR
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: smtp

--- a/tests/bug-1450-02/test.yaml
+++ b/tests/bug-1450-02/test.yaml
@@ -10,7 +10,8 @@ checks:
         event_type: alert
         alert.signature_id: 2230003
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: alert

--- a/tests/bug-2491-02/test.yaml
+++ b/tests/bug-2491-02/test.yaml
@@ -9,28 +9,32 @@ checks:
       match:
         event_type: alert
   - filter:
-      min-version: 8.0
+      requires:
+        min-version: 8.0
       count: 1
       match:
         event_type: alert
         alert.signature_id: 1
         pcap_cnt: 2
   - filter:
-      min-version: 8.0
+      requires:
+        min-version: 8.0
       count: 1
       match:
         event_type: alert
         alert.signature_id: 2
         pcap_cnt: 2
   - filter:
-      lt-version: 8.0
+      requires:
+        lt-version: 8.0
       count: 1
       match:
         event_type: alert
         alert.signature_id: 1
         pcap_cnt: 11
   - filter:
-      lt-version: 8.0
+      requires:
+        lt-version: 8.0
       count: 1
       match:
         event_type: alert
@@ -59,5 +63,3 @@ checks:
         tcp.state: close_wait
         tcp.ts_max_regions: 1
         tcp.tc_max_regions: 1
-
-

--- a/tests/bug-4663-02/test.yaml
+++ b/tests/bug-4663-02/test.yaml
@@ -8,7 +8,8 @@ checks:
         event_type: flow
         flow.alerted: true
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: flow

--- a/tests/bug-4663-03/test.yaml
+++ b/tests/bug-4663-03/test.yaml
@@ -17,7 +17,8 @@ checks:
       match:
         event_type: flow
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: flow

--- a/tests/bug-4663/test.yaml
+++ b/tests/bug-4663/test.yaml
@@ -18,7 +18,8 @@ checks:
       match:
         event_type: drop
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: flow

--- a/tests/bug-4877/test.yaml
+++ b/tests/bug-4877/test.yaml
@@ -71,7 +71,8 @@ checks:
       dest_ip: 192.168.100.230
       dest_port: 20
 - filter:
-    min-version: 8
+    requires:
+      min-version: 8
     count: 1
     match:
       app_proto: ftp-data

--- a/tests/bug-4953/test.yaml
+++ b/tests/bug-4953/test.yaml
@@ -3,12 +3,14 @@ args:
 
 checks:
   - filter:
-      min-version: 6
+      requires:
+        min-version: 6
       count: 3
       match:
         event_type: fileinfo
   - filter:
-      min-version: 6
+      requires:
+        min-version: 6
       count: 1
       match:
         event_type: fileinfo
@@ -25,7 +27,8 @@ checks:
         fileinfo.state: CLOSED
         fileinfo.size: 676
   - filter:
-      min-version: 6
+      requires:
+        min-version: 6
       count: 1
       match:
         event_type: fileinfo

--- a/tests/bug-5162/test.yaml
+++ b/tests/bug-5162/test.yaml
@@ -3,7 +3,8 @@ args:
 
 checks:
 - filter:
-    min-version: 6
+    requires:
+      min-version: 6
     count: 1445
     match:
       event_type: dcerpc

--- a/tests/bug-5464-verdict-05/test.yaml
+++ b/tests/bug-5464-verdict-05/test.yaml
@@ -8,7 +8,8 @@ pcap: ../alert-max/alert-max-append-higher-priority/input.pcap
 checks:
 # Subtest 1
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       event_type: alert
@@ -16,7 +17,8 @@ checks:
       verdict.action: alert
 # Subtest 2
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       event_type: alert
@@ -24,7 +26,8 @@ checks:
       verdict.action: pass
 # Subtest 3
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       event_type: alert
@@ -32,7 +35,8 @@ checks:
       verdict.action: pass
 # Subtest 4
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 0
     match:
       event_type: alert

--- a/tests/bug-6278-2/test.yaml
+++ b/tests/bug-6278-2/test.yaml
@@ -10,4 +10,5 @@ checks:
   - shell:
       args: grep -c 'no user name was provided - ensure it is specified either in the configuration file (run-as.user) or in command-line arguments (--user)' stderr
       expect: 1
-      min-version: 7
+      requires:
+        min-version: 7

--- a/tests/datarep-03-bad-reputation/test.yaml
+++ b/tests/datarep-03-bad-reputation/test.yaml
@@ -9,14 +9,17 @@ args:
 
 checks:
   - shell:
-      min-version: 8
+      requires:
+        min-version: 8
       args: grep "invalid datarep value" suricata.log | wc -l | xargs
       expect: 1
   - shell:
-      lt-version: 8
+      requires:
+        lt-version: 8
       args: grep "is not a valid reputation value" suricata.log | wc -l | xargs
       expect: 1
   - shell:
-      lt-version: 8
+      requires:
+        lt-version: 8
       args: grep "bad rep for dataset" suricata.log | wc -l | xargs
       expect: 1

--- a/tests/datasets-invalid-encoding/test.yaml
+++ b/tests/datasets-invalid-encoding/test.yaml
@@ -7,7 +7,8 @@ exit-code: 1
 
 checks:
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       filename: suricata.json
       count: 1
       match:
@@ -16,7 +17,8 @@ checks:
         engine.message.__find: "bad base64 encoding ua-seen"
         engine.module: "debug"
   - filter:
-      lt-version: 8
+      requires:
+        lt-version: 8
       filename: suricata.json
       count: 1
       match:

--- a/tests/datasets/datarep-bad-datarep-string/test.yaml
+++ b/tests/datasets/datarep-bad-datarep-string/test.yaml
@@ -7,7 +7,8 @@ exit-code: 1
 
 checks:
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       filename: suricata.json
       count: 1
       match:

--- a/tests/datasets/datarep-bad-datarep-value/test.yaml
+++ b/tests/datasets/datarep-bad-datarep-value/test.yaml
@@ -7,7 +7,8 @@ exit-code: 1
 
 checks:
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       filename: suricata.json
       count: 1
       match:

--- a/tests/dcerpc-smb-fail/test.yaml
+++ b/tests/dcerpc-smb-fail/test.yaml
@@ -5,7 +5,8 @@ args:
 
 checks:
 - filter:
-    min-version: 6
+    requires:
+      min-version: 6
     count: 1445
     match:
       event_type: dcerpc

--- a/tests/dcerpc/dcerpc-dce-iface-01/test.yaml
+++ b/tests/dcerpc/dcerpc-dce-iface-01/test.yaml
@@ -3,13 +3,15 @@ args:
 
 checks:
   - filter:
-      min-version: 6
+      requires:
+        min-version: 6
       count: 2
       match:
         event_type: alert
         alert.signature_id: 1
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: dcerpc

--- a/tests/dcerpc/dcerpc-dce-iface-02/test.yaml
+++ b/tests/dcerpc/dcerpc-dce-iface-02/test.yaml
@@ -31,7 +31,8 @@ checks:
         alert.signature_id: 5
         pcap_cnt: 10
   - filter:
-      min-version: 6.0.0  
+      requires:
+        min-version: 6.0.0  
       count: 1
       match:
         dcerpc.response: RESPONSE

--- a/tests/dcerpc/dcerpc-dce-opnum/test.yaml
+++ b/tests/dcerpc/dcerpc-dce-opnum/test.yaml
@@ -10,7 +10,8 @@ checks:
         event_type: alert
         alert.signature_id: 1
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: alert

--- a/tests/dcerpc/dcerpc-dce-stub-data/test.yaml
+++ b/tests/dcerpc/dcerpc-dce-stub-data/test.yaml
@@ -5,7 +5,8 @@ args:
 
 checks:
 - filter:
-    min-version: 6.0.0  
+    requires:
+      min-version: 6.0.0  
     count: 2
     match:
       event_type: dcerpc

--- a/tests/decode-too-small/test.yaml
+++ b/tests/decode-too-small/test.yaml
@@ -11,7 +11,8 @@ checks:
         alert.signature_id: 1
 
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: alert

--- a/tests/decode-unknown-2/test.yaml
+++ b/tests/decode-unknown-2/test.yaml
@@ -14,7 +14,8 @@ checks:
       decoder.unknown_ethertype: 1
   - filter:
       count: 1
-      min-version: 8.0.2
+      requires:
+        min-version: 8.0.2
       match:
         event_type: anomaly
         ether.ether_type: 64439
@@ -22,8 +23,9 @@ checks:
         anomaly.event: decoder.ethernet.unknown_ethertype
   - filter:
       count: 1
-      min-version: 8
-      lt-version: 8.0.2
+      requires:
+        min-version: 8
+        lt-version: 8.0.2
       match:
         event_type: anomaly
         ether.ether_type: 47099

--- a/tests/defrag/bug-6887-defrag-ipv6-tcp/test.yaml
+++ b/tests/defrag/bug-6887-defrag-ipv6-tcp/test.yaml
@@ -12,7 +12,8 @@ checks:
 
 - filter:
     count: 1
-    min-version: 8
+    requires:
+      min-version: 8
     match:
       event_type: alert
       alert.signature_id: 1

--- a/tests/dhcp-eve-extended/test.yaml
+++ b/tests/dhcp-eve-extended/test.yaml
@@ -67,19 +67,22 @@ checks:
       src_ip: 10.16.1.4
       src_port: 68
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       event_type: alert
       alert.signature_id: 1
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       event_type: alert
       alert.signature_id: 2
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       event_type: alert

--- a/tests/dnp3/dnp3-dnp3_obj-alert/test.yaml
+++ b/tests/dnp3/dnp3-dnp3_obj-alert/test.yaml
@@ -14,7 +14,8 @@ checks:
 
   - filter:
       count: 4
-      min-version: 8
+      requires:
+        min-version: 8
       match:
         event_type: alert
         alert.signature_id: 1

--- a/tests/dns-over-http2/test.yaml
+++ b/tests/dns-over-http2/test.yaml
@@ -60,7 +60,8 @@ checks:
         app_proto: doh2
         app_proto_orig: http2
   - filter:
-      min-version: 8.0.1
+      requires:
+        min-version: 8.0.1
       count: 0
       match:
         event_type: dns

--- a/tests/dns-reversed-udp-1/test.yaml
+++ b/tests/dns-reversed-udp-1/test.yaml
@@ -7,14 +7,14 @@ args:
 checks:
 
   - filter:
-      comment: request
+      # request
       count: 0
       match:
         event_type: dns
         dns.type: query
 
   - filter:
-      comment: response
+      # response
       count: 1
       match:
         event_type: dns

--- a/tests/dns/task-7018-dns-ips-stream-rule/test.yaml
+++ b/tests/dns/task-7018-dns-ips-stream-rule/test.yaml
@@ -32,7 +32,8 @@ checks:
       src_ip: 10.16.1.11
       src_port: 36926
 - filter:
-    lt-version: 8
+    requires:
+      lt-version: 8
     count: 1
     match:
       event_type: alert
@@ -55,7 +56,8 @@ checks:
       dns.query[0].type: query
 - filter:
     # DNS has only v3 logging for alerts in 8
-    min-version: 8
+    requires:
+      min-version: 8
     count: 1
     match:
       event_type: alert
@@ -102,7 +104,8 @@ checks:
       dns.type: answer
       dns.version: 2
 - filter:
-    lt-version: 8
+    requires:
+      lt-version: 8
     count: 1
     match:
       event_type: alert
@@ -129,7 +132,8 @@ checks:
       dns.answer.type: answer
       dns.answer.version: 2
 - filter:
-    min-version: 8
+    requires:
+      min-version: 8
     count: 1
     match:
       event_type: alert
@@ -168,7 +172,8 @@ checks:
       src_port: 36926
 - filter:
     # This check is about an undesirable behavior cf redmine ticket #7004
-    lt-version: 8
+    requires:
+      lt-version: 8
     count: 1
     match:
       event_type: alert
@@ -191,7 +196,8 @@ checks:
       dns.query[0].tx_id: 2
 - filter:
     # This check is about an undesirable behavior cf redmine ticket #7004
-    min-version: 8
+    requires:
+      min-version: 8
     count: 1
     match:
       event_type: alert
@@ -212,7 +218,8 @@ checks:
       dns.queries[0].rrname: oisf.net
       dns.queries[0].rrtype: A
 - filter:
-    lt-version: 8
+    requires:
+      lt-version: 8
     count: 1
     match:
       event_type: alert
@@ -238,7 +245,8 @@ checks:
       dns.answer.type: answer
       dns.answer.version: 2
 - filter:
-    min-version: 8
+    requires:
+      min-version: 8
     count: 1
     match:
       event_type: alert
@@ -290,7 +298,8 @@ checks:
       dns.type: answer
       dns.version: 2
 - filter:
-    lt-version: 8
+    requires:
+      lt-version: 8
     count: 1
     match:
       event_type: alert
@@ -311,7 +320,8 @@ checks:
       dns.query[0].tx_id: 4
       dns.query[0].type: query
 - filter:
-    min-version: 8
+    requires:
+      min-version: 8
     count: 1
     match:
       event_type: alert

--- a/tests/dns/task-7018-ids-dns-stream-rule/test.yaml
+++ b/tests/dns/task-7018-ids-dns-stream-rule/test.yaml
@@ -26,7 +26,8 @@ checks:
       src_ip: 10.16.1.11
       src_port: 36926
 - filter:
-    lt-version: 8
+    requires:
+      lt-version: 8
     count: 1
     match:
       event_type: alert
@@ -48,7 +49,8 @@ checks:
       dns.query[0].tx_id: 0
       dns.query[0].type: query
 - filter:
-    min-version: 8
+    requires:
+      min-version: 8
     count: 1
     match:
       event_type: alert
@@ -94,7 +96,8 @@ checks:
       src_ip: 10.16.1.11
       src_port: 36926
 - filter:
-    lt-version: 8
+    requires:
+      lt-version: 8
     count: 1
     match:
       event_type: alert
@@ -121,7 +124,8 @@ checks:
       dns.answer.type: answer
       dns.answer.version: 2
 - filter:
-    min-version: 8
+    requires:
+      min-version: 8
     count: 1
     match:
       event_type: alert

--- a/tests/dns/v2/dns-invalid-opcode/test.yaml
+++ b/tests/dns/v2/dns-invalid-opcode/test.yaml
@@ -40,7 +40,8 @@ checks:
 # Generated checks below.
       
 - filter:
-    min-version: 8
+    requires:
+      min-version: 8
     count: 1
     match:
       alert.action: allowed
@@ -77,7 +78,8 @@ checks:
       tx_id: 0
 
 - filter:
-    lt-version: 8
+    requires:
+      lt-version: 8
     count: 1
     match:
       alert.action: allowed

--- a/tests/dropped-flow-applayer-event-logged-dcerpc/test.yaml
+++ b/tests/dropped-flow-applayer-event-logged-dcerpc/test.yaml
@@ -7,7 +7,8 @@ args:
 
 checks:
   - filter:
-      min-version: 8.0.4
+      requires:
+        min-version: 8.0.4
       count: 0
       match:
         pcap_cnt: 2
@@ -17,30 +18,35 @@ checks:
       match:
         event_type: alert
   - filter:
-      min-version: 8.0.4
+      requires:
+        min-version: 8.0.4
       count: 0
       match:
         pcap_cnt: 2
         event_type: smb
   - filter:
-      min-version: 8.0.4
+      requires:
+        min-version: 8.0.4
       count: 20
       match:
         event_type: drop
   - filter:
-      lt-version: 8.0
+      requires:
+        lt-version: 8.0
       count: 1
       match:
         pcap_cnt: 2
         event_type: alert
   - filter:
-      lt-version: 8.0
+      requires:
+        lt-version: 8.0
       count: 1
       match:
         pcap_cnt: 2
         event_type: smb
   - filter:
-      lt-version: 8.0
+      requires:
+        lt-version: 8.0
       count: 19
       match:
         event_type: drop

--- a/tests/dropped-flow-applayer-event-logged-http/test.yaml
+++ b/tests/dropped-flow-applayer-event-logged-http/test.yaml
@@ -7,24 +7,28 @@ args:
 
 checks:
   - filter:
-      min-version: 8.0.4
+      requires:
+        min-version: 8.0.4
       count: 0
       match:
         event_type: http
         pcap_cnt: 2
   - filter:
-      min-version: 8.0.4
+      requires:
+        min-version: 8.0.4
       count: 2
       match:
         event_type: drop
   - filter:
-      lt-version: 8.0
+      requires:
+        lt-version: 8.0
       count: 1
       match:
         event_type: http
         pcap_cnt: 2
   - filter:
-      lt-version: 8.0
+      requires:
+        lt-version: 8.0
       count: 1
       match:
         event_type: drop

--- a/tests/dropped-flow-applayer-event-logged-smb/test.yaml
+++ b/tests/dropped-flow-applayer-event-logged-smb/test.yaml
@@ -12,34 +12,40 @@ checks:
       match:
         event_type: alert
   - filter:
-      min-version: 8.0.4
+      requires:
+        min-version: 8.0.4
       count: 0
       match:
         event_type: alert
         pcap_cnt: 2
   - filter:
-      min-version: 8.0.4
+      requires:
+        min-version: 8.0.4
       count: 0
       match:
         event_type: smb
   - filter:
-      min-version: 8.0.4
+      requires:
+        min-version: 8.0.4
       count: 54
       match:
         event_type: drop
   - filter:
-      lt-version: 8.0
+      requires:
+        lt-version: 8.0
       count: 1
       match:
         event_type: alert
         pcap_cnt: 2
   - filter:
-      lt-version: 8.0
+      requires:
+        lt-version: 8.0
       count: 1
       match:
         event_type: smb
   - filter:
-      lt-version: 8.0
+      requires:
+        lt-version: 8.0
       count: 53
       match:
         event_type: drop

--- a/tests/enip-keywords/test.yaml
+++ b/tests/enip-keywords/test.yaml
@@ -8,14 +8,16 @@ args:
 
 checks:
   - filter:
-      lt-version: 8
+      requires:
+        lt-version: 8
       count: 41
       match:
         event_type: alert
         alert.signature_id: 1
   - filter:
       # version 8 also works on responses
-      min-version: 8
+      requires:
+        min-version: 8
       count: 81
       match:
         event_type: alert

--- a/tests/eve-flow-vlan-02/test.yaml
+++ b/tests/eve-flow-vlan-02/test.yaml
@@ -3,21 +3,21 @@ requires:
 
 checks:
   - filter:
-      comment: single vlan
+      # single vlan
       count: 1
       match:
         event_type: flow
         vlan: [6]
 
   - filter:
-      comment: double-tagged vlan
+      # double-tagged vlan
       count: 1
       match:
         event_type: flow
         vlan: [1, 10]
 
   - filter:
-      comment: triple-tagged vlan
+      # triple-tagged vlan
       count: 1
       match:
         event_type: flow

--- a/tests/eve-flow-vlan/test.yaml
+++ b/tests/eve-flow-vlan/test.yaml
@@ -1,13 +1,13 @@
 checks:
   - filter:
-      comment: single vlan
+      # single vlan
       count: 1
       match:
         event_type: flow
         vlan: [6]
 
   - filter:
-      comment: double-tagged vlan
+      # double-tagged vlan
       count: 1
       match:
         event_type: flow

--- a/tests/eve-payload-07-http-gap/test.yaml
+++ b/tests/eve-payload-07-http-gap/test.yaml
@@ -14,7 +14,8 @@ checks:
       alert.signature_id: 1
 - filter:
     count: 1
-    min-version: 8
+    requires:
+      min-version: 8
     match:
       event_type: alert
       alert.signature_id: 1
@@ -28,7 +29,8 @@ checks:
       payload_printable: "GET /1 HTTP/1.0\r\nUser-Agent: Mozilla\r\n\r\n"
 - filter:
     count: 1
-    min-version: 8
+    requires:
+      min-version: 8
     match:
       event_type: alert
       alert.signature_id: 1
@@ -42,7 +44,8 @@ checks:
       payload_printable: "GET /1 HTTP/1.0\r\nUser-Agent: Mozilla\r\n\r\nGET /2 HTTP/1.0\r\nUser-Agent: Mozilla\r\n\r\n"
 - filter:
     count: 1
-    min-version: 8
+    requires:
+      min-version: 8
     match:
       event_type: alert
       alert.signature_id: 1
@@ -56,7 +59,8 @@ checks:
       payload_printable: "GET /1 HTTP/1.0\r\nUser-Agent: Mozilla\r\n\r\nGET /2 HTTP/1.0\r\nUser-Agent: Mozilla\r\n\r\nGET /3 HTTP/1.0\r\nUser-Agent: Mozilla\r\n\r\n"
 - filter:
     count: 1
-    min-version: 8
+    requires:
+      min-version: 8
     match:
       event_type: alert
       alert.signature_id: 2
@@ -76,7 +80,8 @@ checks:
       payload_printable: "HTTP/1.0 200 OK\r\nDate: Mon, 31 Aug 2009 20:25:50 GMT\r\nServer: Apache\r\nConnection: close\r\nContent-Type: text/html\r\nContent-Length: 12\r\n\r\n[127 bytes missing]AAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 - filter:
     count: 1
-    min-version: 8
+    requires:
+      min-version: 8
     match:
       event_type: alert
       alert.signature_id: 4

--- a/tests/exception-policy-applayer-02/test.yaml
+++ b/tests/exception-policy-applayer-02/test.yaml
@@ -43,7 +43,8 @@ checks:
         event_type: flow
         flow.action: drop
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: stats
@@ -51,7 +52,8 @@ checks:
         stats.app_layer.error.tls.exception_policy.drop_packet: 0
         stats.exception_policy.app_layer.error.pass_packet: 1
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow

--- a/tests/exception-policy-default-02/test.yaml
+++ b/tests/exception-policy-default-02/test.yaml
@@ -13,7 +13,8 @@ checks:
       match:
         event_type: http
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow

--- a/tests/exception-policy-default-03/test.yaml
+++ b/tests/exception-policy-default-03/test.yaml
@@ -6,18 +6,21 @@ args:
 
 checks:
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 0
       match:
         event_type: alert
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: drop
         drop.reason: stream midstream
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 9
       match:
         event_type: drop
@@ -27,7 +30,8 @@ checks:
         event_type: flow
         flow.state: bypassed
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: flow
@@ -37,22 +41,25 @@ checks:
       match:
         event_type: http
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow
         flow.exception_policy[0].target: "stream_midstream"
         flow.exception_policy[0].policy: "drop_flow"
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: stats
         stats.exception_policy.tcp.midstream.drop_flow: 1
   # in Suricata 7, the exception policy stats counters can be disabled
   - filter:
-      min-version: 7.0.12
-      lt-version: 8
+      requires:
+        min-version: 7.0.12
+        lt-version: 8
       count: 1
       match:
         event_type: stats

--- a/tests/exception-policy-default-04/test.yaml
+++ b/tests/exception-policy-default-04/test.yaml
@@ -24,7 +24,8 @@ checks:
       match:
         event_type: http
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-01/test.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-01/test.yaml
@@ -36,14 +36,16 @@ checks:
       match:
         event_type: http
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow
         flow.exception_policy[0].target: "stream_midstream"
         flow.exception_policy[0].policy: "drop_flow"
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: stats

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-02/test.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-02/test.yaml
@@ -26,7 +26,8 @@ checks:
       match:
         event_type: http
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-03/test.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-03/test.yaml
@@ -26,7 +26,8 @@ checks:
       match:
         event_type: http
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-04/test.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-04/test.yaml
@@ -27,14 +27,16 @@ checks:
       match:
         event_type: http
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow
         flow.exception_policy[0].target: "stream_midstream"
         flow.exception_policy[0].policy: "pass_flow"
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: stats

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-05/test.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-05/test.yaml
@@ -21,7 +21,8 @@ checks:
       match:
         event_type: http
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-06/test.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-06/test.yaml
@@ -37,14 +37,16 @@ checks:
         log_level: Warning
         engine.module: exception-policy
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow
         flow.exception_policy[0].target: "stream_midstream"
         flow.exception_policy[0].policy: "ignore"
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: stats

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-07/test.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-07/test.yaml
@@ -37,14 +37,16 @@ checks:
         log_level: Warning
         engine.module: exception-policy
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow
         flow.exception_policy[0].target: "stream_midstream"
         flow.exception_policy[0].policy: "ignore"
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: stats

--- a/tests/exception-policy-midstream-01/test.yaml
+++ b/tests/exception-policy-midstream-01/test.yaml
@@ -19,13 +19,15 @@ checks:
       match:
         event_type: http
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: stats
         stats.exception_policy.tcp.midstream.pass_flow: 9
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow

--- a/tests/exception-policy-midstream-02/test.yaml
+++ b/tests/exception-policy-midstream-02/test.yaml
@@ -25,19 +25,22 @@ checks:
       match:
         event_type: anomaly
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: stats
         stats.ips.drop_reason.stream_midstream: 1
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: stats
         stats.exception_policy.tcp.midstream.drop_flow: 1
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow

--- a/tests/exception-policy-midstream-03/test.yaml
+++ b/tests/exception-policy-midstream-03/test.yaml
@@ -25,7 +25,8 @@ checks:
         event_type: http
         dest_port: 80
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow

--- a/tests/exception-policy-midstream-04/test.yaml
+++ b/tests/exception-policy-midstream-04/test.yaml
@@ -20,13 +20,15 @@ checks:
     match:
       event_type: http
 - filter:
-    min-version: 7.0.12
+    requires:
+      min-version: 7.0.12
     count: 1
     match:
       event_type: stats
       stats.exception_policy.tcp.midstream.pass_flow: 2
 - filter:
-    min-version: 7.0.12
+    requires:
+      min-version: 7.0.12
     count: 1
     match:
       event_type: flow

--- a/tests/exception-policy-midstream-05/test.yaml
+++ b/tests/exception-policy-midstream-05/test.yaml
@@ -19,13 +19,15 @@ checks:
       match:
         event_type: http
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: stats
         stats.exception_policy.tcp.midstream.bypass: 1
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow

--- a/tests/exception-policy-midstream-06/test.yaml
+++ b/tests/exception-policy-midstream-06/test.yaml
@@ -17,13 +17,15 @@ checks:
         event_type: flow
         flow.action: drop
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: stats
         stats.exception_policy.tcp.midstream.drop_flow: 1
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow

--- a/tests/exception-policy-midstream-07/test.yaml
+++ b/tests/exception-policy-midstream-07/test.yaml
@@ -19,7 +19,8 @@ checks:
       match:
         event_type: smb
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow

--- a/tests/exception-policy-reject-action-01/test.yaml
+++ b/tests/exception-policy-reject-action-01/test.yaml
@@ -19,14 +19,16 @@ checks:
         event_type: flow
         flow.action: drop
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: flow
         flow.exception_policy[0].target: "stream_midstream"
         flow.exception_policy[0].policy: "reject"
   - filter:
-      min-version: 7.0.12
+      requires:
+        min-version: 7.0.12
       count: 1
       match:
         event_type: stats

--- a/tests/filestore-alert-log/test.yaml
+++ b/tests/filestore-alert-log/test.yaml
@@ -10,7 +10,8 @@ checks:
         args: test -e filestore/e0/e092858d5bd66ab33085a966ee4ac0bf0edf6eab8d8b1e66432ee600e904bb4f
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: alert

--- a/tests/ftp-epsv/test.yaml
+++ b/tests/ftp-epsv/test.yaml
@@ -7,7 +7,8 @@ checks:
         ftp.command: "EPSV"
         ftp.dynamic_port: 58612
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 0
       match:
         event_type: anomaly

--- a/tests/ftp/ftp-too-long-command/test.yaml
+++ b/tests/ftp/ftp-too-long-command/test.yaml
@@ -21,7 +21,8 @@ checks:
 
   # Look for anomaly event.
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: anomaly
@@ -29,14 +30,16 @@ checks:
 
   # Look for app-layer alert.
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: alert
         alert.signature_id: 2232000
   # Alert has app-layer details.
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: alert

--- a/tests/ftp/ftp-too-long-response/test.yaml
+++ b/tests/ftp/ftp-too-long-response/test.yaml
@@ -16,7 +16,8 @@ checks:
 
   # Look for anomaly event.
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: anomaly
@@ -24,7 +25,8 @@ checks:
 
   # Look for app-layer alert.
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: alert

--- a/tests/http-gap-simple-frames/test.yaml
+++ b/tests/http-gap-simple-frames/test.yaml
@@ -71,7 +71,8 @@ checks:
         frame.direction: toserver
         frame.tx_id: 0
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: alert

--- a/tests/http-not09/test.yaml
+++ b/tests/http-not09/test.yaml
@@ -8,13 +8,15 @@ checks:
         event_type: http
         http.http_user_agent: myscript
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: anomaly
         anomaly.event: REQUEST_LINE_MISSING_PROTOCOL
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: alert

--- a/tests/http-xff-eve-forward-extra-data/test.yaml
+++ b/tests/http-xff-eve-forward-extra-data/test.yaml
@@ -5,7 +5,8 @@ args:
 
 checks:
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         alert.xff: 10.2.2.2

--- a/tests/http-xff-eve-reverse-extra-data/test.yaml
+++ b/tests/http-xff-eve-reverse-extra-data/test.yaml
@@ -5,7 +5,8 @@ args:
 
 checks:
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         alert.xff: 10.3.3.3

--- a/tests/http2-errorcode/test.yaml
+++ b/tests/http2-errorcode/test.yaml
@@ -13,7 +13,8 @@ checks:
         alert.signature_id: 1
         http.http2.request.error_code: INTERNALERROR
   - filter:
-      min-version: 9
+      requires:
+        min-version: 9
       count: 2
       match:
         event_type: alert

--- a/tests/http2-upgrade/test.yaml
+++ b/tests/http2-upgrade/test.yaml
@@ -28,7 +28,8 @@ checks:
         http.http2.request.settings[2].settings_id: "SETTINGSENABLEPUSH"
         http.http2.request.settings[2].settings_value: 0
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: http

--- a/tests/ikev2-weak-dh/test.yaml
+++ b/tests/ikev2-weak-dh/test.yaml
@@ -13,7 +13,8 @@ checks:
   # from suricata version >=7 the event_type for ikev2 is ike
   - filter:
       count: 1
-      min-version: 7
+      requires:
+        min-version: 7
       match:
         event_type: ike
         ike.version_major: 2

--- a/tests/krb5-kerberoasting/test.yaml
+++ b/tests/krb5-kerberoasting/test.yaml
@@ -22,7 +22,8 @@ checks:
         event_type: alert
         alert.signature_id: 1
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: alert

--- a/tests/krb5-request-frag-log/test.yaml
+++ b/tests/krb5-request-frag-log/test.yaml
@@ -13,7 +13,7 @@ checks:
         event_type: alert
         alert.signature_id: 2
   - filter:
-      comment: authentication service (AS) response
+      # authentication service (AS) response
       count: 1
       match:
         event_type: krb5
@@ -23,7 +23,7 @@ checks:
         krb5.sname: krbtgt/dom.test.lo.com
 
   - filter:
-      comment: ticket granting service (TGS) reponse
+      # ticket granting service (TGS) reponse
       count: 1
       match:
         event_type: krb5

--- a/tests/nfs3-01/test.yaml
+++ b/tests/nfs3-01/test.yaml
@@ -11137,7 +11137,8 @@ checks:
       src_ip: 139.25.22.2
       src_port: 3296
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       app_proto: failed
@@ -11199,7 +11200,8 @@ checks:
       src_ip: 139.25.22.2
       src_port: 3298
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       app_proto: failed
@@ -11261,7 +11263,8 @@ checks:
       src_ip: 139.25.22.2
       src_port: 722
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       app_proto: failed
@@ -11323,7 +11326,8 @@ checks:
       src_ip: 139.25.22.2
       src_port: 1022
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       app_proto: nfs
@@ -11385,7 +11389,8 @@ checks:
       src_ip: 139.25.22.2
       src_port: 3295
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       app_proto: failed
@@ -11447,7 +11452,8 @@ checks:
       src_ip: 139.25.22.2
       src_port: 3299
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       app_proto: failed
@@ -11509,7 +11515,8 @@ checks:
       src_ip: 139.25.22.2
       src_port: 3297
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       app_proto: failed
@@ -11571,7 +11578,8 @@ checks:
       src_ip: 139.25.22.2
       src_port: 706
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       app_proto: failed

--- a/tests/output-eve-tftp-01/test.yaml
+++ b/tests/output-eve-tftp-01/test.yaml
@@ -11,7 +11,8 @@ checks:
     match:
       event_type: alert
 - filter:
-    min-version: 8
+    requires:
+      min-version: 8
     count: 1
     match:
       event_type: alert

--- a/tests/pcre-invalid-rule-01/test.yaml
+++ b/tests/pcre-invalid-rule-01/test.yaml
@@ -26,7 +26,8 @@ checks:
         expect: 1
 
     - shell:
-        min-version: 7
+        requires:
+          min-version: 7
         args: grep -o "use a sticky.*\"data from tracked files" suricata.log | wc -l | xargs
         expect: 1
 

--- a/tests/pgsql/pgsql-pwd-output-disabled/test.yaml
+++ b/tests/pgsql/pgsql-pwd-output-disabled/test.yaml
@@ -64,7 +64,8 @@ checks:
       src_port: 41662
 # check to ensure there's no empty request (Bug #7647)
 - filter:
-    min-version: 8
+    requires:
+      min-version: 8
     count: 1
     match:
       dest_ip: 192.168.1.74

--- a/tests/rfb-protocol-3.3/test.yaml
+++ b/tests/rfb-protocol-3.3/test.yaml
@@ -7,7 +7,8 @@ checks:
         app_proto: rfb
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: rfb

--- a/tests/rules/ftpbounce/test.yaml
+++ b/tests/rules/ftpbounce/test.yaml
@@ -7,7 +7,8 @@ args:
 
 checks:
 - filter:
-    lt-version: 8
+    requires:
+      lt-version: 8
     filename: rules.json
     count: 1
     match:
@@ -16,7 +17,8 @@ checks:
       engines[0].direction: "toserver"
       engines[0].matches[0].name: "ftpbounce"
 - filter:
-    min-version: 8
+    requires:
+      min-version: 8
     filename: rules.json
     count: 1
     match:

--- a/tests/rules/icmp_id/test.yaml
+++ b/tests/rules/icmp_id/test.yaml
@@ -7,7 +7,8 @@ args:
 
 checks:
 - filter:
-    lt-version: 9.0
+    requires:
+      lt-version: 9.0
     filename: rules.json
     count: 1
     match:
@@ -15,7 +16,8 @@ checks:
       lists.packet.matches[0].name: "icmp_id"
       lists.packet.matches[0].id.number: 2
 - filter:
-    min-version: 9.0
+    requires:
+      min-version: 9.0
     filename: rules.json
     count: 1
     match:

--- a/tests/rules/tcp-seq-keyword/test.yaml
+++ b/tests/rules/tcp-seq-keyword/test.yaml
@@ -7,7 +7,8 @@ args:
 
 checks:
 - filter:
-    lt-version: 9.0
+    requires:
+      lt-version: 9.0
     filename: rules.json
     count: 1
     match:
@@ -15,14 +16,16 @@ checks:
       lists.packet.matches[0].name: "tcp.seq"
       lists.packet.matches[0].seq.number: 624
 - filter:
-    lt-version: 9.0
+    requires:
+      lt-version: 9.0
     filename: rules.json
     count: 1
     match:
         id: 2
         lists.packet.matches[0].seq.number: 723833
 - filter:
-    min-version: 9.0
+    requires:
+      min-version: 9.0
     filename: rules.json
     count: 1
     match:
@@ -30,7 +33,8 @@ checks:
       lists.packet.matches[0].name: "tcp.seq"
       lists.packet.matches[0].seq.equal: 624
 - filter:
-    min-version: 9.0
+    requires:
+      min-version: 9.0
     filename: rules.json
     count: 1
     match:

--- a/tests/rules/tcp_ack/test.yaml
+++ b/tests/rules/tcp_ack/test.yaml
@@ -7,7 +7,8 @@ args:
 
 checks:
 - filter:
-    lt-version: 9.0
+    requires:
+      lt-version: 9.0
     filename: rules.json
     count: 1
     match:
@@ -15,14 +16,16 @@ checks:
       lists.packet.matches[0].name: "tcp.ack"
       lists.packet.matches[0].ack.number: 782
 - filter:
-    lt-version: 9.0
+    requires:
+      lt-version: 9.0
     filename: rules.json
     count: 1
     match:
       id: 2
       lists.packet.matches[0].ack.number: 15
 - filter:
-    lt-version: 9.0
+    requires:
+      lt-version: 9.0
     filename: rules.json
     count: 1
     match:
@@ -30,7 +33,8 @@ checks:
       lists.packet.matches[0].name: "tcp.ack"
       lists.packet.matches[0].ack.number: 437528
 - filter:
-    min-version: 9.0
+    requires:
+      min-version: 9.0
     filename: rules.json
     count: 1
     match:
@@ -38,14 +42,16 @@ checks:
       lists.packet.matches[0].name: "tcp.ack"
       lists.packet.matches[0].ack.equal: 782
 - filter:
-    min-version: 9.0
+    requires:
+      min-version: 9.0
     filename: rules.json
     count: 1
     match:
       id: 2
       lists.packet.matches[0].ack.equal: 15
 - filter:
-    min-version: 9.0
+    requires:
+      min-version: 9.0
     filename: rules.json
     count: 1
     match:

--- a/tests/rules/tcp_window/test.yaml
+++ b/tests/rules/tcp_window/test.yaml
@@ -7,7 +7,8 @@ args:
 
 checks:
 - filter:
-    lt-version: 9.0
+    requires:
+      lt-version: 9.0
     filename: rules.json
     count: 1
     match:
@@ -16,7 +17,8 @@ checks:
       lists.packet.matches[0].window.size: 30336
       lists.packet.matches[0].window.negated: false
 - filter:
-    lt-version: 9.0
+    requires:
+      lt-version: 9.0
     filename: rules.json
     count: 1
     match:
@@ -26,7 +28,8 @@ checks:
       lists.packet.matches[0].window.negated: true
 
 - filter:
-    min-version: 9.0
+    requires:
+      min-version: 9.0
     filename: rules.json
     count: 1
     match:
@@ -34,7 +37,8 @@ checks:
       lists.packet.matches[0].name: "tcp.window"
       lists.packet.matches[0].window.equal: 30336
 - filter:
-    min-version: 9.0
+    requires:
+      min-version: 9.0
     filename: rules.json
     count: 1
     match:

--- a/tests/sip-pattern-matching/test.yaml
+++ b/tests/sip-pattern-matching/test.yaml
@@ -1,6 +1,7 @@
 checks:
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: sip
@@ -9,7 +10,8 @@ checks:
         sip.version: "SIP/2.0"
         sip.request_line: "REGISTER sip:sip.cybercity.dk SIP/2.0"
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: sip

--- a/tests/sip-tcp-method/test.yaml
+++ b/tests/sip-tcp-method/test.yaml
@@ -9,18 +9,21 @@ pcap: sip-tcp.pcap
 
 checks:
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: alert
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 2
       match:
         proto: TCP
         event_type: sip
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: stats

--- a/tests/sip-tcp-pattern-matching/test.yaml
+++ b/tests/sip-tcp-pattern-matching/test.yaml
@@ -6,7 +6,8 @@ args:
 
 checks:
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         proto: TCP
@@ -16,7 +17,8 @@ checks:
         sip.version: "SIP/2.0"
         sip.request_line: "REGISTER sip:sip.cybercity.dk SIP/2.0"
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         proto: TCP
@@ -26,7 +28,8 @@ checks:
         sip.reason: "Unauthorized"
         sip.response_line: "SIP/2.0 401 Unauthorized"
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: stats

--- a/tests/sip-tcp-protocol/test.yaml
+++ b/tests/sip-tcp-protocol/test.yaml
@@ -9,30 +9,35 @@ pcap: ../sip-tcp-method/sip-tcp.pcap
 
 checks:
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 2
       match:
         event_type: alert
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: alert
         alert.signature_id: 1
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: alert
         alert.signature_id: 2
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 2
       match:
         proto: TCP
         event_type: sip
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: stats

--- a/tests/sip-tcp-request-line/test.yaml
+++ b/tests/sip-tcp-request-line/test.yaml
@@ -9,18 +9,21 @@ pcap: ../sip-tcp-method/sip-tcp.pcap
 
 checks:
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: alert
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 2
       match:
         proto: TCP
         event_type: sip
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: stats

--- a/tests/sip-tcp-response-line/test.yaml
+++ b/tests/sip-tcp-response-line/test.yaml
@@ -9,18 +9,21 @@ pcap: ../sip-tcp-method/sip-tcp.pcap
 
 checks:
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: alert
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 2
       match:
         proto: TCP
         event_type: sip
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: stats

--- a/tests/sip-tcp-stat-code/test.yaml
+++ b/tests/sip-tcp-stat-code/test.yaml
@@ -9,18 +9,21 @@ pcap: ../sip-tcp-method/sip-tcp.pcap
 
 checks:
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: alert
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 2
       match:
         proto: TCP
         event_type: sip
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: stats

--- a/tests/sip-tcp-stat-msg/test.yaml
+++ b/tests/sip-tcp-stat-msg/test.yaml
@@ -9,18 +9,21 @@ pcap: ../sip-tcp-method/sip-tcp.pcap
 
 checks:
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: alert
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 2
       match:
         proto: TCP
         event_type: sip
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: stats

--- a/tests/sip-tcp-uri/test.yaml
+++ b/tests/sip-tcp-uri/test.yaml
@@ -9,18 +9,21 @@ pcap: ../sip-tcp-method/sip-tcp.pcap
 
 checks:
   - filter:
-      min-version: 8 
+      requires:
+        min-version: 8 
       count: 1
       match:
         event_type: alert
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 2
       match:
         proto: TCP
         event_type: sip
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: stats

--- a/tests/smb-eicar-file/test.yaml
+++ b/tests/smb-eicar-file/test.yaml
@@ -12,7 +12,8 @@ checks:
   # Check for something in the files array, which is an array of
   # fileinfo objects.
   - filter:
-      min-version: 6.0.0
+      requires:
+        min-version: 6.0.0
       count: 1
       match:
         event_type: alert

--- a/tests/smb2-07/test.yaml
+++ b/tests/smb2-07/test.yaml
@@ -6,12 +6,14 @@ args:
 checks:
   - filter:
       # additional event for file deletion
-      min-version: 7
+      requires:
+        min-version: 7
       count: 60
       match:
         event_type: smb
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: smb

--- a/tests/smtp-eve/test.yaml
+++ b/tests/smtp-eve/test.yaml
@@ -113,7 +113,8 @@ checks:
       tcp.tcp_flags_tc: 1b
       tcp.tcp_flags_ts: 1b
 - filter:
-    min-version: 8
+    requires:
+      min-version: 8
     count: 0
     match:
       event_type: anomaly

--- a/tests/smtp-tls-protodetect/test.yaml
+++ b/tests/smtp-tls-protodetect/test.yaml
@@ -7,21 +7,24 @@ args:
 
 checks:
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: flow
         app_proto: tls
         app_proto_tc: smtp
   - filter:
-      version: 7
+      requires:
+        version: 7
       count: 1
       match:
         event_type: flow
         app_proto: tls
         # no smtp probin parser in 7
   - filter:
-      version: 7
+      requires:
+        version: 7
       count: 1
       match:
         event_type: anomaly

--- a/tests/snmp-v3-encrypted/test.yaml
+++ b/tests/snmp-v3-encrypted/test.yaml
@@ -23,7 +23,8 @@ checks:
        snmp.pdu_type: encrypted
        snmp.version: 3
  - filter:
-     min-version: 7
+     requires:
+       min-version: 7
      count: 8
      match:
        event_type: alert

--- a/tests/stream-async/http/stream-async-6063-srv-01/test.yaml
+++ b/tests/stream-async/http/stream-async-6063-srv-01/test.yaml
@@ -34,7 +34,8 @@ checks:
         anomaly.event: UNABLE_TO_MATCH_RESPONSE_TO_REQUEST
         anomaly.layer: proto_parser
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: flow
@@ -62,7 +63,8 @@ checks:
         tcp.ts_max_regions: 1
         tcp.tc_max_regions: 1
   - filter:
-      lt-version: 8
+      requires:
+        lt-version: 8
       count: 1
       match:
         event_type: flow

--- a/tests/stream-async/http/stream-async-6063-srv-02/test.yaml
+++ b/tests/stream-async/http/stream-async-6063-srv-02/test.yaml
@@ -36,7 +36,8 @@ checks:
         anomaly.event: UNABLE_TO_MATCH_RESPONSE_TO_REQUEST
         anomaly.layer: proto_parser
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: flow
@@ -64,7 +65,8 @@ checks:
         tcp.ts_max_regions: 1
         tcp.tc_max_regions: 1
   - filter:
-      lt-version: 8
+      requires:
+        lt-version: 8
       count: 1
       match:
         event_type: flow

--- a/tests/stream-depth-reached-event/test.yaml
+++ b/tests/stream-depth-reached-event/test.yaml
@@ -20,7 +20,8 @@ checks:
         alert.signature_id: 2210062
 
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 2
       match:
         event_type: alert

--- a/tests/tcp-fastopen-10-syn-data-ignore/test.yaml
+++ b/tests/tcp-fastopen-10-syn-data-ignore/test.yaml
@@ -39,28 +39,32 @@ checks:
         direction: "to_server"
         stream_tcp.session.state: "syn_sent"
   - filter:
-      lt-version: 8.0.3
+      requires:
+        lt-version: 8.0.3
       count: 1
       match:
         event_type: tls
         tls.sni: "icloud.com"
         tls.version: "UNDETERMINED"
   - filter:
-      lt-version: 8.0.3
+      requires:
+        lt-version: 8.0.3
       count: 1
       match:
         event_type: tls
         tls.sni: "icloud.com"
         tls.version: "TLS 1.3"
   - filter:
-      min-version: 8.0.3
+      requires:
+        min-version: 8.0.3
       count: 0
       match:
         event_type: tls
         tls.sni: "icloud.com"
         tls.version: "UNDETERMINED"
   - filter:
-      min-version: 8.0.3
+      requires:
+        min-version: 8.0.3
       count: 2
       match:
         event_type: tls

--- a/tests/test-bad-byte-extract-rule-1/test.yaml
+++ b/tests/test-bad-byte-extract-rule-1/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "unknown byte_ keyword var seen in depth - d."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-byte-extract-rule-2/test.yaml
+++ b/tests/test-bad-byte-extract-rule-2/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "invalid value for depth: -5."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-content-quotes-rule-1/test.yaml
+++ b/tests/test-bad-content-quotes-rule-1/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "Invalid unescaped double quote within content section."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-depth-depth-rule-1/test.yaml
+++ b/tests/test-bad-depth-depth-rule-1/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "can't use multiple depths for the same content."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-depth-distance-rule-1/test.yaml
+++ b/tests/test-bad-depth-distance-rule-1/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "can't use a relative keyword like within/distance with a absolute relative keyword like depth/offset for the same content."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-depth-distance-rule-2/test.yaml
+++ b/tests/test-bad-depth-distance-rule-2/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "can't use a relative keyword like within/distance with a absolute relative keyword like depth/offset for the same content."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-depth-rule-1/test.yaml
+++ b/tests/test-bad-depth-rule-1/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "depth needs preceding content, uricontent option, http_client_body, http_server_body, http_header option, http_raw_header option, http_method option, http_cookie, http_raw_uri, http_stat_msg, http_stat_code, http_user_agent, http_host, http_raw_host or file_data/dce_stub_data sticky buffer options."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-depth-within-rule-1/test.yaml
+++ b/tests/test-bad-depth-within-rule-1/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "can't use a relative keyword like within/distance with a absolute relative keyword like depth/offset for the same content."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-depth-within-rule-2/test.yaml
+++ b/tests/test-bad-depth-within-rule-2/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "depth needs preceding content, uricontent option, http_client_body, http_server_body, http_header option, http_raw_header option, http_method option, http_cookie, http_raw_uri, http_stat_msg, http_stat_code, http_user_agent, http_host, http_raw_host or file_data/dce_stub_data sticky buffer options."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-hex-rule-1/test.yaml
+++ b/tests/test-bad-hex-rule-1/test.yaml
@@ -14,14 +14,16 @@ checks:
         engine.message: "Invalid hex code in content - |l0 01 01|, hex l. Invalidating signature."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 4
       match:
         event_type: engine
         engine.module: detect
 
   - filter:
-      min-version: 7.0
+      requires:
+        min-version: 7.0
       count: 1
       match:
         event_type: engine

--- a/tests/test-bad-hex-rule-2/test.yaml
+++ b/tests/test-bad-hex-rule-2/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "Invalid hex code in content - |01 10 0j|, hex j. Invalidating signature."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-hex-rule-3/test.yaml
+++ b/tests/test-bad-hex-rule-3/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "Invalid hex code assembly in content - |1.  Invalidating signature."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-http-host-rule-1/test.yaml
+++ b/tests/test-bad-http-host-rule-1/test.yaml
@@ -5,13 +5,15 @@ checks:
   # check that we have the following entries in eve.json
   # match 1 specific rule load failure reason
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: engine
         engine.message: "rule 1111: A pattern with uppercase characters detected for http.host. The hostname buffer is normalized to lowercase, please specify a lowercase pattern."
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-http-host-rule-2/test.yaml
+++ b/tests/test-bad-http-host-rule-2/test.yaml
@@ -5,13 +5,15 @@ checks:
   # check that we have the following entries in eve.json
   # match 1 specific rule load failure reason
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 1
       match:
         event_type: engine
         engine.message: "rule 123: http.host keyword specified along with \"nocase\". The hostname buffer is normalized to lowercase, specifying nocase is redundant."
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-negate-fast-pattern-rule-1/test.yaml
+++ b/tests/test-bad-negate-fast-pattern-rule-1/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "can't have a relative negated keyword set along with 'fast_pattern'."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-offset-distance-rule-1/test.yaml
+++ b/tests/test-bad-offset-distance-rule-1/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "can't use a relative keyword like within/distance with a absolute relative keyword like depth/offset for the same content."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-offset-offset-rule-1/test.yaml
+++ b/tests/test-bad-offset-offset-rule-1/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "can't use multiple offsets for the same content."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-offset-within-rule-1/test.yaml
+++ b/tests/test-bad-offset-within-rule-1/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "can't use a relative keyword like within/distance with a absolute relative keyword like depth/offset for the same content."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-quotation-marks-rule-1/test.yaml
+++ b/tests/test-bad-quotation-marks-rule-1/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "invalid formatting to content keyword: value must be double quoted 'content'"
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-relative-keyword-fast-pattern-rule-1/test.yaml
+++ b/tests/test-bad-relative-keyword-fast-pattern-rule-1/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "can't have a relative keyword set along with 'fast_pattern:only;'."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-semicolon-rule-1/test.yaml
+++ b/tests/test-bad-semicolon-rule-1/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "bad option value formatting (possible missing semicolon) for keyword content: '\"AA\" depth:20'"
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-semicolon-rule-2/test.yaml
+++ b/tests/test-bad-semicolon-rule-2/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "unknown rule keyword ''."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/test-bad-within-within-rule-1/test.yaml
+++ b/tests/test-bad-within-within-rule-1/test.yaml
@@ -11,7 +11,8 @@ checks:
         engine.message: "can't use multiple withins for the same content."
 
   - filter:
-      min-version: 7
+      requires:
+        min-version: 7
       count: 3
       match:
         event_type: engine

--- a/tests/tls/tls-eve-custom-fields/test.yaml
+++ b/tests/tls/tls-eve-custom-fields/test.yaml
@@ -5,7 +5,8 @@ pcap: ../tls-store-02/tls-client-auth.pcap
 
 checks:
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 1
       match:
         event_type: tls
@@ -22,7 +23,8 @@ checks:
         tls.client.notbefore: '2018-04-14T20:55:27'
         tls.client.notafter: '2018-05-14T20:55:27'
   - filter:
-      min-version: 7.0.8
+      requires:
+        min-version: 7.0.8
       count: 1
       match:
         event_type: tls

--- a/tests/udp-5379/udp-hlen-invalid-non-strict/test.yaml
+++ b/tests/udp-5379/udp-hlen-invalid-non-strict/test.yaml
@@ -10,7 +10,8 @@ command: |
 
 checks:
     - shell:
-        version: 7
+        requires:
+          version: 7
         args: |-
           grep "Warning: detect: decode-event keyword no longer supports event \"decoder.udp.hlen_invalid\"" suricata.log | wc -l
         expect: 1

--- a/tests/udp-5379/udp-hlen-invalid-strict/test.yaml
+++ b/tests/udp-5379/udp-hlen-invalid-strict/test.yaml
@@ -9,7 +9,8 @@ command: |
 
 checks:
     - shell:
-        version: 7
+        requires:
+          version: 7
         args: |-
           grep "Error: detect: decode-event keyword no longer supports event \"decoder.udp.hlen_invalid\"" suricata.log | wc -l
         expect: 1

--- a/tests/util-action-tests/util-action-01/test.yaml
+++ b/tests/util-action-tests/util-action-01/test.yaml
@@ -6,7 +6,8 @@ args:
 
 checks:
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       event_type: flow

--- a/tests/util-action-tests/util-action-02/test.yaml
+++ b/tests/util-action-tests/util-action-02/test.yaml
@@ -6,7 +6,8 @@ args:
 
 checks:
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       event_type: flow

--- a/tests/util-action-tests/util-action-05/test.yaml
+++ b/tests/util-action-tests/util-action-05/test.yaml
@@ -4,7 +4,8 @@ args:
 
 checks:
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       event_type: flow

--- a/tests/util-action-tests/util-action-09/test.yaml
+++ b/tests/util-action-tests/util-action-09/test.yaml
@@ -6,7 +6,8 @@ args:
 
 checks:
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       event_type: flow

--- a/tests/util-action-tests/util-action-10/test.yaml
+++ b/tests/util-action-tests/util-action-10/test.yaml
@@ -4,7 +4,8 @@ args:
 
 checks:
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       event_type: flow

--- a/tests/util-action-tests/util-action-11/test.yaml
+++ b/tests/util-action-tests/util-action-11/test.yaml
@@ -6,7 +6,8 @@ args:
 
 checks:
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       event_type: flow

--- a/tests/util-action-tests/util-action-12/test.yaml
+++ b/tests/util-action-tests/util-action-12/test.yaml
@@ -4,7 +4,8 @@ args:
 
 checks:
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       event_type: flow

--- a/tests/util-action-tests/util-action-14/test.yaml
+++ b/tests/util-action-tests/util-action-14/test.yaml
@@ -6,7 +6,8 @@ args:
 
 checks:
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       event_type: flow

--- a/tests/util-action-tests/util-action-15/test.yaml
+++ b/tests/util-action-tests/util-action-15/test.yaml
@@ -6,7 +6,8 @@ args:
 
 checks:
 - filter:
-    min-version: 7
+    requires:
+      min-version: 7
     count: 1
     match:
       event_type: flow

--- a/tests/vxlan-decoder-03/test.yaml
+++ b/tests/vxlan-decoder-03/test.yaml
@@ -3,7 +3,8 @@ args:
 
 checks:
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 14
       match:
         event_type: flow
@@ -11,7 +12,8 @@ checks:
         flow.pkts_toclient: 0
         flow.bytes_toclient: 0
   - filter:
-      min-version: 8
+      requires:
+        min-version: 8
       count: 2
       match:
         event_type: flow
@@ -20,7 +22,8 @@ checks:
         flow.pkts_toclient: 0
         flow.bytes_toclient: 0
   - filter:
-      lt-version: 8
+      requires:
+        lt-version: 8
       count: 13
       match:
         event_type: flow


### PR DESCRIPTION
Filters that prevent a check from running should be inside a requires block as
this is what is documented in the README.

- Fix-up tests that didn't have their require expressions inside "requires"
- Fail on unknown keywords in a check block
- Remove now unused code
