### PR TITLE
Backport8 8619 v2

### DIFF
--- a/tests/bug-8619/test.yaml
+++ b/tests/bug-8619/test.yaml
@@ -1,6 +1,6 @@
 requires:
   # May affect older versions.
-  min-version: 9
+  min-version: 8.0.6
 
 args:
   # Lower the LDAP live-transaction cap so a small pcap can demonstrate the


### PR DESCRIPTION
Redmine ticket: https://redmine.openinfosecfoundation.org/issues/8620

Backport for suricata branch: backport8-8619-v2