### PR TITLE
test(firewall): Add verify tests for untested firewall keywords

### DIFF
--- a/tests/firewall/firewall-keyword-dns/dns_rep.rep
+++ b/tests/firewall/firewall-keyword-dns/dns_rep.rep
@@ -1,0 +1,2 @@
+Y2xpZW50LWNmLmRyb3Bib3guY29t,255
+YmxvY2suZHJvcGJveC5jb20=,255

--- a/tests/firewall/firewall-keyword-dns/firewall.rules
+++ b/tests/firewall/firewall-keyword-dns/firewall.rules
@@ -1,0 +1,15 @@
+# Test dns.opcode and datarep keywords in firewall mode
+# dns-eve PCAP: 4 DNS queries (3 dropbox, 1 codemonkey.net), all standard queries (opcode 0)
+
+# Accept all UDP packets
+accept:hook udp:all any any -> any any (sid:100;)
+
+# Test dns.opcode: match standard query (opcode 0) and alert
+accept:hook dns:request_started any any -> any any (dns.opcode:0; alert; sid:1;)
+
+# Test datarep: match DNS query against reputation list
+accept:hook dns:request_complete any any -> any any (dns.query; datarep:dns_rep,>,0,load dns_rep.rep,type string; alert; sid:2;)
+
+# Accept response hooks
+accept:hook dns:response_started any any -> any any (sid:201;)
+accept:hook dns:response_complete any any -> any any (sid:202;)

--- a/tests/firewall/firewall-keyword-dns/test.yaml
+++ b/tests/firewall/firewall-keyword-dns/test.yaml
@@ -1,0 +1,33 @@
+requires:
+  min-version: 8
+
+pcap: ../../dns/dns-eve/input.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+# dns.opcode:0 matches all 4 DNS requests (all are standard queries)
+- filter:
+    count: 4
+    match:
+      event_type: alert
+      alert.signature_id: 1
+# datarep matches 3 queries (client-cf.dropbox.com x2 + block.dropbox.com)
+- filter:
+    count: 3
+    match:
+      event_type: alert
+      alert.signature_id: 2
+- filter:
+    count: 0
+    match:
+      event_type: drop
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 7
+      stats.ips.blocked: 1
+      stats.ips.drop_reason.default_packet_policy: 1

--- a/tests/firewall/firewall-keyword-http/firewall.rules
+++ b/tests/firewall/firewall-keyword-http/firewall.rules
@@ -1,0 +1,26 @@
+# Test pcre, urilen, and dataset keywords in firewall mode
+# flowbit-oring PCAP: single HTTP GET / to testmyids.com, user-agent curl/7.43.0
+
+# Accept TCP session setup
+accept:hook tcp:all any any -> any any (sid:100;)
+
+# Accept request_started to allow app-layer processing
+accept:hook http1:request_started any any -> any any (sid:101;)
+
+# Test pcre: match URI "/" with regex (request_line hook)
+# Test urilen: URI "/" has length 1 (request_line hook)
+accept:hook http1:request_line any any -> any any (http.uri; pcre:"/^\//"; urilen:1; alert; sid:1;)
+
+# Test dataset: match user-agent against loaded dataset (request_headers hook)
+accept:hook http1:request_headers any any -> any any (http.user_agent; dataset:isset,ua-seen,type string,load ua-seen.csv; alert; sid:2;)
+
+# Accept remaining request/response hooks
+accept:hook http1:request_body any any -> any any (sid:104;)
+accept:hook http1:request_trailer any any -> any any (sid:105;)
+accept:hook http1:request_complete any any -> any any (sid:106;)
+accept:hook http1:response_started any any -> any any (sid:201;)
+accept:hook http1:response_line any any -> any any (sid:202;)
+accept:hook http1:response_headers any any -> any any (sid:203;)
+accept:hook http1:response_body any any -> any any (sid:204;)
+accept:hook http1:response_trailer any any -> any any (sid:205;)
+accept:hook http1:response_complete any any -> any any (sid:206;)

