### PR TITLE
tests: bsize applied as depth to content

### DIFF
--- a/tests/bug-4226/README.md
+++ b/tests/bug-4226/README.md
@@ -1,0 +1,78 @@
+# Description
+
+Tests for the `bsize` optimization from
+https://redmine.openinfosecfoundation.org/issues/4226
+
+When a buffer carries a `bsize` with a usable upper bound (`bsize:N`,
+`bsize:<N`, or a range), the bound is applied as a `depth` to the content
+matches in that buffer, so the engine bounds its search instead of scanning the
+whole buffer. This mirrors the existing `dsize` and `urilen` optimizations. The
+analyzer reports both the applied optimization and a suggestion to use `bsize`
+where a rule pins a buffer to a fixed length the long way.
+
+## bug-4226-01
+
+`--engine-analysis` check that the `bsize` upper bound is applied as a content
+`depth` (`bsize:10` -> `depth:10`, `bsize:<26` -> `depth:26`,
+`bsize:13<>34` -> `depth:34`) and that `bsize:>8` applies none. Also confirms the
+analysis note attributing the `depth` to `bsize` is emitted for the bounded
+rules only.
+
+## bug-4226-02
+
+Matching behaviour is preserved across all `bsize` modes (exact, less-than,
+range, greater-than) and a partial content. A `bsize` that mismatches the buffer
+length does not alert, proving the length check still runs alongside the depth
+optimization.
+
+## bug-4226-03
+
+Correctness of the depth application against `offset`, multi-content
+`distance`, and negated content -- the cases that interact with content limit
+propagation, since the depth is applied after `DetectContentPropagateLimits`.
+
+## bug-4226-04
+
+`--engine-analysis` check that the analyzer suggests `bsize` when a single
+content is pinned to the whole buffer with `startswith`/`endswith` (and the
+`isdataat:!1,relative` form), and stays quiet when only one end is anchored,
+when `bsize` already exists, or for a plain unbounded content.
+
+## bug-4226-05
+
+A buffer may carry more than one `bsize`; the tightest (smallest) bound
+applies. A content longer than that tightest bound can never match, so the
+signature is rejected at load -- in either keyword order.
+
+## bug-4226-06
+
+An exact `bsize` equal to a lone content's length means the content fills the
+buffer, so it is marked `startswith`+`endswith`. `--engine-analysis` confirms
+the marking happens for that case and not for a shorter content, a non-exact
+`bsize`, or a buffer with more than one content.
+
+## bug-4226-07
+
+Multiple `bsize` on a buffer (a lower + upper bound forming a range) are
+accepted; the rule loads, and engine-analysis suggests collapsing them into a
+single `bsize` range.
+
+## bug-4226-08
+
+Multiple `bsize` on a buffer whose bounds share no satisfiable length are
+rejected at load: two differing exact `bsize` values, and a lower bound above
+an upper bound, in either keyword order.
+
+## bug-4226-09
+
+Same-direction bounds (two upper or two lower `bsize`) are accepted but are not
+suggested as a range -- the fold hint fires only for a genuine lower+upper pair
+(contrast bug-4226-07).
+
+# PCAP
+
+bug-4226-02 and bug-4226-03 reference the DNS query to google[.]com (`dns.query`
+buffer "google.com", 10 bytes) from the `test-bsize-values-2` capture via the
+`pcap:` key in their test.yaml.
+bug-4226-01, bug-4226-04, bug-4226-05, bug-4226-06, bug-4226-07, bug-4226-08
+and bug-4226-09 run `--engine-analysis` only and need no pcap.

--- a/tests/bug-4226/bug-4226-01/test.rules
+++ b/tests/bug-4226/bug-4226-01/test.rules
@@ -1,0 +1,6 @@
+# bsize is applied as a depth to the content matches in the same buffer when
+# it yields a usable upper bound. bsize:>N has no upper bound, so no depth.
+alert dns any any -> any any (msg:"bsize exact -> depth"; dns.query; content:"google.com"; bsize:10; sid:1;)
+alert dns any any -> any any (msg:"bsize less-than -> depth"; dns.query; content:"google.com"; bsize:<26; sid:2;)
+alert dns any any -> any any (msg:"bsize range -> depth (upper bound)"; dns.query; content:"google.com"; bsize:13<>34; sid:3;)
+alert dns any any -> any any (msg:"bsize greater-than -> no depth"; dns.query; content:"google.com"; bsize:>8; sid:4;)

