### PR TITLE
tests: firewall stats - v5

### DIFF
--- a/tests/exception-policy-applayer-01/test.yaml
+++ b/tests/exception-policy-applayer-01/test.yaml
@@ -24,10 +24,12 @@ checks:
         event_type: drop
         drop.reason: "applayer error"
   - filter:
+      requires:
+        min-version: 9
       count: 28
       match:
         event_type: drop
-        drop.reason: "flow drop"
+        drop.reason: "exception policy flow drop"
   - filter:
       count: 0
       match:
@@ -49,10 +51,13 @@ checks:
         flow.action: drop
   - filter:
     #min-version: 7 temporary removal
+      requires:
+        min-version: 9
       count: 1
       match:
         event_type: stats
         stats.ips.drop_reason.applayer_error: 1
+        stats.ips.drop_reason.exception_policy_flow_drop: 28
   - filter:
     #min-version: 7.0.12 temporary removal
       count: 1

--- a/tests/exception-policy-stream-reassembly-memcap-01/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-01/test.yaml
@@ -24,10 +24,12 @@ checks:
         event_type: drop
         drop.reason: "stream reassembly"
   - filter:
+      requires:
+        min-version: 9
       count: 28
       match:
         event_type: drop
-        drop.reason: "flow drop"
+        drop.reason: "exception policy flow drop"
   - filter:
       count: 0
       match:
@@ -49,10 +51,13 @@ checks:
         flow.action: drop
   - filter:
     #min-version: 7.0.12 temporary removal
+      requires:
+        min-version: 9
       count: 1
       match:
         event_type: stats
         stats.ips.drop_reason.stream_reassembly: 1
+        stats.ips.drop_reason.exception_policy_flow_drop: 28
         stats.exception_policy.tcp.reassembly.drop_flow: 1
   - filter:
     #min-version: 7.0.12 temporary removal

--- a/tests/exception-policy-stream-reassembly-memcap-04/test.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-04/test.yaml
@@ -1,5 +1,6 @@
 requires:
   min-version: 7.0.16
+  lt-version: 9
   features:
     - QA_SIMULATION
 pcap: ../tls/tls-certs-alert/input.pcap

--- a/tests/exception-policy-stream-ssn-memcap-01/test.yaml
+++ b/tests/exception-policy-stream-ssn-memcap-01/test.yaml
@@ -23,10 +23,12 @@ checks:
         event_type: drop
         drop.reason: "stream memcap"
   - filter:
+      requires:
+        min-version: 9
       count: 31
       match:
         event_type: drop
-        drop.reason: "flow drop"
+        drop.reason: "exception policy flow drop"
   - filter:
       count: 0
       match:
@@ -48,10 +50,13 @@ checks:
         flow.action: drop
   - filter:
     #min-version: 7 temporary removal
+      requires:
+        min-version: 9
       count: 1
       match:
         event_type: stats
         stats.ips.drop_reason.stream_memcap: 1
+        stats.ips.drop_reason.exception_policy_flow_drop: 31
   - filter:
     #min-version: 7.0.12 temporary removal
       count: 1

--- a/tests/firewall/firewall-01-tcp-pkt-state-flowbits/suricata.yaml
+++ b/tests/firewall/firewall-01-tcp-pkt-state-flowbits/suricata.yaml
@@ -22,6 +22,7 @@ outputs:
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
       types:
+        - stats
         - alert:
             # payload: yes             # enable dumping payload in Base64
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log

--- a/tests/firewall/firewall-01-tcp-pkt-state-flowbits/test.yaml
+++ b/tests/firewall/firewall-01-tcp-pkt-state-flowbits/test.yaml
@@ -21,3 +21,10 @@ checks:
     match:
       event_type: tls
       tls.subject: C=FR, ST=IDF, L=Paris, O=Stamus, CN=SELKS
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      not-has-key: stats.firewall

--- a/tests/firewall/firewall-04-tls-sni-enforce/test.yaml
+++ b/tests/firewall/firewall-04-tls-sni-enforce/test.yaml
@@ -19,11 +19,21 @@ checks:
       pcap_cnt: 28
       drop.reason: "stream midstream"
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: drop
       pcap_cnt: 29
       drop.reason: "flow drop"
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: drop
+      pcap_cnt: 29
+      drop.reason: "exception policy flow drop"
 - filter:
     count: 2
     match:

--- a/tests/firewall/firewall-06-tls-sni-enforce/test.yaml
+++ b/tests/firewall/firewall-06-tls-sni-enforce/test.yaml
@@ -32,11 +32,21 @@ checks:
       pcap_cnt: 28
       drop.reason: "stream midstream"
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: drop
       pcap_cnt: 29
       drop.reason: "flow drop"
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: drop
+      pcap_cnt: 29
+      drop.reason: "exception policy flow drop"
 - filter:
     count: 26
     match:

--- a/tests/firewall/ruletype-firewall-03-ruleset-vs-ping/test.yaml
+++ b/tests/firewall/ruletype-firewall-03-ruleset-vs-ping/test.yaml
@@ -28,8 +28,21 @@ checks:
       flow.alerted: true
       flow.action: "accept"
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
       stats.ips.accepted: 150
       stats.ips.blocked: 0
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.decoder.pkts: 150
+      stats.ips.accepted: 150
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 150
+      stats.firewall.blocked: 0

--- a/tests/firewall/ruletype-firewall-08-ruleset-default-packet-policy/test.yaml
+++ b/tests/firewall/ruletype-firewall-08-ruleset-default-packet-policy/test.yaml
@@ -37,9 +37,26 @@ checks:
       flow.alerted: true
       not-has-key: flow.action
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
       stats.ips.accepted: 3
       stats.ips.blocked: 59
       stats.ips.drop_reason.default_packet_policy: 59