--- a/tests/firewall/firewall-keyword-http/test.yaml
+++ b/tests/firewall/firewall-keyword-http/test.yaml
@@ -1,0 +1,33 @@
+requires:
+  min-version: 8
+
+pcap: ../../flowbit-oring/input.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+# pcre + urilen match on URI "/" at request_line hook
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      alert.signature_id: 1
+# dataset matches user-agent "curl/7.43.0" at request_headers hook
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      alert.signature_id: 2
+# No drops - all hooks covered
+- filter:
+    count: 0
+    match:
+      event_type: drop
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 10
+      stats.ips.blocked: 0

--- a/tests/firewall/firewall-keyword-http/ua-seen.csv
+++ b/tests/firewall/firewall-keyword-http/ua-seen.csv
@@ -1,0 +1,1 @@
+Y3VybC83LjQzLjA=

--- a/tests/firewall/firewall-keyword-icode/firewall.rules
+++ b/tests/firewall/firewall-keyword-icode/firewall.rules
@@ -1,0 +1,8 @@
+# Test icode keyword in firewall mode
+# ICMP PCAP has echo requests (type 8, code 0) and echo replies (type 0, code 0)
+
+# Accept all ICMP packets with icode:0 (all packets match)
+accept:hook icmp:all any any -> any any (icode:0; alert; sid:1;)
+
+# Drop everything else
+drop:packet ip:all any any -> any any (sid:999;)

--- a/tests/firewall/firewall-keyword-icode/test.yaml
+++ b/tests/firewall/firewall-keyword-icode/test.yaml
@@ -1,0 +1,26 @@
+requires:
+  min-version: 8
+
+pcap: ../../detect-itype-prefilter/icmpv4-ping.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+# icode:0 matches all 150 ICMP packets (75 echo req + 75 echo reply, all code 0)
+- filter:
+    count: 150
+    match:
+      event_type: alert
+      alert.signature_id: 1
+- filter:
+    count: 0
+    match:
+      event_type: drop
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 150
+      stats.ips.blocked: 0

--- a/tests/firewall/firewall-keyword-tls/firewall.rules
+++ b/tests/firewall/firewall-keyword-tls/firewall.rules
@@ -1,0 +1,21 @@
+# Test tls.cert_chain_len keyword in firewall mode
+# tls-certs-alert PCAP: TLS handshake with 3 certificates in chain
+
+# Accept TCP session setup
+accept:hook tcp:all any any -> any any (sid:100;)
+
+# Accept TLS client states
+accept:hook tls:client_in_progress any any -> any any (sid:101;)
+accept:hook tls:client_hello_done any any -> any any (sid:102;)
+accept:hook tls:client_cert_done any any -> any any (sid:103;)
+accept:hook tls:client_handshake_done any any -> any any (sid:104;)
+
+# Accept TLS server states
+accept:hook tls:server_in_progress any any -> any any (sid:201;)
+accept:hook tls:server_hello any any -> any any (sid:202;)
+
+# Test tls.cert_chain_len: match cert chain with 3 certs
+accept:flow tls:server_cert_done any any -> any any (tls.cert_chain_len:3; alert; sid:1;)
+
+accept:hook tls:server_hello_done any any -> any any (sid:204;)
+accept:hook tls:server_handshake_done any any -> any any (sid:205;)

--- a/tests/firewall/firewall-keyword-tls/test.yaml
+++ b/tests/firewall/firewall-keyword-tls/test.yaml
@@ -1,0 +1,25 @@
+requires:
+  min-version: 8
+
+pcap: ../../tls/tls-certs-alert/input.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+# tls.cert_chain_len:3 matches the certificate chain
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      alert.signature_id: 1
+- filter:
+    count: 0
+    match:
+      event_type: drop
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.blocked: 0


### PR DESCRIPTION
Add suricata-verify tests for 7 keywords that emit 'has not been tested for firewall rules' warnings. Tests are consolidated into 4 test cases:

- firewall-keyword-icode: tests icode with ICMP echo traffic
- firewall-keyword-http: tests pcre, urilen, dataset with HTTP traffic
- firewall-keyword-dns: tests dns.opcode, datarep with DNS traffic
- firewall-keyword-tls: tests tls.cert_chain_len with TLS cert chain

These tests validate that the keywords function correctly in firewall mode and can be used to justify adding SIGMATCH_SUPPORT_FIREWALL to each keyword in the engine.


## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/8387