--- a/tests/bug-4226/bug-4226-01/test.yaml
+++ b/tests/bug-4226/bug-4226-01/test.yaml
@@ -1,0 +1,35 @@
+requires:
+    min-version: 9
+    pcap: false
+
+args:
+    - --engine-analysis
+    - --set engine-analysis.rules=yes
+
+# Each content is dumped three times in rules.json (rule, mpm, prefilter), so
+# the per-bsize depth appears three times. bsize:>8 (sid:4) yields no upper
+# bound, so it contributes no depth; the total count proves it added none.
+checks:
+    - shell:
+        args: grep -o '"depth":10' rules.json | wc -l | xargs
+        expect: 3
+
+    - shell:
+        args: grep -o '"depth":26' rules.json | wc -l | xargs
+        expect: 3
+
+    - shell:
+        args: grep -o '"depth":34' rules.json | wc -l | xargs
+        expect: 3
+
+    - shell:
+        args: grep -o '"depth":' rules.json | wc -l | xargs
+        expect: 9
+
+    # The optimization is attributed in the analysis notes: each of the three
+    # bounded rules carries the note twice (content dumped per match list),
+    # and bsize:>8 (sid:4) contributes none.
+    - shell:
+        args: grep -o "applied as a 'depth'" rules.json | wc -l | xargs
+        expect: 6
+

--- a/tests/bug-4226/bug-4226-02/test.rules
+++ b/tests/bug-4226/bug-4226-02/test.rules
@@ -1,0 +1,9 @@
+# Applying bsize as a content depth must not change matching. The dns.query
+# buffer is "google.com" (10 bytes). sids 1-5 match; sid 6 does not, proving
+# the bsize length check still runs alongside the depth optimization.
+alert dns any any -> any any (msg:"bsize exact"; dns.query; content:"google.com"; bsize:10; sid:1;)
+alert dns any any -> any any (msg:"bsize less-than"; dns.query; content:"google.com"; bsize:<25; sid:2;)
+alert dns any any -> any any (msg:"bsize range"; dns.query; content:"google.com"; bsize:8<>20; sid:3;)
+alert dns any any -> any any (msg:"bsize greater-than"; dns.query; content:"google.com"; bsize:>8; sid:4;)
+alert dns any any -> any any (msg:"bsize partial content"; dns.query; content:"google"; bsize:10; sid:5;)
+alert dns any any -> any any (msg:"bsize length mismatch"; dns.query; content:"goog"; bsize:5; sid:6;)

--- a/tests/bug-4226/bug-4226-02/test.yaml
+++ b/tests/bug-4226/bug-4226-02/test.yaml
@@ -1,0 +1,40 @@
+requires:
+    min-version: 9
+
+pcap:
+  ../../test-bsize-values-2/input.pcap
+
+args:
+    - -k none
+
+checks:
+    - filter:
+        count: 1
+        match:
+            event_type: alert
+            alert.signature_id: 1
+    - filter:
+        count: 1
+        match:
+            event_type: alert
+            alert.signature_id: 2
+    - filter:
+        count: 1
+        match:
+            event_type: alert
+            alert.signature_id: 3
+    - filter:
+        count: 1
+        match:
+            event_type: alert
+            alert.signature_id: 4
+    - filter:
+        count: 1
+        match:
+            event_type: alert
+            alert.signature_id: 5
+    - filter:
+        count: 0
+        match:
+            event_type: alert
+            alert.signature_id: 6