+      stats.ips.drop_reason.rules: 0
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.decoder.pkts: 62
+      stats.ips.accepted: 3
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 3
+      stats.firewall.blocked: 59
+      stats.firewall.drop_reason.rules: 0
+      stats.firewall.drop_reason.default_packet_policy: 59
+      stats.firewall.discarded_alerts: 0

--- a/tests/firewall/ruletype-firewall-09-ruleset-default-app-policy/test.yaml
+++ b/tests/firewall/ruletype-firewall-09-ruleset-default-app-policy/test.yaml
@@ -64,6 +64,8 @@ checks:
       flow.alerted: true
       flow.action: drop
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -71,3 +73,17 @@ checks:
       stats.ips.blocked: 57
       stats.ips.drop_reason.default_app_policy: 1
       stats.ips.drop_reason.flow_drop: 56
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.decoder.pkts: 62
+      stats.ips.accepted: 5
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 5
+      stats.firewall.blocked: 57
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.flow_drop: 56
+      stats.firewall.drop_reason.rules: 0

--- a/tests/firewall/ruletype-firewall-10-ruleset-packet-drop-vs-app/test.yaml
+++ b/tests/firewall/ruletype-firewall-10-ruleset-packet-drop-vs-app/test.yaml
@@ -131,6 +131,8 @@ checks:
       flow.alerted: true
       flow.action: drop
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -139,3 +141,20 @@ checks:
       stats.ips.drop_reason.default_app_policy: 1
       stats.ips.drop_reason.rules: 0
       stats.ips.drop_reason.flow_drop: 56
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.decoder.pkts: 62
+      stats.ips.accepted: 5
+      stats.ips.blocked: 0
+      stats.ips.drop_reason.rules: 0
+      stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 5
+      stats.firewall.blocked: 57
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.rules: 0
+      stats.firewall.drop_reason.flow_drop: 56
+      stats.firewall.discarded_alerts: 1

--- a/tests/firewall/ruletype-firewall-11-ruleset-pass-vs-fw/test.yaml
+++ b/tests/firewall/ruletype-firewall-11-ruleset-pass-vs-fw/test.yaml
@@ -86,6 +86,8 @@ checks:
       flow.alerted: true
       flow.action: "accept"
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -93,3 +95,16 @@ checks:
       stats.ips.blocked: 0
       stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.rules: 0
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.decoder.pkts: 62
+      stats.ips.accepted: 62
+      stats.ips.blocked: 0
+      stats.ips.drop_reason.rules: 0
+      stats.firewall.accepted: 62
+      stats.firewall.blocked: 0
+      stats.firewall.drop_reason.default_app_policy: 0

--- a/tests/firewall/ruletype-firewall-14-ruleset-pass-vs-fw/test.yaml
+++ b/tests/firewall/ruletype-firewall-14-ruleset-pass-vs-fw/test.yaml
@@ -85,6 +85,8 @@ checks:
       flow.alerted: true
       flow.action: "accept"
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -92,3 +94,17 @@ checks:
       stats.ips.blocked: 0
       stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.rules: 0
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.decoder.pkts: 62
+      stats.ips.accepted: 62
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 62
+      stats.firewall.blocked: 0
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.rules: 0
+      stats.firewall.discarded_alerts: 0

--- a/tests/firewall/ruletype-firewall-16-http-per-hook/test.yaml
+++ b/tests/firewall/ruletype-firewall-16-http-per-hook/test.yaml
@@ -91,10 +91,27 @@ checks:
       flow.alerted: true
       flow.action: drop
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
       stats.ips.accepted: 3
       stats.ips.blocked: 7
       stats.ips.drop_reason.default_app_policy: 1
+      stats.ips.drop_reason.rules: 0
       stats.ips.drop_reason.flow_drop: 6
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.decoder.pkts: 10
+      stats.ips.accepted: 3
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 3
+      stats.firewall.blocked: 7
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.flow_drop: 6
+      stats.firewall.discarded_alerts: 0

--- a/tests/firewall/ruletype-firewall-18-http-per-hook/test.yaml
+++ b/tests/firewall/ruletype-firewall-18-http-per-hook/test.yaml
@@ -91,6 +91,8 @@ checks:
       flow.alerted: true
       flow.action: drop
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -98,3 +100,15 @@ checks:
       stats.ips.blocked: 7
       stats.ips.drop_reason.default_app_policy: 1
       stats.ips.drop_reason.flow_drop: 6
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 3
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 3
+      stats.firewall.blocked: 7
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.flow_drop: 6

--- a/tests/firewall/ruletype-firewall-19-http-per-hook/test.yaml
+++ b/tests/firewall/ruletype-firewall-19-http-per-hook/test.yaml
@@ -91,6 +91,8 @@ checks:
       flow.alerted: true
       flow.action: drop
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -98,3 +100,15 @@ checks:
       stats.ips.blocked: 7
       stats.ips.drop_reason.default_app_policy: 1
       stats.ips.drop_reason.flow_drop: 6
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 3
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 3
+      stats.firewall.blocked: 7
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.flow_drop: 6

--- a/tests/firewall/ruletype-firewall-20-http-per-hook/test.yaml
+++ b/tests/firewall/ruletype-firewall-20-http-per-hook/test.yaml
@@ -91,10 +91,25 @@ checks:
       flow.alerted: true
       flow.action: drop
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
       stats.ips.accepted: 3
       stats.ips.blocked: 7
       stats.ips.drop_reason.default_app_policy: 1
+      stats.ips.drop_reason.rules: 0
       stats.ips.drop_reason.flow_drop: 6
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 3
+      stats.ips.blocked: 0
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.flow_drop: 6
+      stats.firewall.drop_reason.rules: 0
+      stats.firewall.discarded_alerts: 0

