### PR TITLE
tests: add test for ticket 5711

### DIFF
--- a/tests/runmode-error-5711/README.md
+++ b/tests/runmode-error-5711/README.md
@@ -1,0 +1,7 @@
+## Description
+
+Test that an error is given in case a cmdline option was provided but no runmode was specified.
+
+### Ticket
+
+https://redmine.openinfosecfoundation.org/issues/5711

--- a/tests/runmode-error-5711/blah.rules
+++ b/tests/runmode-error-5711/blah.rules
@@ -1,0 +1,1 @@
+# Nothing to see here. Just a placeholder.

--- a/tests/runmode-error-5711/test.yaml
+++ b/tests/runmode-error-5711/test.yaml
@@ -1,0 +1,13 @@
+requires:
+  min-version: 9
+
+pcap: false
+command: |
+  ${SRCDIR}/src/suricata -S ${TEST_DIR}/blah.rules
+
+exit-code: 1
+
+checks:
+  - shell:
+      args: grep "Please specify a runmode or capture option. Use --list-runmodes to see available runmodes." stderr | wc -l
+      expect: 1


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata-verify/pull/2934

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/5711

Changes since v1:
- rebased on top of latest master
- checks stderr instead of stdout as per Suricata PR changes