--- a/tests/bug-4226/bug-4226-03/test.rules
+++ b/tests/bug-4226/bug-4226-03/test.rules
@@ -1,0 +1,7 @@
+# bsize depth is applied after DetectContentPropagateLimits, so it must not
+# break offset/distance/within propagation or negation. The dns.query buffer
+# is "google.com" (10 bytes). sids 11-13 match; sid 14 does not.
+alert dns any any -> any any (msg:"bsize with offset"; dns.query; content:"com"; offset:7; bsize:10; sid:11;)
+alert dns any any -> any any (msg:"bsize multi-content distance"; dns.query; content:"google"; content:"com"; distance:1; bsize:10; sid:12;)
+alert dns any any -> any any (msg:"bsize negated content present-elsewhere"; dns.query; content:!"example"; bsize:10; sid:13;)
+alert dns any any -> any any (msg:"bsize multi-content no match"; dns.query; content:"google"; content:"net"; distance:0; bsize:10; sid:14;)

--- a/tests/bug-4226/bug-4226-03/test.yaml
+++ b/tests/bug-4226/bug-4226-03/test.yaml
@@ -1,0 +1,30 @@
+requires:
+    min-version: 9
+
+pcap:
+  ../../test-bsize-values-2/input.pcap
+
+args:
+    - -k none
+
+checks:
+    - filter:
+        count: 1
+        match:
+            event_type: alert
+            alert.signature_id: 11
+    - filter:
+        count: 1
+        match:
+            event_type: alert
+            alert.signature_id: 12
+    - filter:
+        count: 1
+        match:
+            event_type: alert
+            alert.signature_id: 13
+    - filter:
+        count: 0
+        match:
+            event_type: alert
+            alert.signature_id: 14

--- a/tests/bug-4226/bug-4226-04/test.rules
+++ b/tests/bug-4226/bug-4226-04/test.rules
@@ -1,0 +1,10 @@
+# engine-analysis suggests bsize when a single content is pinned to the whole
+# buffer with startswith+endswith (isdataat:!1,relative folds into endswith).
+# The note must NOT fire when only one end is anchored, when bsize already
+# exists, or for a plain unbounded content.
+alert dns any any -> any any (msg:"startswith+endswith"; dns.query; content:"example.com"; startswith; endswith; sid:1;)
+alert http any any -> any any (msg:"startswith+isdataat"; http.uri; content:"/a/b/"; startswith; isdataat:!1,relative; sid:2;)
+alert dns any any -> any any (msg:"endswith only"; dns.query; content:"com"; endswith; sid:3;)
+alert dns any any -> any any (msg:"startswith only"; dns.query; content:"example"; startswith; sid:4;)
+alert dns any any -> any any (msg:"already has bsize"; dns.query; content:"example.com"; startswith; endswith; bsize:11; sid:5;)
+alert dns any any -> any any (msg:"plain content"; dns.query; content:"example.com"; sid:6;)

--- a/tests/bug-4226/bug-4226-04/test.yaml
+++ b/tests/bug-4226/bug-4226-04/test.yaml
@@ -1,0 +1,15 @@
+requires:
+    min-version: 9
+    pcap: false
+
+args:
+    - --engine-analysis
+    - --set engine-analysis.rules=yes
+
+# The two pinned rules (sids 1 and 2) each carry the suggestion note twice
+# (content dumped per match list); the four other shapes carry none, so the
+# total count of 4 proves the heuristic stays quiet on the negatives.
+checks:
+    - shell:
+        args: grep -o "pins a single content" rules.json | wc -l | xargs
+        expect: 4

--- a/tests/bug-4226/bug-4226-05/test.rules
+++ b/tests/bug-4226/bug-4226-05/test.rules
@@ -1,0 +1,6 @@
+# A buffer may carry more than one bsize; the tightest (smallest) upper bound
+# applies. When the required content is longer than that tightest bound the
+# signature can never match, and it is rejected at load -- regardless of the
+# order the bsize keywords appear in.
+alert dns any any -> any any (msg:"tight bound first"; dns.query; content:"abcdefghij"; bsize:<8; bsize:<20; sid:1;)
+alert dns any any -> any any (msg:"tight bound last"; dns.query; content:"abcdefghij"; bsize:<20; bsize:<8; sid:2;)

