### PR TITLE
test: ban replace & bypass keywords from firewall - v1

### DIFF
--- a/tests/firewall/ruletype-firewall-90-ban-replace-keyword/README.md
+++ b/tests/firewall/ruletype-firewall-90-ban-replace-keyword/README.md
@@ -1,0 +1,8 @@
+# Test
+
+Ensure that the engine throws an error message if the `replace` keyword is used
+in firewall rules, as it's banned from them.
+
+## Ticket
+
+https://redmine.openinfosecfoundation.org/issues/8551

--- a/tests/firewall/ruletype-firewall-90-ban-replace-keyword/firewall.rules
+++ b/tests/firewall/ruletype-firewall-90-ban-replace-keyword/firewall.rules
@@ -1,0 +1,2 @@
+# should error out, as 'replace' is not allowed in firewall mode
+accept:hook http1:request_started any any -> any any (msg:"Test replace keyword with firewall rules or mode"; content:"foo"; replace:"bar"; sid:2000001;)

--- a/tests/firewall/ruletype-firewall-90-ban-replace-keyword/test.yaml
+++ b/tests/firewall/ruletype-firewall-90-ban-replace-keyword/test.yaml
@@ -1,0 +1,15 @@
+requires:
+  min-version: 9
+
+pcap: ../../tls/tls-random/input.pcap
+
+args:
+  - --simulate-ips
+  - -v
+exit-code: 1
+
+checks:
+  - shell:
+      args: grep "keyword 'replace' is not allowed in firewall mode" stderr | wc -l
+      expect: 1
+

--- a/tests/firewall/ruletype-firewall-91-ban-replace-from-fw-mode/README.md
+++ b/tests/firewall/ruletype-firewall-91-ban-replace-from-fw-mode/README.md
@@ -1,0 +1,8 @@
+# Test
+
+Ensure that the engine throws an error message if the `replace` keyword is used
+in threat detection rules, as it's banned in firewall mode.
+
+## Ticket
+
+https://redmine.openinfosecfoundation.org/issues/8551

--- a/tests/firewall/ruletype-firewall-91-ban-replace-from-fw-mode/firewall.rules
+++ b/tests/firewall/ruletype-firewall-91-ban-replace-from-fw-mode/firewall.rules
@@ -1,0 +1,1 @@
+accept:hook tcp:all any any -> any any (msg:"Simple firewall rule."; sid: 1;)

--- a/tests/firewall/ruletype-firewall-91-ban-replace-from-fw-mode/td.rules
+++ b/tests/firewall/ruletype-firewall-91-ban-replace-from-fw-mode/td.rules
@@ -1,0 +1,2 @@
+# should error out, as 'replace' is not allowed in firewall mode
+alert http any any -> any any (msg:"Test replace keyword with firewall rules"; content:"foo"; replace:"bar"; sid:2000001;)

--- a/tests/firewall/ruletype-firewall-91-ban-replace-from-fw-mode/test.yaml
+++ b/tests/firewall/ruletype-firewall-91-ban-replace-from-fw-mode/test.yaml
@@ -1,0 +1,15 @@
+requires:
+  min-version: 9
+
+pcap: ../../tls/tls-random/input.pcap
+
+args:
+  - --simulate-ips
+  - -v
+exit-code: 1
+
+checks:
+  - shell:
+      args: grep "keyword 'replace' is not allowed in firewall mode" stderr | wc -l
+      expect: 1
+

--- a/tests/firewall/ruletype-firewall-92-ban-bypass-keyword/README.md
+++ b/tests/firewall/ruletype-firewall-92-ban-bypass-keyword/README.md
@@ -1,0 +1,10 @@
+# Test
+
+Ensure that the engine throws an error if the `bypass` keyword is used
+in threat detection rules, as it's banned in firewall mode.
+
+## Ticket
+
+Related to
+https://redmine.openinfosecfoundation.org/issues/8551
+and https://redmine.openinfosecfoundation.org/issues/8459.

--- a/tests/firewall/ruletype-firewall-92-ban-bypass-keyword/firewall.rules
+++ b/tests/firewall/ruletype-firewall-92-ban-bypass-keyword/firewall.rules
@@ -1,0 +1,1 @@
+accept:hook tcp:all any any -> any any (msg:"Simple firewall rule."; sid: 1;)

--- a/tests/firewall/ruletype-firewall-92-ban-bypass-keyword/td.rules
+++ b/tests/firewall/ruletype-firewall-92-ban-bypass-keyword/td.rules
@@ -1,0 +1,2 @@
+# should error out, as 'bypass' is not allowed in firewall mode
+alert http any any -> any any (msg:"Test bypass keyword with firewall mode"; bypass; sid:2000001;)

--- a/tests/firewall/ruletype-firewall-92-ban-bypass-keyword/test.yaml
+++ b/tests/firewall/ruletype-firewall-92-ban-bypass-keyword/test.yaml
@@ -1,0 +1,15 @@
+requires:
+  min-version: 9
+
+pcap: ../../tls/tls-random/input.pcap
+
+args:
+  - --simulate-ips
+  - -v
+exit-code: 1
+
+checks:
+  - shell:
+      args: grep "keyword 'bypass' is not allowed in firewall mode" stderr | wc -l
+      expect: 1
+


### PR DESCRIPTION
Tests for `replace` and `bypass` keywords with firewall mode/ rules.

`replace` should be banned for both firewall mode as a whole, and firewall rules.
`bypass` is banned from firewall mode (right?).

Not sure if ticket https://redmine.openinfosecfoundation.org/issues/8459 should be the correct one for bypass, or another should be created.

## Ticket

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/
https://redmine.openinfosecfoundation.org/issues/8551
