### PR TITLE
tests: check for more ruletypes in firewall mode - v4

### DIFF
--- a/tests/firewall/ruletype-firewall-43-tls-cert-chain/README.md
+++ b/tests/firewall/ruletype-firewall-43-tls-cert-chain/README.md
@@ -1,0 +1,3 @@
+Test that the ``tls.cert_chain_len`` keyword works in firewall mode.
+
+Expected result: traffic not allowed.

--- a/tests/firewall/ruletype-firewall-43-tls-cert-chain/firewall.rules
+++ b/tests/firewall/ruletype-firewall-43-tls-cert-chain/firewall.rules
@@ -1,0 +1,22 @@
+# allow session setup
+accept:hook tcp:all $HOME_NET any <> $EXTERNAL_NET any (flow:not_established; sid:1021;)
+accept:hook tcp:all $HOME_NET any <> $EXTERNAL_NET 443 (flow:established; sid:1022;)
+
+accept:hook tls:client_in_progress $HOME_NET any -> $EXTERNAL_NET any (sid:101;)
+drop:flow tls:client_hello_done $HOME_NET any -> $EXTERNAL_NET any (tls.version:1.0; msg:"TLS 1.0 not allowed"; sid:102;)
+accept:hook tls:client_hello_done $HOME_NET any -> $EXTERNAL_NET any (tls.sni; content:"www.google.com"; sid:103;)
+accept:hook tls:client_cert_done $HOME_NET any -> $EXTERNAL_NET any (sid:104;)
+accept:hook tls:client_handshake_done $HOME_NET any -> $EXTERNAL_NET any (sid:105;)
+accept:hook tls:client_finished $HOME_NET any -> $EXTERNAL_NET any (sid:106;)
+
+accept:hook tls:server_in_progress $EXTERNAL_NET any -> $HOME_NET any (sid:107;)
+accept:hook tls:server_hello $EXTERNAL_NET any -> $HOME_NET any (sid:109;)
+drop:flow tls:server_hello_done $EXTERNAL_NET any -> $HOME_NET any (tls.version:1.0; msg:"TLS 1.0 not allowed"; sid:108;)
+drop:flow tls:server_cert_done $EXTERNAL_NET any -> $HOME_NET any (tls.cert_chain_len:>2; sid:110; msg:"TLS certs chain length check"; alert;)
+accept:hook tls:server_hello_done $EXTERNAL_NET any -> $HOME_NET any (sid:111;)
+accept:hook tls:server_cert_done $EXTERNAL_NET any -> $HOME_NET any (sid:112;)
+accept:hook tls:server_handshake_done $EXTERNAL_NET any -> $HOME_NET any (sid:113;)
+accept:hook tls:server_finished $EXTERNAL_NET any -> $HOME_NET any (sid:114;)
+
+
+# Implicit drop all else

--- a/tests/firewall/ruletype-firewall-43-tls-cert-chain/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-43-tls-cert-chain/suricata.yaml
@@ -1,0 +1,32 @@
+%YAML 1.1
+---
+
+vars:
+  # more specific is better for alert accuracy and performance
+  address-groups:
+    HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
+
+    EXTERNAL_NET: "!$HOME_NET"
+
+
+# Global stats configuration
+stats:
+  enabled: yes
+  interval: 8
+
+# Configure the type of alert (and other) logging you would like.
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+          - stats
+          - flow
+          - alert:
+              verdict: yes
+          - tls:
+              extended: yes     # enable this for extended logging information
+          - drop:
+              alerts: yes      # log alerts that caused drops
+              flows: all       # start or all: 'start' logs only a single drop

--- a/tests/firewall/ruletype-firewall-43-tls-cert-chain/test.yaml
+++ b/tests/firewall/ruletype-firewall-43-tls-cert-chain/test.yaml
@@ -1,0 +1,37 @@
+requires:
+  min-version: 9
+
+pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      alert.signature_id: 110
+- filter:
+    count: 42
+    match:
+      event_type: drop
+      drop.reason: "flow drop"
+- filter:
+    count: 1
+    match:
+      event_type: flow
+      app_proto: tls
+      flow.action: drop
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.app_layer.flow.tls: 1
+      stats.flow.total: 1
+      stats.ips.accepted: 19
+      stats.ips.blocked: 43
+      stats.ips.drop_reason.flow_drop: 42
+      stats.ips.drop_reason.rules: 1
+      stats.decoder.pkts: 62

--- a/tests/firewall/ruletype-firewall-51-tls-cert-chain/README.md
+++ b/tests/firewall/ruletype-firewall-51-tls-cert-chain/README.md
@@ -1,0 +1,3 @@
+Test that the ``tls.cert_chain_len`` keyword works in firewall mode.
+
+Expected result: traffic allowed.