--- a/tests/bug-4226/bug-4226-05/test.yaml
+++ b/tests/bug-4226/bug-4226-05/test.yaml
@@ -1,0 +1,16 @@
+requires:
+    min-version: 9
+    pcap: false
+
+args:
+    - --engine-analysis
+
+exit-code: 1
+
+# Both orderings of the two bsize keywords must be rejected, because the
+# required content length (10) exceeds the tightest bound (8). Before the
+# tightest-bound check the order-last case slipped through validation.
+checks:
+    - shell:
+        args: grep -c "can't match as required content length 10 exceeds bsize value.*8" suricata.log | xargs
+        expect: 2

--- a/tests/bug-4226/bug-4226-06/test.rules
+++ b/tests/bug-4226/bug-4226-06/test.rules
@@ -1,0 +1,7 @@
+# An exact bsize equal to a lone content's length means the content fills the
+# buffer, so it is marked startswith+endswith. The marking must NOT happen for
+# a shorter content, a non-exact bsize, or a buffer with more than one content.
+alert dns any any -> any any (msg:"exact equals content length"; dns.query; content:"google.com"; bsize:10; sid:1;)
+alert dns any any -> any any (msg:"content shorter than exact bsize"; dns.query; content:"google"; bsize:10; sid:2;)
+alert dns any any -> any any (msg:"non-exact bsize"; dns.query; content:"google.com"; bsize:<11; sid:3;)
+alert dns any any -> any any (msg:"more than one content"; dns.query; content:"goog"; content:"le.com"; bsize:10; sid:4;)

--- a/tests/bug-4226/bug-4226-06/test.yaml
+++ b/tests/bug-4226/bug-4226-06/test.yaml
@@ -1,0 +1,19 @@
+requires:
+    min-version: 9
+    pcap: false
+
+args:
+    - --engine-analysis
+    - --set engine-analysis.rules=yes
+
+# Only the exact-equals rule (sid 1) is marked startswith+endswith. Its lone
+# content is dumped three times in rules.json (rule, mpm, prefilter); the other
+# three rules contribute none, so both counts are exactly 3.
+checks:
+    - shell:
+        args: grep -o '"starts_with":true' rules.json | wc -l | xargs
+        expect: 3
+
+    - shell:
+        args: grep -o '"ends_with":true' rules.json | wc -l | xargs
+        expect: 3

--- a/tests/bug-4226/bug-4226-07/test.rules
+++ b/tests/bug-4226/bug-4226-07/test.rules
@@ -1,0 +1,3 @@
+# Multiple bsize on a buffer (here a lower + upper bound forming a range) are
+# accepted; engine-analysis suggests collapsing them into a single bsize range.
+alert dns any any -> any any (msg:"range via two bsize"; dns.query; content:"abc"; bsize:>2; bsize:<20; sid:1;)

--- a/tests/bug-4226/bug-4226-07/test.yaml
+++ b/tests/bug-4226/bug-4226-07/test.yaml
@@ -1,0 +1,19 @@
+requires:
+    min-version: 9
+    pcap: false
+
+args:
+    - --engine-analysis
+    - --set engine-analysis.rules=yes
+
+# The rule loads (multiple bsize is accepted) and engine-analysis suggests a
+# single bsize range.
+checks:
+    - filter:
+        filename: rules.json
+        count: 1
+        match:
+            id: 1
+    - shell:
+        args: grep -c "uses multiple 'bsize' keywords" rules.json | xargs
+        expect: 1

--- a/tests/bug-4226/bug-4226-08/test.rules
+++ b/tests/bug-4226/bug-4226-08/test.rules
@@ -1,0 +1,8 @@
+# A buffer may carry more than one bsize, and the buffer must satisfy them all.
+# When those bounds share no common length the signature can never match, so it
+# is rejected at load. Two differing exact bsizes and a lower bound above an
+# upper bound are both unsatisfiable, in either keyword order.
+alert dns any any -> any any (msg:"two exacts, tight first"; dns.query; content:"abc"; bsize:15; bsize:27; sid:1;)
+alert dns any any -> any any (msg:"two exacts, tight last"; dns.query; content:"abc"; bsize:27; bsize:15; sid:2;)
+alert dns any any -> any any (msg:"lower above upper"; dns.query; content:"abc"; bsize:>20; bsize:<10; sid:3;)
+alert dns any any -> any any (msg:"upper below lower"; dns.query; content:"abc"; bsize:<10; bsize:>20; sid:4;)