--- a/tests/firewall/ruletype-firewall-23-dns-per-hook/test.yaml
+++ b/tests/firewall/ruletype-firewall-23-dns-per-hook/test.yaml
@@ -54,10 +54,27 @@ checks:
       flow.alerted: true
       flow.action: drop
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
       stats.ips.accepted: 6
       stats.ips.blocked: 2
       stats.ips.drop_reason.default_app_policy: 1
+      stats.ips.drop_reason.rules: 0
       stats.ips.drop_reason.flow_drop: 1
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 6
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 6
+      stats.firewall.blocked: 2
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.flow_drop: 1
+      stats.firewall.drop_reason.rules: 0
+      stats.firewall.discarded_alerts: 0

--- a/tests/firewall/ruletype-firewall-24-dnstcp-per-hook/test.yaml
+++ b/tests/firewall/ruletype-firewall-24-dnstcp-per-hook/test.yaml
@@ -46,6 +46,8 @@ checks:
       flow.alerted: true
       not-has-key: flow.action
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -53,3 +55,19 @@ checks:
       stats.ips.blocked: 2
       stats.ips.drop_reason.default_packet_policy: 2
       stats.ips.drop_reason.default_app_policy: 0
+      stats.ips.drop_reason.rules: 0
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.decoder.pkts: 12
+      stats.ips.accepted: 10
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 10
+      stats.firewall.blocked: 2
+      stats.firewall.drop_reason.default_packet_policy: 2
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.rules: 0
+      stats.firewall.discarded_alerts: 0

--- a/tests/firewall/ruletype-firewall-25-tcp-udp/test.yaml
+++ b/tests/firewall/ruletype-firewall-25-tcp-udp/test.yaml
@@ -34,6 +34,8 @@ checks:
       flow.pkts_toclient: 1
       not-has-key: flow.action
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -41,3 +43,19 @@ checks:
       stats.ips.blocked: 10
       stats.ips.drop_reason.default_packet_policy: 10
       stats.ips.drop_reason.default_app_policy: 0
+      stats.ips.drop_reason.rules: 0
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 2
+      stats.ips.blocked: 0
+      stats.ips.drop_reason.rules: 0
+      stats.firewall.accepted: 2
+      stats.firewall.blocked: 10
+      stats.firewall.drop_reason.default_packet_policy: 10
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.rules: 0
+      stats.firewall.discarded_alerts: 0

--- a/tests/firewall/ruletype-firewall-27-http-drop-rule/test.yaml
+++ b/tests/firewall/ruletype-firewall-27-http-drop-rule/test.yaml
@@ -88,6 +88,8 @@ checks:
       flow.alerted: true
       flow.action: "drop"
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -95,3 +97,16 @@ checks:
       stats.ips.blocked: 7
       stats.ips.drop_reason.rules: 1
       stats.ips.drop_reason.flow_drop: 6
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 3
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 3
+      stats.firewall.blocked: 7
+      stats.firewall.drop_reason.rules: 1
+      stats.firewall.drop_reason.flow_drop: 6
+      stats.firewall.discarded_alerts: 5

--- a/tests/firewall/ruletype-firewall-28-http-drop-flow-rule/test.yaml
+++ b/tests/firewall/ruletype-firewall-28-http-drop-flow-rule/test.yaml
@@ -74,16 +74,35 @@ checks:
       event_type: alert
       alert.signature_id: 206
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: drop
       alert.signature_id: 999
       drop.reason: "rules"
 - filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: drop
+      alert.signature_id: 999
+      drop.reason: "firewall rules"
+- filter:
+    requires:
+      lt-version: 9
     count: 6
     match:
       event_type: drop
       drop.reason: "flow drop"
+- filter:
+    requires:
+      min-version: 9
+    count: 6
+    match:
+      event_type: drop
+      drop.reason: "firewall flow drop"
 - filter:
     count: 1
     match:
@@ -94,6 +113,8 @@ checks:
       flow.alerted: true
       flow.action: drop
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -101,3 +122,16 @@ checks:
       stats.ips.blocked: 7
       stats.ips.drop_reason.rules: 1
       stats.ips.drop_reason.flow_drop: 6
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 3
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 3
+      stats.firewall.blocked: 7
+      stats.firewall.drop_reason.rules: 1
+      stats.firewall.drop_reason.flow_drop: 6
+      stats.firewall.discarded_alerts: 5

--- a/tests/firewall/ruletype-firewall-29-http-drop-flow-rule/test.yaml
+++ b/tests/firewall/ruletype-firewall-29-http-drop-flow-rule/test.yaml
@@ -14,16 +14,35 @@ checks:
       event_type: alert
       alert.signature_id: 100
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: drop
       alert.signature_id: 100
       drop.reason: "rules"
 - filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: drop
+      alert.signature_id: 100
+      drop.reason: "firewall rules"
+- filter:
+    requires:
+      lt-version: 9
     count: 9
     match:
       event_type: drop
       drop.reason: "flow drop"
+- filter:
+    requires:
+      min-version: 9
+    count: 9
+    match:
+      event_type: drop
+      drop.reason: "firewall flow drop"
 - filter:
     count: 1
     match:
@@ -34,6 +53,8 @@ checks:
       flow.alerted: true
       flow.action: drop
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -41,3 +62,15 @@ checks:
       stats.ips.blocked: 10
       stats.ips.drop_reason.rules: 1
       stats.ips.drop_reason.flow_drop: 9
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 0
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 0
+      stats.firewall.blocked: 10
+      stats.firewall.drop_reason.rules: 1
+      stats.firewall.drop_reason.flow_drop: 9

