### PR TITLE
backport: support issue 7908 tests for 7 - v2

### DIFF
--- a/tests/bug-6149-exception-policy-auto-ips/test.yaml
+++ b/tests/bug-6149-exception-policy-auto-ips/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.4
+  min-version: 7.0.16
   features:
     - QA_SIMULATION
 

--- a/tests/exception-policy-applayer-01/test.yaml
+++ b/tests/exception-policy-applayer-01/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.4
+  min-version: 7.0.16
   features:
     - QA_SIMULATION
 pcap: ../tls/tls-certs-alert/input.pcap

--- a/tests/exception-policy-applayer-02/test.yaml
+++ b/tests/exception-policy-applayer-02/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.4
+  min-version: 7.0.16
   features:
     - QA_SIMULATION
 pcap: ../tls/tls-certs-alert/input.pcap

--- a/tests/exception-policy-applayer-03/test.yaml
+++ b/tests/exception-policy-applayer-03/test.yaml
@@ -1,6 +1,5 @@
 requires:
-  #min-version: 7.0.12 temporary change
-  min-version: 8.0.4
+  min-version: 7.0.16
   features:
     - QA_SIMULATION
 pcap: ../bittorrent-dht/input.pcap

--- a/tests/exception-policy-default-01/test.yaml
+++ b/tests/exception-policy-default-01/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.4
+  min-version: 7.0.16
   features:
     - QA_SIMULATION
 

--- a/tests/exception-policy-defrag-01/test.yaml
+++ b/tests/exception-policy-defrag-01/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.4
+  min-version: 7.0.16
   features:
     - QA_SIMULATION
 args:

--- a/tests/exception-policy-simulated-flow-memcap/test.yaml
+++ b/tests/exception-policy-simulated-flow-memcap/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.4
+  min-version: 7.0.16
   features:
     - QA_SIMULATION
 

--- a/tests/exception-policy-stream-reassembly-memcap-01/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-01/test.yaml
@@ -1,6 +1,5 @@
 requires:
-  #min-version: 7 temporary removal
-  min-version: 8.0.4
+  min-version: 7.0.16
   features:
     - QA_SIMULATION
 pcap: ../tls/tls-certs-alert/input.pcap

--- a/tests/exception-policy-stream-reassembly-memcap-02/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-02/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.4
+  min-version: 7.0.16
   features:
     - QA_SIMULATION
 pcap: ../tls/tls-certs-alert/input.pcap

--- a/tests/exception-policy-stream-reassembly-memcap-03/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-03/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.4
+  min-version: 7.0.16
   features:
     - QA_SIMULATION
 pcap: ../tls/tls-certs-alert/input.pcap

--- a/tests/exception-policy-stream-reassembly-memcap-04/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-04/test.yaml
@@ -1,6 +1,5 @@
 requires:
-  #min-version: 7 temporary removal
-  min-version: 8.0.4
+  min-version: 7.0.16
   features:
     - QA_SIMULATION
 pcap: ../tls/tls-certs-alert/input.pcap

--- a/tests/exception-policy-stream-reassembly-memcap-05/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-05/test.yaml
@@ -1,6 +1,5 @@
 requires:
-  #min-version: 7 temporary removal
-  min-version: 8.0.4
+  min-version: 7.0.16
   features:
     - QA_SIMULATION
 pcap: ../tls/tls-certs-alert/input.pcap

--- a/tests/exception-policy-stream-reassembly-memcap-06/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-06/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.4
+  min-version: 7.0.16
   features:
     - QA_SIMULATION
 pcap: ../tls/tls-certs-alert/input.pcap

--- a/tests/exception-policy-stream-ssn-memcap-01/test.yaml
+++ b/tests/exception-policy-stream-ssn-memcap-01/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.4
+  min-version: 7.0.16
   features:
     - QA_SIMULATION
 pcap: ../tls/tls-certs-alert/input.pcap


### PR DESCRIPTION
https://github.com/OISF/suricata-verify/pull/2950, rebased and adjusted for 7.0.16, now.

Tests should pass here, as if no `qa-simulation` enabled, they'll just be skipped.

## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7908