--- a/tests/bug-4226/bug-4226-08/test.yaml
+++ b/tests/bug-4226/bug-4226-08/test.yaml
@@ -1,0 +1,15 @@
+requires:
+    min-version: 9
+    pcap: false
+
+args:
+    - --engine-analysis
+
+exit-code: 1
+
+# All four signatures carry mutually exclusive bsize keywords, so each is
+# rejected at load, regardless of the order the keywords appear in.
+checks:
+    - shell:
+        args: grep -c "'bsize' keywords are mutually exclusive" suricata.log | xargs
+        expect: 4

--- a/tests/bug-4226/bug-4226-09/test.rules
+++ b/tests/bug-4226/bug-4226-09/test.rules
@@ -1,0 +1,6 @@
+# The "fold into a bsize range" hint only applies when the multiple bsize
+# keywords form a two-sided bound (a lower and an upper). Same-direction bounds
+# -- two upper bounds or two lower bounds -- are not a range, so the analyzer
+# must not suggest one. Both signatures are satisfiable and load.
+alert dns any any -> any any (msg:"two upper bounds"; dns.query; content:"ab"; bsize:<8; bsize:<20; sid:1;)
+alert dns any any -> any any (msg:"two lower bounds"; dns.query; content:"ab"; bsize:>2; bsize:>1; sid:2;)

--- a/tests/bug-4226/bug-4226-09/test.yaml
+++ b/tests/bug-4226/bug-4226-09/test.yaml
@@ -1,0 +1,24 @@
+requires:
+    min-version: 9
+    pcap: false
+
+args:
+    - --engine-analysis
+    - --set engine-analysis.rules=yes
+
+# Both rules load; neither forms a two-sided bound, so engine-analysis does not
+# suggest a bsize range for them (contrast bug-4226-07, a lower+upper pair).
+checks:
+    - filter:
+        filename: rules.json
+        count: 1
+        match:
+            id: 1
+    - filter:
+        filename: rules.json
+        count: 1
+        match:
+            id: 2
+    - shell:
+        args: grep -c "uses multiple 'bsize' keywords" rules.json | xargs
+        expect: 0

--- a/tests/detect-exact/README.md
+++ b/tests/detect-exact/README.md
@@ -1,0 +1,52 @@
+# Description
+
+Tests for the `exact` keyword. `exact` is shorthand for a `bsize` equal to the
+length of the preceding `content`: the content spans the whole buffer. It is
+equivalent to `bsize:<content-length>` and, for a lone content, lets the engine
+anchor the match with `startswith`/`endswith` and prefilter on buffer length.
+
+## detect-exact-01 (allowed)
+
+`--engine-analysis` check that `content:"google.com"; exact;` loads and produces
+the same `startswith`+`endswith` anchoring as the explicit `bsize:10` form.
+
+## detect-exact-02 (boundary)
+
+Matching against a pcap whose `dns.query` is exactly `google.com` (10 bytes). A
+content that fills the buffer alerts; a shorter content -- where the buffer is
+longer than the length `exact` implies -- never matches.
+
+## detect-exact-03 (invalid)
+
+Every rule is rejected at load: `exact` with no preceding content, a non-zero
+`offset`, a relative `within`, a relative `distance`, and a negated content (the
+`exact` guards), plus a multi-content buffer whose other content no longer fits
+the pinned length (the bsize length check).
+
+## detect-exact-04 (edge)
+
+Accepted corner cases: an explicit `offset:0` (allowed), a single-byte content,
+and `exact` composed with a matching explicit `bsize` (two identical bounds).
+
+## detect-exact-05 (suggestion)
+
+The reverse direction: a single content anchored the long way with
+`startswith`/`endswith` triggers the engine-analysis suggestion to use `exact`.
+
+## detect-exact-06 (transform)
+
+`exact` composes with a transform: the content and the length bound it injects
+both apply to the transformed buffer, so a length-changing transform
+(`strip_whitespace`) still yields the depth + `startswith`/`endswith` anchoring.
+
+## detect-exact-07 (transform suggestion)
+
+An anchored `startswith`/`endswith` content on a transformed buffer still gets
+the `exact` suggestion -- the transform no longer suppresses it.
+
+# PCAP
+
+detect-exact-02 references the `google.com` `dns.query` capture from
+`test-bsize-values-2` via the `pcap:` key. detect-exact-01, detect-exact-03,
+detect-exact-04, detect-exact-05, detect-exact-06 and detect-exact-07 run
+`--engine-analysis` only and need no pcap.

