### PR TITLE
detect-bytetest-02: fix alert count

### DIFF
--- a/tests/detect-bytetest-02/test.yaml
+++ b/tests/detect-bytetest-02/test.yaml
@@ -1,5 +1,5 @@
 args:
-- --set stream.midstream=true
+  - --set stream.midstream=true
 
 checks:
 - filter:
@@ -26,12 +26,12 @@ checks:
       event_type: alert
       alert.signature_id: 3
 - filter:
-    count: 2
+    count: 1
     match:
       event_type: alert
       alert.signature_id: 4
 - filter:
-    count: 2
+    count: 1
     match:
       event_type: alert
       alert.signature_id: 5


### PR DESCRIPTION
There's just one packet in the pcap that matches the rules 4 and 5, there's no need for 2 alerts. However, with the way packet-stream rules are assessed by Suricata, the rules are inspected twice by packet and stream payload inspection engines thus creating 2 alerts.


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/8266
