### PR TITLE
tests/arp: Extend version to 8.0.5

### DIFF
--- a/tests/arp/detect-arp-01/test.yaml
+++ b/tests/arp/detect-arp-01/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.5
 
 pcap: ../../decode-arp-1/input.pcap
 

--- a/tests/arp/detect-arp-02-ethhdr/test.yaml
+++ b/tests/arp/detect-arp-02-ethhdr/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.5
 
 pcap: ../../decode-arp-1/input.pcap
 

--- a/tests/arp/detect-arp-03-vlan/test.yaml
+++ b/tests/arp/detect-arp-03-vlan/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.5
 
 checks:
   - filter:

--- a/tests/arp/detect-arp-04-vxlan/test.yaml
+++ b/tests/arp/detect-arp-04-vxlan/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.5
 
 checks:
   - filter:


### PR DESCRIPTION
Issue: 8314

Extend the arp detection tests to support 8.0.5. Update the versions for the tests added for 8313.


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/8314