--- a/tests/detect-exact/detect-exact-01/test.rules
+++ b/tests/detect-exact/detect-exact-01/test.rules
@@ -1,0 +1,5 @@
+# 'exact' is shorthand for a bsize equal to the preceding content's length: the
+# content spans the whole buffer. For a lone content that means it is marked
+# startswith+endswith, exactly like writing bsize:<content-length>.
+alert dns any any -> any any (msg:"exact"; dns.query; content:"google.com"; exact; sid:1;)
+alert dns any any -> any any (msg:"equivalent bsize"; dns.query; content:"google.com"; bsize:10; sid:2;)

--- a/tests/detect-exact/detect-exact-01/test.yaml
+++ b/tests/detect-exact/detect-exact-01/test.yaml
@@ -1,0 +1,28 @@
+requires:
+    min-version: 9
+    pcap: false
+
+args:
+    - --engine-analysis
+    - --set engine-analysis.rules=yes
+
+# Both rules load. Being a single content pinned to the whole buffer, the
+# content is marked startswith+endswith -- 'exact' produces the same anchoring
+# as the explicit bsize:10 form.
+checks:
+    - filter:
+        filename: rules.json
+        count: 1
+        match:
+            id: 1
+    - filter:
+        filename: rules.json
+        count: 1
+        match:
+            id: 2
+    - shell:
+        args: grep -c '"starts_with":true' rules.json | xargs
+        expect: 2
+    - shell:
+        args: grep -c '"ends_with":true' rules.json | xargs
+        expect: 2

--- a/tests/detect-exact/detect-exact-02/test.rules
+++ b/tests/detect-exact/detect-exact-02/test.rules
@@ -1,0 +1,6 @@
+# Boundary: the pcap has a dns.query of exactly "google.com" (10 bytes).
+# 'exact' forces the buffer length to equal the content length, so a content
+# that fills the buffer alerts, while a shorter content (buffer longer than the
+# implied bsize) does not.
+alert dns any any -> any any (msg:"exact full buffer"; dns.query; content:"google.com"; exact; sid:1;)
+alert dns any any -> any any (msg:"exact shorter than buffer"; dns.query; content:"google"; exact; sid:2;)

--- a/tests/detect-exact/detect-exact-02/test.yaml
+++ b/tests/detect-exact/detect-exact-02/test.yaml
@@ -1,0 +1,22 @@
+requires:
+    min-version: 9
+
+pcap:
+  ../../test-bsize-values-2/input.pcap
+
+args:
+    - -k none
+
+# sid 1 fills the buffer exactly (10 == 10) and alerts; sid 2's content is
+# shorter than the 10-byte buffer, so exact (bsize:6) can never match.
+checks:
+    - filter:
+        count: 1
+        match:
+            event_type: alert
+            alert.signature_id: 1
+    - filter:
+        count: 0
+        match:
+            event_type: alert
+            alert.signature_id: 2