--- a/tests/firewall/ruletype-firewall-30-fw-accept-td-drop/test.yaml
+++ b/tests/firewall/ruletype-firewall-30-fw-accept-td-drop/test.yaml
@@ -63,6 +63,8 @@ checks:
       flow.alerted: true
       flow.action: "accept"
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -70,3 +72,18 @@ checks:
       stats.ips.blocked: 1
       stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.rules: 1
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 61
+      stats.ips.blocked: 1
+      stats.ips.drop_reason.rules: 1
+      stats.firewall.accepted: 62
+      stats.firewall.blocked: 0
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.rules: 0
+        # discarded alert because of the drop from td rule sid 666
+      stats.firewall.discarded_alerts: 1

--- a/tests/firewall/ruletype-firewall-31-retrans-of-drop/test.yaml
+++ b/tests/firewall/ruletype-firewall-31-retrans-of-drop/test.yaml
@@ -94,6 +94,8 @@ checks:
       flow.alerted: true
       flow.action: drop
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -101,3 +103,15 @@ checks:
       stats.ips.blocked: 6
       stats.ips.drop_reason.default_app_policy: 1
       stats.ips.drop_reason.flow_drop: 5
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 3
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 3
+      stats.firewall.blocked: 6
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.flow_drop: 5

--- a/tests/firewall/ruletype-firewall-32-proto-detect-ssh/test.yaml
+++ b/tests/firewall/ruletype-firewall-32-proto-detect-ssh/test.yaml
@@ -48,6 +48,8 @@ checks:
       flow.alerted: true
       not-has-key: flow.action
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -55,3 +57,15 @@ checks:
       stats.ips.blocked: 0
       stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.rules: 0
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 322
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 322
+      stats.firewall.blocked: 0
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.rules: 0

--- a/tests/firewall/ruletype-firewall-33-ssh/test.yaml
+++ b/tests/firewall/ruletype-firewall-33-ssh/test.yaml
@@ -42,6 +42,8 @@ checks:
       flow.alerted: true
       not-has-key: flow.action
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -49,3 +51,15 @@ checks:
       stats.ips.blocked: 0
       stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.rules: 0
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 322
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 322
+      stats.firewall.blocked: 0
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.rules: 0

--- a/tests/firewall/ruletype-firewall-34-ssh-sw/test.yaml
+++ b/tests/firewall/ruletype-firewall-34-ssh-sw/test.yaml
@@ -47,6 +47,8 @@ checks:
       flow.alerted: true
       not-has-key: flow.action
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats

--- a/tests/firewall/ruletype-firewall-35-ssh-sw/test.yaml
+++ b/tests/firewall/ruletype-firewall-35-ssh-sw/test.yaml
@@ -67,6 +67,8 @@ checks:
       flow.alerted: true
       not-has-key: flow.action
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats

--- a/tests/firewall/ruletype-firewall-36-minimal/test.yaml
+++ b/tests/firewall/ruletype-firewall-36-minimal/test.yaml
@@ -32,6 +32,8 @@ checks:
       flow.alerted: true
       flow.action: "accept"
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats

--- a/tests/firewall/ruletype-firewall-37-minimal-bad/test.yaml
+++ b/tests/firewall/ruletype-firewall-37-minimal-bad/test.yaml
@@ -32,6 +32,8 @@ checks:
       flow.alerted: true
       not-has-key: flow.action
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -40,3 +42,16 @@ checks:
       stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.default_packet_policy: 320
       stats.ips.drop_reason.rules: 0
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 2
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 2
+      stats.firewall.blocked: 320
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.default_packet_policy: 320
+      stats.firewall.drop_reason.rules: 0

--- a/tests/firewall/ruletype-firewall-38-ssh-vs-telnet/test.yaml
+++ b/tests/firewall/ruletype-firewall-38-ssh-vs-telnet/test.yaml
@@ -32,6 +32,8 @@ checks:
       flow.alerted: true
       not-has-key: flow.action
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -40,3 +42,16 @@ checks:
       stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.default_packet_policy: 89
       stats.ips.drop_reason.rules: 0
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 3
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 3
+      stats.firewall.blocked: 89
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.default_packet_policy: 89
+      stats.firewall.drop_reason.rules: 0

--- a/tests/firewall/ruletype-firewall-39-pre-stream/test.yaml
+++ b/tests/firewall/ruletype-firewall-39-pre-stream/test.yaml
@@ -54,6 +54,7 @@ checks:
       stats.ips.accepted: 0
       stats.ips.blocked: 12
       stats.ips.drop_reason.stream_midstream: 1
+      stats.ips.drop_reason.exception_policy_flow_drop: 11
       stats.firewall.accepted: 12
       stats.firewall.blocked: 1
       stats.firewall.drop_reason.default_packet_policy: 0

--- a/tests/firewall/ruletype-firewall-39-pre-stream/test.yaml
+++ b/tests/firewall/ruletype-firewall-39-pre-stream/test.yaml
@@ -34,12 +34,28 @@ checks:
       tcp.tcp_flags: "00"
       flow.alerted: true
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
       stats.ips.accepted: 0
       stats.ips.blocked: 13
-      stats.ips.drop_reason.pre_stream_hook: 1
       stats.ips.drop_reason.default_packet_policy: 0
+      stats.ips.drop_reason.pre_stream_hook: 1
       stats.ips.drop_reason.flow_drop: 11
       stats.ips.drop_reason.stream_midstream: 1
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 0
+      stats.ips.blocked: 12
+      stats.ips.drop_reason.stream_midstream: 1
+      stats.firewall.accepted: 12
+      stats.firewall.blocked: 1
+      stats.firewall.drop_reason.default_packet_policy: 0
+      stats.firewall.drop_reason.pre_stream_hook: 1
+      stats.firewall.drop_reason.rules: 0