--- a/tests/firewall/ruletype-firewall-51-tls-cert-chain/firewall.rules
+++ b/tests/firewall/ruletype-firewall-51-tls-cert-chain/firewall.rules
@@ -1,0 +1,20 @@
+# allow session setup
+accept:hook tcp:all $HOME_NET any <> $EXTERNAL_NET any (flow:not_established; sid:1021;)
+accept:hook tcp:all $HOME_NET any <> $EXTERNAL_NET 443 (flow:established; sid:1022;)
+
+accept:hook tls:client_in_progress $HOME_NET any -> $EXTERNAL_NET any (sid:101;)
+drop:flow tls:client_hello_done $HOME_NET any -> $EXTERNAL_NET any (tls.version:1.0; msg:"TLS 1.0 not allowed"; sid:102;)
+accept:hook tls:client_hello_done $HOME_NET any -> $EXTERNAL_NET any (tls.sni; content:"www.google.com"; sid:103;)
+accept:hook tls:client_cert_done $HOME_NET any -> $EXTERNAL_NET any (sid:104;)
+accept:hook tls:client_handshake_done $HOME_NET any -> $EXTERNAL_NET any (sid:105;)
+accept:hook tls:client_finished $HOME_NET any -> $EXTERNAL_NET any (sid:106;)
+
+accept:hook tls:server_in_progress $EXTERNAL_NET any -> $HOME_NET any (sid:107;)
+accept:hook tls:server_hello $EXTERNAL_NET any -> $HOME_NET any (sid:108;)
+drop:flow tls:server_hello_done $EXTERNAL_NET any -> $HOME_NET any (tls.version:1.0; msg:"TLS 1.0 not allowed"; sid:109;)
+accept:hook tls:server_hello_done $EXTERNAL_NET any -> $HOME_NET any (sid:110;)
+accept:flow tls:server_cert_done $EXTERNAL_NET any -> $HOME_NET any (tls.cert_chain_len:>2; sid:111; msg:"TLS certs chain length check"; alert;)
+# other hooks skipped
+
+
+# Implicit drop all else

--- a/tests/firewall/ruletype-firewall-51-tls-cert-chain/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-51-tls-cert-chain/suricata.yaml
@@ -1,0 +1,31 @@
+%YAML 1.1
+---
+
+vars:
+  # more specific is better for alert accuracy and performance
+  address-groups:
+    HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
+
+    EXTERNAL_NET: "!$HOME_NET"
+
+# Global stats configuration
+stats:
+  enabled: yes
+  interval: 8
+
+# Configure the type of alert (and other) logging you would like.
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+          - stats
+          - flow
+          - alert:
+              verdict: yes
+          - tls:
+              extended: yes     # enable this for extended logging information
+          - drop:
+              alerts: yes      # log alerts that caused drops
+              flows: all       # start or all: 'start' logs only a single drop

--- a/tests/firewall/ruletype-firewall-51-tls-cert-chain/test.yaml
+++ b/tests/firewall/ruletype-firewall-51-tls-cert-chain/test.yaml
@@ -1,0 +1,30 @@
+requires:
+  min-version: 9
+
+pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      alert.signature_id: 111
+- filter:
+    count: 0
+    match:
+      event_type: drop
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.app_layer.flow.tls: 1
+      stats.flow.total: 1
+      stats.ips.accepted: 62
+      stats.ips.blocked: 0
+      stats.ips.drop_reason.flow_drop: 0
+      stats.ips.drop_reason.rules: 0
+      stats.decoder.pkts: 62

--- a/tests/firewall/ruletype-firewall-53-http-pcre-urilen-dataset/firewall.rules
+++ b/tests/firewall/ruletype-firewall-53-http-pcre-urilen-dataset/firewall.rules
@@ -1,0 +1,26 @@
+# Test pcre, urilen, and dataset keywords in firewall mode
+# flowbit-oring PCAP: single HTTP GET / to testmyids.com, user-agent curl/7.43.0
+
+# Accept TCP session setup
+accept:hook tcp:all any any -> any any (sid:100;)
+
+# Accept request_started to allow app-layer processing
+accept:hook http1:request_started any any -> any any (sid:101;)
+
+# Test pcre: match URI "/" with regex (request_line hook)
+# Test urilen: URI "/" has length 1 (request_line hook)
+accept:hook http1:request_line any any -> any any (http.uri; pcre:"/^\//"; urilen:1; alert; sid:1;)
+
+# Test dataset: match user-agent against loaded dataset (request_headers hook)
+accept:hook http1:request_headers any any -> any any (http.user_agent; dataset:isset,ua-seen,type string,load ua-seen.csv; alert; sid:2;)
+
+# Accept remaining request/response hooks
+accept:hook http1:request_body any any -> any any (sid:104;)
+accept:hook http1:request_trailer any any -> any any (sid:105;)
+accept:hook http1:request_complete any any -> any any (sid:106;)
+accept:hook http1:response_started any any -> any any (sid:201;)
+accept:hook http1:response_line any any -> any any (sid:202;)
+accept:hook http1:response_headers any any -> any any (sid:203;)
+accept:hook http1:response_body any any -> any any (sid:204;)
+accept:hook http1:response_trailer any any -> any any (sid:205;)
+accept:hook http1:response_complete any any -> any any (sid:206;)

