### PR TITLE
ci: add qa-simulation to runs - v1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -83,7 +83,7 @@ jobs:
         working-directory: suricata
         run: |
           ./autogen.sh
-          ./configure --enable-lua --enable-debug-validation
+          ./configure --enable-lua --enable-debug-validation --enable-qa-simulation
           make -j2
       - name: Running suricata-verify
         working-directory: suricata
@@ -151,7 +151,7 @@ jobs:
         working-directory: suricata
         run: |
           ./autogen.sh
-          ./configure --enable-lua --enable-debug-validation
+          ./configure --enable-lua --enable-debug-validation --enable-qa-simulation
           make -j2
       - name: Running suricata-verify
         working-directory: suricata


### PR DESCRIPTION
Related to
Task #7885

## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/

Related to https://redmine.openinfosecfoundation.org/issues/7885 -- in the sense that we should have qa-simulation enabled...