--- a/tests/firewall/ruletype-firewall-40-pre-stream-wscale/test.yaml
+++ b/tests/firewall/ruletype-firewall-40-pre-stream-wscale/test.yaml
@@ -34,6 +34,8 @@ checks:
       tcp.tcp_flags: "00"
       flow.alerted: true
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -43,3 +45,17 @@ checks:
       stats.ips.drop_reason.default_packet_policy: 0
       stats.ips.drop_reason.flow_drop: 11
       stats.ips.drop_reason.stream_midstream: 1
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 0
+      stats.ips.blocked: 12
+      stats.firewall.accepted: 12
+      stats.firewall.blocked: 1
+      stats.ips.drop_reason.stream_midstream: 1
+      stats.firewall.drop_reason.pre_stream_hook: 1
+      stats.firewall.drop_reason.default_packet_policy: 0
+      # TODO add check for drop reason exception policy flow drop?

--- a/tests/firewall/ruletype-firewall-41-pre-flow/test.yaml
+++ b/tests/firewall/ruletype-firewall-41-pre-flow/test.yaml
@@ -33,10 +33,24 @@ checks:
     match:
       event_type: flow
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
       stats.ips.accepted: 0
       stats.ips.blocked: 13
-      stats.ips.drop_reason.pre_flow_hook: 13
       stats.ips.drop_reason.default_packet_policy: 0
+      stats.ips.drop_reason.pre_flow_hook: 13
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 0
+      stats.ips.blocked: 0
+      stats.firewall.drop_reason.default_packet_policy: 0
+      stats.firewall.drop_reason.pre_flow_hook: 13
+      stats.firewall.drop_reason.rules: 0
+      stats.firewall.discarded_alerts: 0

--- a/tests/firewall/ruletype-firewall-42-pre-flow-notrack/test.yaml
+++ b/tests/firewall/ruletype-firewall-42-pre-flow-notrack/test.yaml
@@ -29,6 +29,8 @@ checks:
     match:
       event_type: flow
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -36,3 +38,14 @@ checks:
       stats.ips.blocked: 0
       stats.ips.drop_reason.pre_flow_hook: 0
       stats.ips.drop_reason.default_packet_policy: 0
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 13
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 13
+      stats.firewall.blocked: 0
+      stats.firewall.drop_reason.default_packet_policy: 0

--- a/tests/firewall/ruletype-firewall-43-tls-cert-chain/test.yaml
+++ b/tests/firewall/ruletype-firewall-43-tls-cert-chain/test.yaml
@@ -17,7 +17,7 @@ checks:
     count: 42
     match:
       event_type: drop
-      drop.reason: "flow drop"
+      drop.reason: "firewall flow drop"
 - filter:
     count: 1
     match:
@@ -30,8 +30,13 @@ checks:
       event_type: stats
       stats.app_layer.flow.tls: 1
       stats.flow.total: 1
-      stats.ips.accepted: 19
-      stats.ips.blocked: 43
-      stats.ips.drop_reason.flow_drop: 42
-      stats.ips.drop_reason.rules: 1
       stats.decoder.pkts: 62
+      stats.ips.accepted: 19
+      stats.ips.blocked: 0
+      stats.ips.drop_reason.flow_drop: 0
+      stats.ips.drop_reason.rules: 0
+      stats.firewall.accepted: 19
+      stats.firewall.blocked: 43
+      stats.firewall.drop_reason.flow_drop: 42
+      stats.firewall.drop_reason.rules: 1
+      stats.firewall.discarded_alerts: 3

--- a/tests/firewall/ruletype-firewall-45-iprep-8285/test.yaml
+++ b/tests/firewall/ruletype-firewall-45-iprep-8285/test.yaml
@@ -26,6 +26,8 @@ checks:
       event_type: flow
       dest_ip: 82.165.177.154
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -36,3 +38,15 @@ checks:
       stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.rules: 1
       stats.ips.drop_reason.flow_drop: 6
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 3
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 3
+      stats.firewall.blocked: 7
+      stats.firewall.drop_reason.rules: 1
+      stats.firewall.drop_reason.flow_drop: 6

--- a/tests/firewall/ruletype-firewall-46-iprep-8285/test.yaml
+++ b/tests/firewall/ruletype-firewall-46-iprep-8285/test.yaml
@@ -32,6 +32,8 @@ checks:
       event_type: flow
       dest_ip: 82.165.177.154
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -41,3 +43,17 @@ checks:
       stats.ips.drop_reason.default_packet_policy: 0
       stats.ips.drop_reason.default_app_policy: 1
       stats.ips.drop_reason.flow_drop: 6
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 3
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 3
+      stats.firewall.blocked: 7
+      stats.firewall.drop_reason.default_packet_policy: 0
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.flow_drop: 6
+      stats.firewall.drop_reason.pre_flow_hook: 0

--- a/tests/firewall/ruletype-firewall-49-reject-app/test.yaml
+++ b/tests/firewall/ruletype-firewall-49-reject-app/test.yaml
@@ -90,6 +90,8 @@ checks:
       flow.alerted: true
       flow.action: drop
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats
@@ -99,3 +101,18 @@ checks:
       stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.rules: 1
       stats.ips.drop_reason.flow_drop: 56
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 5
+      stats.ips.rejected: 0
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 5
+      stats.firewall.rejected: 1
+      stats.firewall.blocked: 56
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.rules: 1
+      stats.firewall.drop_reason.flow_drop: 56

--- a/tests/firewall/ruletype-firewall-54-snmp-v1-trap/test.yaml
+++ b/tests/firewall/ruletype-firewall-54-snmp-v1-trap/test.yaml
@@ -49,6 +49,8 @@ checks:
       flow.state: "new"
       flow.alerted: true
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats

--- a/tests/firewall/ruletype-firewall-55-snmp-v1-trap-default/test.yaml
+++ b/tests/firewall/ruletype-firewall-55-snmp-v1-trap-default/test.yaml
@@ -46,6 +46,8 @@ checks:
       flow.state: "new"
       flow.alerted: true
 - filter:
+    requires:
+      lt-version: 9
     count: 1
     match:
       event_type: stats

