### PR TITLE
framework: improve error msg for unknown exception - v2

### DIFF
--- a/run.py
+++ b/run.py
@@ -189,7 +189,8 @@ def handle_exceptions(func):
                 print("===> {}: Sub test #{}: SKIPPED : {}".format(kwargs["test_name"], kwargs["test_num"], ue))
             kwargs["count"]["skipped"] += 1
         except Exception as err:
-            raise TestError("Internal runtime error: {}".format(err))
+            test_path = os.path.relpath(args[0].directory, args[0].cwd)
+            raise TestError("Internal runtime error: \"{}\"  with test.yaml, check #{}. Full test path: {}.".format(err, kwargs["test_num"], test_path))
         else:
             if result:
               kwargs["count"]["success"] += 1


### PR DESCRIPTION
Previous PR: #3016 

If an internal error happens while reading the test.yaml file, indicate which test caused it as well as which sub-check in the file, to be more user-friendly.

Changes from previous PR:
- improve error message
- improve commit message.

Samples:

Yaml examples:
```yaml
checks:
  - filter:
      count: 0
      match:
      event_type: drop
      drop.reason: "firewall default packet policy"
```

```yaml
  - filter:
      count: 3 2
      match:
        event_type: alert
        alert.signature_id: 102
```

Output: 

Before:
```
===> ruletype-firewall-110-dns-lte: FAILED: Internal runtime error: Unexpected key in filter check: event_type
```

```
===> ruletype-firewall-110-dns-lte: FAILED: Internal runtime error: %d format: a real number is required, not str
```

With patch:
```
===> ruletype-firewall-110-dns-lte: FAILED: Internal runtime error: "Unexpected key in filter check: event_type"  with test.yaml, check #3. Full test path: ../sv-fix-nonetype/tests/firewall/ruletype-firewall-110-dns-lte.
```

```
===> ruletype-firewall-110-dns-lte: FAILED: Internal runtime error: "%d format: a real number is required, not str"  with test.yaml, check #1. Full test path: ../sv-fix-nonetype/tests/firewall/ruletype-firewall-110-dns-lte.
```