--- a/tests/detect-exact/detect-exact-03/test.rules
+++ b/tests/detect-exact/detect-exact-03/test.rules
@@ -1,0 +1,11 @@
+# Invalid: every rule here is rejected at load. The first five hit an 'exact'
+# guard; the last is accepted by the guard but rejected by the bsize length
+# check, since exact pins the buffer to the last content's length and the other
+# content no longer fits.
+alert dns any any -> any any (msg:"no preceding content"; dns.query; exact; sid:1;)
+alert dns any any -> any any (msg:"non-zero offset"; dns.query; content:"google.com"; offset:5; exact; sid:2;)
+alert dns any any -> any any (msg:"relative within"; dns.query; content:"a"; content:"b"; within:3; exact; sid:3;)
+alert dns any any -> any any (msg:"relative distance"; dns.query; content:"a"; content:"b"; distance:1; exact; sid:4;)
+alert dns any any -> any any (msg:"negated content"; dns.query; content:!"google.com"; exact; sid:5;)
+alert dns any any -> any any (msg:"multi-content no longer fits"; dns.query; content:"abcdefghij"; content:"xyz"; exact; sid:6;)
+alert tcp any any -> any any (msg:"raw payload has no buffer"; content:"abc"; exact; sid:7;)

--- a/tests/detect-exact/detect-exact-03/test.yaml
+++ b/tests/detect-exact/detect-exact-03/test.yaml
@@ -1,0 +1,29 @@
+requires:
+    min-version: 9
+    pcap: false
+
+args:
+    - --engine-analysis
+
+exit-code: 1
+
+# Each rule is rejected: no content, a non-zero offset, two relative forms, a
+# negated content, and use on the raw payload (all caught by the 'exact'
+# guards), plus a multi-content buffer whose other content no longer fits the
+# pinned length (caught by bsize).
+checks:
+    - shell:
+        args: grep -c "'exact' needs a preceding content option" suricata.log | xargs
+        expect: 1
+    - shell:
+        args: grep -c "'exact' can't be used with a non-zero offset" suricata.log | xargs
+        expect: 1
+    - shell:
+        args: grep -c "'exact' can't be used with a relative or negated content" suricata.log | xargs
+        expect: 3
+    - shell:
+        args: grep -c "'exact' can only be used with an app-layer or sticky buffer" suricata.log | xargs
+        expect: 1
+    - shell:
+        args: grep -c "exceeds bsize value" suricata.log | xargs
+        expect: 1

--- a/tests/detect-exact/detect-exact-04/test.rules
+++ b/tests/detect-exact/detect-exact-04/test.rules
@@ -1,0 +1,6 @@
+# Edge: accepted corner cases. A plain offset:0 is allowed (the content still
+# starts the buffer); a single-byte content pins the buffer to one byte; and
+# 'exact' composes with an explicit, matching bsize (two identical bounds).
+alert dns any any -> any any (msg:"explicit offset zero"; dns.query; content:"google.com"; offset:0; exact; sid:1;)
+alert dns any any -> any any (msg:"single byte"; dns.query; content:"a"; exact; sid:2;)
+alert dns any any -> any any (msg:"exact plus matching bsize"; dns.query; content:"google.com"; exact; bsize:10; sid:3;)

--- a/tests/detect-exact/detect-exact-04/test.yaml
+++ b/tests/detect-exact/detect-exact-04/test.yaml
@@ -1,0 +1,26 @@
+requires:
+    min-version: 9
+    pcap: false
+
+args:
+    - --engine-analysis
+    - --set engine-analysis.rules=yes
+
+# All three load: offset:0 is permitted, a one-byte content is a valid exact,
+# and exact alongside a matching explicit bsize is a feasible (redundant) pair.
+checks:
+    - filter:
+        filename: rules.json
+        count: 1
+        match:
+            id: 1
+    - filter:
+        filename: rules.json
+        count: 1
+        match:
+            id: 2
+    - filter:
+        filename: rules.json
+        count: 1
+        match:
+            id: 3