--- a/tests/firewall/ruletype-firewall-56-ntp/test.yaml
+++ b/tests/firewall/ruletype-firewall-56-ntp/test.yaml
@@ -49,6 +49,22 @@ checks:
         event_type: drop
         pcap_cnt: 4
 
-  - stats:
-      ips.accepted: 3
-      ips.blocked: 1
+  - filter:
+      requires:
+        lt-version: 9
+      count: 1
+      match:
+        event_type: stats
+        stats.ips.accepted: 3
+        stats.ips.blocked: 1
+        stats.ips.drop_reason.default_app_policy: 1
+  - filter:
+      requires:
+        min-version: 9
+      count: 1
+      match:
+        stats.ips.accepted: 3
+        stats.ips.blocked: 0
+        stats.firewall.accepted: 3
+        stats.firewall.blocked: 1
+        stats.firewall.drop_reason.default_app_policy: 1

--- a/tests/firewall/ruletype-firewall-57-dns-datarep/test.yaml
+++ b/tests/firewall/ruletype-firewall-57-dns-datarep/test.yaml
@@ -23,6 +23,9 @@ checks:
     match:
       event_type: stats
       stats.ips.accepted: 6
-      stats.ips.blocked: 2
-      stats.ips.drop_reason.default_app_policy: 1
-      stats.ips.drop_reason.flow_drop: 1
+      stats.ips.blocked: 0
+      stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 6
+      stats.firewall.blocked: 2
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.flow_drop: 1

--- a/tests/firewall/ruletype-firewall-58-missing-hook-vs-td/test.yaml
+++ b/tests/firewall/ruletype-firewall-58-missing-hook-vs-td/test.yaml
@@ -23,7 +23,10 @@ checks:
     match:
       event_type: stats
       stats.ips.accepted: 0
-      stats.ips.blocked: 8
-      stats.ips.drop_reason.default_app_policy: 4
-      stats.ips.drop_reason.default_packet_policy: 0
-      stats.ips.drop_reason.flow_drop: 4
+      stats.ips.blocked: 0
+      stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 0
+      stats.firewall.blocked: 8
+      stats.firewall.drop_reason.default_app_policy: 4
+      stats.firewall.drop_reason.default_packet_policy: 0
+      stats.firewall.drop_reason.flow_drop: 4

--- a/tests/firewall/ruletype-firewall-59-tls-default-policy/test.yaml
+++ b/tests/firewall/ruletype-firewall-59-tls-default-policy/test.yaml
@@ -24,6 +24,10 @@ checks:
       event_type: stats
       stats.ips.accepted: 62
       stats.ips.blocked: 0
-      stats.ips.drop_reason.default_app_policy: 0
-      stats.ips.drop_reason.default_packet_policy: 0
       stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 62
+      stats.firewall.blocked: 0
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.default_packet_policy: 0
+      stats.firewall.drop_reason.flow_drop: 0
+      stats.firewall.discarded_alerts: 0

--- a/tests/firewall/ruletype-firewall-60-no-app-rules/test.yaml
+++ b/tests/firewall/ruletype-firewall-60-no-app-rules/test.yaml
@@ -23,7 +23,10 @@ checks:
     match:
       event_type: stats
       stats.ips.accepted: 3
-      stats.ips.blocked: 59
-      stats.ips.drop_reason.default_app_policy: 1
-      stats.ips.drop_reason.default_packet_policy: 0
-      stats.ips.drop_reason.flow_drop: 58
+      stats.ips.blocked: 0
+      stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 3
+      stats.firewall.blocked: 59
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.default_packet_policy: 0
+      stats.firewall.drop_reason.flow_drop: 58

--- a/tests/firewall/ruletype-firewall-61-snmp-v1-trap-scope-packet/test.yaml
+++ b/tests/firewall/ruletype-firewall-61-snmp-v1-trap-scope-packet/test.yaml
@@ -55,4 +55,10 @@ checks:
     match:
       event_type: stats
       stats.app_layer.error.snmp.parser: 1
-      stats.ips.drop_reason.rules: 1
+      stats.ips.drop_reason.rules: 0
+      stats.ips.drop_reason.applayer_error: 1
+      stats.ips.accepted: 6
+      stats.ips.blocked: 5
+      stats.firewall.accepted: 11
+      stats.firewall.blocked: 1
+      stats.firewall.drop_reason.rules: 1

--- a/tests/firewall/ruletype-firewall-63-dns-opcode/test.yaml
+++ b/tests/firewall/ruletype-firewall-63-dns-opcode/test.yaml
@@ -30,4 +30,6 @@ checks:
       event_type: stats
       stats.ips.accepted: 8
       stats.ips.blocked: 0
-      stats.ips.drop_reason.default_packet_policy: 0
+      stats.firewall.accepted: 8
+      stats.firewall.blocked: 0
+      stats.firewall.drop_reason.default_packet_policy: 0

--- a/tests/firewall/ruletype-firewall-68-config-default-policy-tls/test.yaml
+++ b/tests/firewall/ruletype-firewall-68-config-default-policy-tls/test.yaml
@@ -17,7 +17,7 @@ checks:
     count: 42
     match:
       event_type: drop
-      drop.reason: "flow drop"
+      drop.reason: "firewall flow drop"
 - filter:
     count: 1
     match:
@@ -30,8 +30,10 @@ checks:
       event_type: stats
       stats.app_layer.flow.tls: 1
       stats.flow.total: 1
-      stats.ips.accepted: 19
-      stats.ips.blocked: 43
-      stats.ips.drop_reason.flow_drop: 42
-      stats.ips.drop_reason.rules: 1
       stats.decoder.pkts: 62
+      stats.ips.accepted: 19
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 19
+      stats.firewall.blocked: 43
+      stats.firewall.drop_reason.flow_drop: 42
+      stats.firewall.drop_reason.rules: 1

