### PR TITLE
tests: remove setup of http-log

### DIFF
--- a/tests/transform-base64-7296/suricata.yaml
+++ b/tests/transform-base64-7296/suricata.yaml
@@ -65,10 +65,6 @@ outputs:
         - flow
         - netflow
         - metadata
-  - http-log:
-      enabled: yes
-      filename: /dev/null
-      extended: yes
   - file-store:
       version: 2
       enabled: yes


### PR DESCRIPTION
http-log has been removed in Suricata 9. This test did not depend on its
output either.

Ticket: #7232