--- a/tests/detect-exact/detect-exact-05/test.rules
+++ b/tests/detect-exact/detect-exact-05/test.rules
@@ -1,0 +1,4 @@
+# The reverse direction: a single content anchored the long way with
+# startswith/endswith spans the whole buffer, which the 'exact' keyword
+# expresses directly, so engine-analysis suggests it.
+alert dns any any -> any any (msg:"anchored suggests exact"; dns.query; content:"abc"; startswith; endswith; sid:1;)

--- a/tests/detect-exact/detect-exact-05/test.yaml
+++ b/tests/detect-exact/detect-exact-05/test.yaml
@@ -1,0 +1,14 @@
+requires:
+    min-version: 9
+    pcap: false
+
+args:
+    - --engine-analysis
+    - --set engine-analysis.rules=yes
+
+# The anchored single content (startswith+endswith) triggers the engine-analysis
+# suggestion to use the 'exact' keyword instead.
+checks:
+    - shell:
+        args: grep -c "the 'exact' keyword expresses this" rules.json | xargs
+        expect: 1

--- a/tests/detect-exact/detect-exact-06/test.rules
+++ b/tests/detect-exact/detect-exact-06/test.rules
@@ -1,0 +1,5 @@
+# exact composes with a transform: both the content and the length bound that
+# exact injects apply to the transformed buffer. A length-changing transform
+# such as strip_whitespace therefore still yields the depth + startswith/endswith
+# anchoring, computed against the transformed buffer.
+alert dns any any -> any any (msg:"exact after strip_whitespace"; dns.query; strip_whitespace; content:"google.com"; exact; sid:1;)

--- a/tests/detect-exact/detect-exact-06/test.yaml
+++ b/tests/detect-exact/detect-exact-06/test.yaml
@@ -1,0 +1,22 @@
+requires:
+    min-version: 9
+    pcap: false
+
+args:
+    - --engine-analysis
+    - --set engine-analysis.rules=yes
+
+# The rule loads and, despite the length-changing transform, the content is
+# anchored startswith+endswith on the transformed buffer.
+checks:
+    - filter:
+        filename: rules.json
+        count: 1
+        match:
+            id: 1
+    - shell:
+        args: grep -c '"starts_with":true' rules.json | xargs
+        expect: 1
+    - shell:
+        args: grep -c '"ends_with":true' rules.json | xargs
+        expect: 1

--- a/tests/detect-exact/detect-exact-07/test.rules
+++ b/tests/detect-exact/detect-exact-07/test.rules
@@ -1,0 +1,4 @@
+# A single content anchored startswith/endswith still spans the buffer when the
+# buffer carries a transform, so engine-analysis suggests 'exact'. The
+# suggestion is no longer suppressed for transformed buffers.
+alert dns any any -> any any (msg:"transformed anchored suggests exact"; dns.query; strip_whitespace; content:"google.com"; startswith; endswith; sid:1;)

--- a/tests/detect-exact/detect-exact-07/test.yaml
+++ b/tests/detect-exact/detect-exact-07/test.yaml
@@ -1,0 +1,14 @@
+requires:
+    min-version: 9
+    pcap: false
+
+args:
+    - --engine-analysis
+    - --set engine-analysis.rules=yes
+
+# The anchored content is on a transformed buffer, and the 'exact' suggestion
+# still fires (the transform no longer suppresses it).
+checks:
+    - shell:
+        args: grep -c "the 'exact' keyword expresses this" rules.json | xargs
+        expect: 1


### PR DESCRIPTION
Test Coverage for the bsize-as-depth optimization:

- bug-4226-01: engine-analysis confirms the bsize upper bound is applied as a content depth, and the attributing note is emitted
- bug-4226-02: matching is preserved across all bsize modes
- bug-4226-03: depth application is correct with offset, multi-content distance, and negated content
- bug-4226-04: engine-analysis suggests bsize where a single content is pinned to the whole buffer via startswith/endswith
- bug-4226-05 checks that a content longer than the tightest of several bsize bounds on a buffer is rejected at load, in either keyword order.
- bug-4226-06 checks that a lone content whose length equals an exact bsize is marked startswith+endswith, and that shorter content, a non-exact bsize, and multi-content buffers are not.

Issue: 4226


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/4226