--- a/tests/firewall/ruletype-firewall-69-config-default-policy-tls-accept/test.yaml
+++ b/tests/firewall/ruletype-firewall-69-config-default-policy-tls-accept/test.yaml
@@ -17,7 +17,7 @@ checks:
     count: 42
     match:
       event_type: drop
-      drop.reason: "flow drop"
+      drop.reason: "firewall flow drop"
 - filter:
     count: 1
     match:
@@ -30,8 +30,13 @@ checks:
       event_type: stats
       stats.app_layer.flow.tls: 1
       stats.flow.total: 1
-      stats.ips.accepted: 19
-      stats.ips.blocked: 43
-      stats.ips.drop_reason.flow_drop: 42
-      stats.ips.drop_reason.rules: 1
       stats.decoder.pkts: 62
+      stats.ips.accepted: 19
+      stats.ips.blocked: 0
+      stats.ips.drop_reason.flow_drop: 0
+      stats.ips.drop_reason.rules: 0
+      stats.firewall.accepted: 19
+      stats.firewall.blocked: 43
+      stats.firewall.drop_reason.flow_drop: 42
+      stats.firewall.drop_reason.rules: 1
+      stats.firewall.discarded_alerts: 3

--- a/tests/firewall/ruletype-firewall-70-config-default-policy-http/test.yaml
+++ b/tests/firewall/ruletype-firewall-70-config-default-policy-http/test.yaml
@@ -76,5 +76,8 @@ checks:
       event_type: stats
       stats.ips.accepted: 10
       stats.ips.blocked: 0
-      stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 10
+      stats.firewall.blocked: 0
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.flow_drop: 0

--- a/tests/firewall/ruletype-firewall-71-reject-app-default-policy/test.yaml
+++ b/tests/firewall/ruletype-firewall-71-reject-app-default-policy/test.yaml
@@ -79,8 +79,13 @@ checks:
     match:
       event_type: stats
       stats.ips.accepted: 5
-      stats.ips.rejected: 1
-      stats.ips.blocked: 56
-      stats.ips.drop_reason.default_app_policy: 1
+      stats.ips.rejected: 0
+      stats.ips.blocked: 0
       stats.ips.drop_reason.rules: 0
-      stats.ips.drop_reason.flow_drop: 56
+      stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 5
+      stats.firewall.rejected: 1
+      stats.firewall.blocked: 56
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.rules: 0
+      stats.firewall.drop_reason.flow_drop: 56

--- a/tests/firewall/ruletype-firewall-72-config-default-policy-http/test.yaml
+++ b/tests/firewall/ruletype-firewall-72-config-default-policy-http/test.yaml
@@ -91,5 +91,8 @@ checks:
       event_type: stats
       stats.ips.accepted: 10
       stats.ips.blocked: 0
-      stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 10
+      stats.firewall.blocked: 0
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.flow_drop: 0

--- a/tests/firewall/ruletype-firewall-73-config-default-policy-http/test.yaml
+++ b/tests/firewall/ruletype-firewall-73-config-default-policy-http/test.yaml
@@ -91,5 +91,8 @@ checks:
       event_type: stats
       stats.ips.accepted: 10
       stats.ips.blocked: 0
-      stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 10
+      stats.firewall.blocked: 0
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.flow_drop: 0

--- a/tests/firewall/ruletype-firewall-74-config-default-policy-dns/test.yaml
+++ b/tests/firewall/ruletype-firewall-74-config-default-policy-dns/test.yaml
@@ -58,6 +58,9 @@ checks:
     match:
       event_type: stats
       stats.ips.accepted: 6
-      stats.ips.blocked: 2
-      stats.ips.drop_reason.default_app_policy: 1
-      stats.ips.drop_reason.flow_drop: 1
+      stats.ips.blocked: 0
+      stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 6
+      stats.firewall.blocked: 2
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.flow_drop: 1

--- a/tests/firewall/ruletype-firewall-75-config-default-policy-http-accept-tx/test.yaml
+++ b/tests/firewall/ruletype-firewall-75-config-default-policy-http-accept-tx/test.yaml
@@ -92,5 +92,8 @@ checks:
       event_type: stats
       stats.ips.accepted: 10
       stats.ips.blocked: 0
-      stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 10
+      stats.firewall.blocked: 0
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.flow_drop: 0

--- a/tests/firewall/ruletype-firewall-76-config-default-policy-http-accept-tx-td/test.yaml
+++ b/tests/firewall/ruletype-firewall-76-config-default-policy-http-accept-tx-td/test.yaml
@@ -92,8 +92,11 @@ checks:
       event_type: stats
       stats.ips.accepted: 10
       stats.ips.blocked: 0
-      stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 10
+      stats.firewall.blocked: 0
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.flow_drop: 0
 - filter:
     count: 1
     match:

--- a/tests/firewall/ruletype-firewall-77-ruleset-default-packet-policy/test.yaml
+++ b/tests/firewall/ruletype-firewall-77-ruleset-default-packet-policy/test.yaml
@@ -43,5 +43,7 @@ checks:
     match:
       event_type: stats
       stats.ips.accepted: 3
-      stats.ips.rejected: 59
-      stats.ips.drop_reason.default_packet_policy: 59
+      stats.ips.rejected: 0
+      stats.firewall.accepted: 3
+      stats.firewall.rejected: 59
+      stats.firewall.drop_reason.default_packet_policy: 59

--- a/tests/firewall/ruletype-firewall-78-ruleset-default-packet-policy-accept/test.yaml
+++ b/tests/firewall/ruletype-firewall-78-ruleset-default-packet-policy-accept/test.yaml
@@ -28,4 +28,7 @@ checks:
       stats.ips.accepted: 62
       stats.ips.blocked: 0
       stats.ips.rejected: 0