--- a/tests/firewall/ruletype-firewall-53-http-pcre-urilen-dataset/test.yaml
+++ b/tests/firewall/ruletype-firewall-53-http-pcre-urilen-dataset/test.yaml
@@ -1,0 +1,33 @@
+requires:
+  min-version: 9
+
+pcap: ../../flowbit-oring/input.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+# pcre + urilen match on URI "/" at request_line hook
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      alert.signature_id: 1
+# dataset matches user-agent "curl/7.43.0" at request_headers hook
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      alert.signature_id: 2
+# No drops - all hooks covered
+- filter:
+    count: 0
+    match:
+      event_type: drop
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 10
+      stats.ips.blocked: 0

--- a/tests/firewall/ruletype-firewall-53-http-pcre-urilen-dataset/ua-seen.csv
+++ b/tests/firewall/ruletype-firewall-53-http-pcre-urilen-dataset/ua-seen.csv
@@ -1,0 +1,1 @@
+Y3VybC83LjQzLjA=

--- a/tests/firewall/ruletype-firewall-54-icmp-icode/firewall.rules
+++ b/tests/firewall/ruletype-firewall-54-icmp-icode/firewall.rules
@@ -1,0 +1,8 @@
+# Test icode keyword in firewall mode
+# ICMP PCAP has echo requests (type 8, code 0) and echo replies (type 0, code 0)
+
+# Accept all ICMP packets with icode:0 (all packets match)
+accept:hook icmp:all any any -> any any (icode:0; alert; sid:1;)
+
+# Drop everything else
+drop:packet ip:all any any -> any any (sid:999;)

--- a/tests/firewall/ruletype-firewall-54-icmp-icode/test.yaml
+++ b/tests/firewall/ruletype-firewall-54-icmp-icode/test.yaml
@@ -1,0 +1,26 @@
+requires:
+  min-version: 9
+
+pcap: ../../detect-itype-prefilter/icmpv4-ping.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+# icode:0 matches all 150 ICMP packets (75 echo req + 75 echo reply, all code 0)
+- filter:
+    count: 150
+    match:
+      event_type: alert
+      alert.signature_id: 1
+- filter:
+    count: 0
+    match:
+      event_type: drop
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 150
+      stats.ips.blocked: 0

--- a/tests/firewall/ruletype-firewall-56-dns-opcode/dns_rep.rep
+++ b/tests/firewall/ruletype-firewall-56-dns-opcode/dns_rep.rep
@@ -1,0 +1,2 @@
+Y2xpZW50LWNmLmRyb3Bib3guY29t,255
+YmxvY2suZHJvcGJveC5jb20=,255

--- a/tests/firewall/ruletype-firewall-56-dns-opcode/firewall.rules
+++ b/tests/firewall/ruletype-firewall-56-dns-opcode/firewall.rules
@@ -1,0 +1,12 @@
+# Test dns.opcode keyword in firewall mode
+# dns-eve PCAP: 4 DNS queries (3 dropbox, 1 codemonkey.net), all standard queries (opcode 0)
+
+# Accept all UDP packets
+accept:hook udp:all any any -> any any (sid:100;)
+
+# Test dns.opcode: match standard query (opcode 0) and alert
+accept:hook dns:request_complete any any -> any any (dns.opcode:0; alert; sid:1;)
+
+# Accept response hooks
+accept:hook dns:response_started any any -> any any (sid:201;)
+accept:hook dns:response_complete any any -> any any (sid:202;)

--- a/tests/firewall/ruletype-firewall-56-dns-opcode/test.yaml
+++ b/tests/firewall/ruletype-firewall-56-dns-opcode/test.yaml
@@ -1,0 +1,33 @@
+requires:
+  min-version: 9
+
+pcap: ../../dns/dns-eve/input.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+# dns.opcode:0 matches all 4 DNS requests (all are standard queries)
+- filter:
+    count: 4
+    match:
+      event_type: alert
+      alert.signature_id: 1
+# datarep matches 3 queries (client-cf.dropbox.com x2 + block.dropbox.com)
+- filter:
+    count: 0
+    match:
+      event_type: alert
+      alert.signature_id: 2
+- filter:
+    count: 0
+    match:
+      event_type: drop
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 8
+      stats.ips.blocked: 0
+      stats.ips.drop_reason.default_packet_policy: 0

--- a/tests/firewall/ruletype-firewall-57-dns-datarep/dns_rep.rep
+++ b/tests/firewall/ruletype-firewall-57-dns-datarep/dns_rep.rep
@@ -1,0 +1,2 @@
+Y2xpZW50LWNmLmRyb3Bib3guY29t,255
+YmxvY2suZHJvcGJveC5jb20=,255

--- a/tests/firewall/ruletype-firewall-57-dns-datarep/firewall.rules
+++ b/tests/firewall/ruletype-firewall-57-dns-datarep/firewall.rules
@@ -1,0 +1,12 @@
+# Test datarep keyword in firewall mode
+# dns-eve PCAP: 4 DNS queries (3 dropbox, 1 codemonkey.net), all standard queries (opcode 0)
+
+# Accept all UDP packets
+accept:hook udp:all any any -> any any (sid:100;)
+
+# Test datarep: match DNS query against reputation list
+accept:hook dns:request_complete any any -> any any (dns.query; datarep:dns_rep,>,0,load dns_rep.rep,type string; alert; sid:1;)
+
+# Accept response hooks
+accept:hook dns:response_started any any -> any any (sid:201;)
+accept:hook dns:response_complete any any -> any any (sid:202;)

--- a/tests/firewall/ruletype-firewall-57-dns-datarep/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-57-dns-datarep/suricata.yaml
@@ -1,0 +1,63 @@
+%YAML 1.1
+---
+
+vars:
+  # more specific is better for alert accuracy and performance
+  address-groups:
+    HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
+    #HOME_NET: "[192.168.0.0/16]"
+    #HOME_NET: "[10.0.0.0/8]"
+    #HOME_NET: "[172.16.0.0/12]"
+    #HOME_NET: "any"
+
+    EXTERNAL_NET: "!$HOME_NET"
+    #EXTERNAL_NET: "any"
+
+    HTTP_SERVERS: "$HOME_NET"
+    SMTP_SERVERS: "$HOME_NET"
+    SQL_SERVERS: "$HOME_NET"
+    DNS_SERVERS: "$HOME_NET"
+    TELNET_SERVERS: "$HOME_NET"
+    AIM_SERVERS: "$EXTERNAL_NET"
+    DC_SERVERS: "$HOME_NET"
+    DNP3_SERVER: "$HOME_NET"
+    DNP3_CLIENT: "$HOME_NET"
+    MODBUS_CLIENT: "$HOME_NET"
+    MODBUS_SERVER: "$HOME_NET"
+    ENIP_CLIENT: "$HOME_NET"
+    ENIP_SERVER: "$HOME_NET"
+
+  port-groups:
+    HTTP_PORTS: "80"
+    SHELLCODE_PORTS: "!80"
+    ORACLE_PORTS: 1521
+    SSH_PORTS: 22
+    DNP3_PORTS: 20000
+    MODBUS_PORTS: 502
+    FILE_DATA_PORTS: "[$HTTP_PORTS,110,143]"
+    FTP_PORTS: 21
+    GENEVE_PORTS: 6081
+    VXLAN_PORTS: 4789
+    TEREDO_PORTS: 3544
+    SIP_PORTS: "[5060, 5061]"
+
+# Global stats configuration
+stats:
+  enabled: yes
+  interval: 8
+
+# Configure the type of alert (and other) logging you would like.
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - stats
+        - flow
+        - alert
+        - tls:
+            extended: yes     # enable this for extended logging information
+        - drop:
+            alerts: yes      # log alerts that caused drops
+            flows: all       # start or all: 'start' logs only a single drop

--- a/tests/firewall/ruletype-firewall-57-dns-datarep/test.yaml
+++ b/tests/firewall/ruletype-firewall-57-dns-datarep/test.yaml
@@ -1,0 +1,28 @@
+requires:
+  min-version: 9
+
+pcap: ../../dns/dns-eve/input.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+# datarep matches 3 queries (client-cf.dropbox.com x2 + block.dropbox.com)
+- filter:
+    count: 3
+    match:
+      event_type: alert
+      alert.signature_id: 1
+- filter:
+    count: 2
+    match:
+      event_type: drop
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 6
+      stats.ips.blocked: 2
+      stats.ips.drop_reason.default_app_policy: 1
+      stats.ips.drop_reason.flow_drop: 1


### PR DESCRIPTION
Follow-up of https://github.com/OISF/suricata-verify/pull/3025

- Rebased, adjusting naming conflict after the last additions to firewalls tests
- adjusted dns tests, that now need a different dns hook to work, (since the Helper function registers the progress, now), and that now can't be in the same test to have alerts for both (as they're using the same dns hook for different keywords, and thus either I got alert for one, or for the other).

## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/8387