-      stats.ips.drop_reason.default_packet_policy: 0
+      stats.firewall.accepted: 62
+      stats.firewall.blocked: 0
+      stats.firewall.rejected: 0
+      stats.firewall.drop_reason.default_packet_policy: 0

--- a/tests/firewall/ruletype-firewall-79-ruleset-default-packet-policy-accept-hook/test.yaml
+++ b/tests/firewall/ruletype-firewall-79-ruleset-default-packet-policy-accept-hook/test.yaml
@@ -26,8 +26,12 @@ checks:
     match:
       event_type: stats
       stats.ips.accepted: 3
-      stats.ips.blocked: 59
+      stats.ips.blocked: 0
       stats.ips.rejected: 0
-      stats.ips.drop_reason.default_packet_policy: 0
-      stats.ips.drop_reason.default_app_policy: 1
-      stats.ips.drop_reason.flow_drop: 58
+      stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 3
+      stats.firewall.blocked: 59
+      stats.firewall.rejected: 0
+      stats.firewall.drop_reason.default_packet_policy: 0
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.flow_drop: 58

--- a/tests/firewall/ruletype-firewall-80-ruleset-default-packet-policy-accept-hook-no-rules/test.yaml
+++ b/tests/firewall/ruletype-firewall-80-ruleset-default-packet-policy-accept-hook-no-rules/test.yaml
@@ -26,8 +26,12 @@ checks:
     match:
       event_type: stats
       stats.ips.accepted: 3
-      stats.ips.blocked: 59
+      stats.ips.blocked: 0
       stats.ips.rejected: 0
-      stats.ips.drop_reason.default_packet_policy: 0
-      stats.ips.drop_reason.default_app_policy: 1
-      stats.ips.drop_reason.flow_drop: 58
+      stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 3
+      stats.firewall.blocked: 59
+      stats.firewall.rejected: 0
+      stats.firewall.drop_reason.default_packet_policy: 0
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.flow_drop: 58

--- a/tests/firewall/ruletype-firewall-81-ruleset-default-packet-policy-accept-hook-all/test.yaml
+++ b/tests/firewall/ruletype-firewall-81-ruleset-default-packet-policy-accept-hook-all/test.yaml
@@ -28,6 +28,10 @@ checks:
       stats.ips.accepted: 62
       stats.ips.blocked: 0
       stats.ips.rejected: 0
-      stats.ips.drop_reason.default_packet_policy: 0
-      stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 62
+      stats.firewall.blocked: 0
+      stats.firewall.rejected: 0
+      stats.firewall.drop_reason.default_packet_policy: 0
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.flow_drop: 0

--- a/tests/firewall/ruletype-firewall-82-ruleset-default-app-policy-accept-flow/test.yaml
+++ b/tests/firewall/ruletype-firewall-82-ruleset-default-app-policy-accept-flow/test.yaml
@@ -28,6 +28,10 @@ checks:
       stats.ips.accepted: 62
       stats.ips.blocked: 0
       stats.ips.rejected: 0
-      stats.ips.drop_reason.default_packet_policy: 0
-      stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 62
+      stats.firewall.blocked: 0
+      stats.firewall.rejected: 0
+      stats.firewall.drop_reason.default_packet_policy: 0
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.flow_drop: 0

--- a/tests/firewall/ruletype-firewall-83-ruleset-default-packet-policy-accept-flow/test.yaml
+++ b/tests/firewall/ruletype-firewall-83-ruleset-default-packet-policy-accept-flow/test.yaml
@@ -28,6 +28,10 @@ checks:
       stats.ips.accepted: 62
       stats.ips.blocked: 0
       stats.ips.rejected: 0
-      stats.ips.drop_reason.default_packet_policy: 0
-      stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 62
+      stats.firewall.blocked: 0
+      stats.firewall.rejected: 0
+      stats.firewall.drop_reason.default_packet_policy: 0
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.flow_drop: 0

--- a/tests/firewall/ruletype-firewall-84-ruleset-default-app-policy-tls-request-started/test.yaml
+++ b/tests/firewall/ruletype-firewall-84-ruleset-default-app-policy-tls-request-started/test.yaml
@@ -28,6 +28,10 @@ checks:
       stats.ips.accepted: 62
       stats.ips.blocked: 0
       stats.ips.rejected: 0
-      stats.ips.drop_reason.default_packet_policy: 0
-      stats.ips.drop_reason.default_app_policy: 0
       stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 62
+      stats.firewall.blocked: 0
+      stats.firewall.rejected: 0
+      stats.firewall.drop_reason.default_packet_policy: 0
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.flow_drop: 0

--- a/tests/firewall/ruletype-firewall-85-packet-filter-accept-flow-with-td/test.yaml
+++ b/tests/firewall/ruletype-firewall-85-packet-filter-accept-flow-with-td/test.yaml
@@ -20,3 +20,5 @@ checks:
       event_type: stats
       stats.ips.accepted: 10
       stats.ips.blocked: 0
+      stats.firewall.accepted: 10
+      stats.firewall.blocked: 0

--- a/tests/firewall/ruletype-firewall-89-defaults-over-drop/test.yaml
+++ b/tests/firewall/ruletype-firewall-89-defaults-over-drop/test.yaml
@@ -22,4 +22,5 @@ checks:
         event_type: drop
         pcap_cnt: 4
   - stats:
-      ips.blocked: 7
+      ips.blocked: 0
+      firewall.blocked: 7


### PR DESCRIPTION
Previous PR: #3109 

Changes from previous PR:
- rebased
- removed commit that changed non-firewall-mode tests to an IPS folder, as this seemed to be the root of some of the ci failures seen in https://github.com/OISF/suricata/pull/15438 (moved them to https://github.com/OISF/suricata-verify/pull/3116 )

## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/7699
