### PR TITLE
Tag tests with protocol metadata

### DIFF
--- a/run.py
+++ b/run.py
@@ -1241,6 +1241,25 @@ def build_eve_validator():
             "{} build --release".format(cargo), cwd=os.path.join(TOPDIR, "eve-validator"),
             shell=True, env=env)
 
+def parse_protocols(values):
+    protocols = set()
+    for value in values or []:
+        for protocol in value.split(","):
+            protocol = protocol.strip()
+            if protocol:
+                protocols.add(protocol)
+    return protocols
+
+def get_test_protocols(dirpath):
+    meta_yaml = os.path.join(dirpath, "meta.yaml")
+    if not os.path.exists(meta_yaml):
+        return set()
+    config = yaml.safe_load(open(meta_yaml, "rb")) or {}
+    protocols = config.get("protocols", []) or []
+    if isinstance(protocols, str):
+        protocols = [protocols]
+    return set(str(protocol) for protocol in protocols)
+
 def main():
     global TOPDIR
     global args
@@ -1276,9 +1295,16 @@ def main():
                         help="Clean up output directories of passing tests")
     parser.add_argument("--no-validation", action="store_true", help="Disable EVE validation")
     parser.add_argument("patterns", nargs="*", default=[])
+    parser.add_argument("--meta-protocols", action="append",
+                        help="Run tests whose meta.yaml protocols include any comma-separated protocol")
     parser.add_argument("-j", type=int, default=min(8, os.cpu_count()),
                         help="Number of jobs to run (threads)")
     args = parser.parse_args()
+
+    requested_protocols = parse_protocols(args.meta_protocols)
+    if args.meta_protocols and not requested_protocols:
+        print("error: --meta-protocols requires at least one protocol")
+        return 1
 
     if args.self_test:
         return unittest.main(argv=[sys.argv[0]])
@@ -1367,16 +1393,27 @@ def main():
         else:
             continue
 
+        matched = False
         if not args.patterns:
-            tests.append(dirpath)
+            matched = True
         else:
             for pattern in args.patterns:
                 if args.exact:
                     if pattern == parent or pattern == basename:
-                        tests.append(dirpath)
+                        matched = True
+                        break
                 # also check the parent dir of the test for pattern
                 elif parent.find(pattern) > -1:
-                    tests.append(dirpath)
+                    matched = True
+                    break
+
+        if not matched:
+            continue
+
+        if requested_protocols and not requested_protocols.intersection(get_test_protocols(dirpath)):
+            continue
+
+        tests.append(dirpath)
 
     # Sort alphabetically.
     tests.sort()

--- a/tests/7858-stream-events/meta.yaml
+++ b/tests/7858-stream-events/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/alert-distance-within-1/meta.yaml
+++ b/tests/alert-distance-within-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/alert-max/alert-max-20/meta.yaml
+++ b/tests/alert-max/alert-max-20/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp]

--- a/tests/alert-max/alert-max-append-higher-priority-drop-5180-01/meta.yaml
+++ b/tests/alert-max/alert-max-append-higher-priority-drop-5180-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/alert-max/alert-max-append-higher-priority-drop-5180-02/meta.yaml
+++ b/tests/alert-max/alert-max-append-higher-priority-drop-5180-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/alert-max/alert-max-append-higher-priority-drop-5180-03/meta.yaml
+++ b/tests/alert-max/alert-max-append-higher-priority-drop-5180-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/alert-max/alert-max-append-higher-priority/meta.yaml
+++ b/tests/alert-max/alert-max-append-higher-priority/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/alert-max/alert-max-default/meta.yaml
+++ b/tests/alert-max/alert-max-default/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp]

--- a/tests/alert-max/alert-max-verdict/meta.yaml
+++ b/tests/alert-max/alert-max-verdict/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/alert-no-3whs-established/meta.yaml
+++ b/tests/alert-no-3whs-established/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp]

--- a/tests/alert-testmyids-async/meta.yaml
+++ b/tests/alert-testmyids-async/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/alert-testmyids-frames/meta.yaml
+++ b/tests/alert-testmyids-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/alert-testmyids-midstream/meta.yaml
+++ b/tests/alert-testmyids-midstream/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/alert-testmyids-midstream3/meta.yaml
+++ b/tests/alert-testmyids-midstream3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/alert-testmyids-midstream5/meta.yaml
+++ b/tests/alert-testmyids-midstream5/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/alert-testmyids-not-established/meta.yaml
+++ b/tests/alert-testmyids-not-established/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/alert-testmyids/meta.yaml
+++ b/tests/alert-testmyids/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/app-layer-template/meta.yaml
+++ b/tests/app-layer-template/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/arp/detect-arp-01/meta.yaml
+++ b/tests/arp/detect-arp-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, eth]

--- a/tests/arp/detect-arp-02-ethhdr/meta.yaml
+++ b/tests/arp/detect-arp-02-ethhdr/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, eth]

--- a/tests/arp/detect-arp-03-vlan/meta.yaml
+++ b/tests/arp/detect-arp-03-vlan/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, eth, vlan]

--- a/tests/arp/detect-arp-04-vxlan/meta.yaml
+++ b/tests/arp/detect-arp-04-vxlan/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, eth, ip, udp, vxlan]

--- a/tests/base64-decode-5885/meta.yaml
+++ b/tests/base64-decode-5885/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, data-text-lines, dhcp, dhcpv6, dns, eth, http, icmpv6, igmp, image-gif, ip, ipv6, ipv6.hopopts, llc, llmnr, mdns, nbdgm, nbns, pkix1implicit, smb, ssdp, stp, tcp, tls, udp, urlencoded-form, x509, x509ce, x509sat, xml]

--- a/tests/base64-issue-5223-6/meta.yaml
+++ b/tests/base64-issue-5223-6/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/base64-issue-5223/meta.yaml
+++ b/tests/base64-issue-5223/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/base64/meta.yaml
+++ b/tests/base64/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, tcp]

--- a/tests/bittorrent-dht/meta.yaml
+++ b/tests/bittorrent-dht/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, udp]

--- a/tests/bpf-command-line/meta.yaml
+++ b/tests/bpf-command-line/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, tcp]

--- a/tests/bug-1045/meta.yaml
+++ b/tests/bug-1045/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, smtp, tcp]

--- a/tests/bug-130/meta.yaml
+++ b/tests/bug-130/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/bug-1401-01/meta.yaml
+++ b/tests/bug-1401-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/bug-1401-02/meta.yaml
+++ b/tests/bug-1401-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/bug-1401-03/meta.yaml
+++ b/tests/bug-1401-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/bug-1401-04/meta.yaml
+++ b/tests/bug-1401-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/bug-1449-01/meta.yaml
+++ b/tests/bug-1449-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, smtp, tcp]

--- a/tests/bug-1450-02/meta.yaml
+++ b/tests/bug-1450-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls]

--- a/tests/bug-1450-03/meta.yaml
+++ b/tests/bug-1450-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls]

--- a/tests/bug-1450-04/meta.yaml
+++ b/tests/bug-1450-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls]

--- a/tests/bug-1450-05/meta.yaml
+++ b/tests/bug-1450-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls]

--- a/tests/bug-2158/meta.yaml
+++ b/tests/bug-2158/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dhcp, dns, eth, ip, udp]

--- a/tests/bug-2190/meta.yaml
+++ b/tests/bug-2190/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, icmp, ip]

--- a/tests/bug-2430/meta.yaml
+++ b/tests/bug-2430/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/bug-2482-01/meta.yaml
+++ b/tests/bug-2482-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dns, eth, http, icmp, ip, logotypecertextn, ocsp, pkix1explicit, pkix1implicit, pkixalgs, ssh, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/bug-2491-01/meta.yaml
+++ b/tests/bug-2491-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/bug-2491-02/meta.yaml
+++ b/tests/bug-2491-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/bug-2511/meta.yaml
+++ b/tests/bug-2511/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/bug-2512/meta.yaml
+++ b/tests/bug-2512/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/bug-2558-01/meta.yaml
+++ b/tests/bug-2558-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, mp4, tcp]

--- a/tests/bug-2558-02/meta.yaml
+++ b/tests/bug-2558-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, mp4, tcp]

--- a/tests/bug-2576-01-ips/meta.yaml
+++ b/tests/bug-2576-01-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, gre, http, ip, tcp]

--- a/tests/bug-2576-01/meta.yaml
+++ b/tests/bug-2576-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, gre, http, ip, tcp]

--- a/tests/bug-2576-02-ips/meta.yaml
+++ b/tests/bug-2576-02-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, gre, http, ip, tcp]

--- a/tests/bug-2576-02/meta.yaml
+++ b/tests/bug-2576-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, gre, http, ip, tcp]

--- a/tests/bug-2576-03-ips/meta.yaml
+++ b/tests/bug-2576-03-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, gre, http, ip, tcp]

--- a/tests/bug-2576-03/meta.yaml
+++ b/tests/bug-2576-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, gre, http, ip, tcp]

--- a/tests/bug-2576-04-ips/meta.yaml
+++ b/tests/bug-2576-04-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, gre, http, ip, tcp]

--- a/tests/bug-2576-04/meta.yaml
+++ b/tests/bug-2576-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, gre, http, ip, tcp]

--- a/tests/bug-2646-01/meta.yaml
+++ b/tests/bug-2646-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/bug-2646-02/meta.yaml
+++ b/tests/bug-2646-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/bug-2736-01/meta.yaml
+++ b/tests/bug-2736-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/bug-2736-02/meta.yaml
+++ b/tests/bug-2736-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/bug-2769/meta.yaml
+++ b/tests/bug-2769/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/bug-28/meta.yaml
+++ b/tests/bug-28/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/bug-2917/meta.yaml
+++ b/tests/bug-2917/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/bug-3286-01-no-evasion/meta.yaml
+++ b/tests/bug-3286-01-no-evasion/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-3286-02-linux-evasion/meta.yaml
+++ b/tests/bug-3286-02-linux-evasion/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-3286-03-windows-evasion/meta.yaml
+++ b/tests/bug-3286-03-windows-evasion/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-3463/meta.yaml
+++ b/tests/bug-3463/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/bug-3490/meta.yaml
+++ b/tests/bug-3490/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/bug-3515/meta.yaml
+++ b/tests/bug-3515/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/bug-3519/meta.yaml
+++ b/tests/bug-3519/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/bug-3616-ips/meta.yaml
+++ b/tests/bug-3616-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/bug-3616-smtp/meta.yaml
+++ b/tests/bug-3616-smtp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data-text-lines, dns, eth, icmp, ip, nbdgm, smb, smtp, tcp, udp]

--- a/tests/bug-3616-urldecode/meta.yaml
+++ b/tests/bug-3616-urldecode/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-3616/meta.yaml
+++ b/tests/bug-3616/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/bug-3844/meta.yaml
+++ b/tests/bug-3844/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/bug-4199-2/meta.yaml
+++ b/tests/bug-4199-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/bug-4199-3/meta.yaml
+++ b/tests/bug-4199-3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, urlencoded-form]

--- a/tests/bug-4199-4/meta.yaml
+++ b/tests/bug-4199-4/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, urlencoded-form]

--- a/tests/bug-4199/meta.yaml
+++ b/tests/bug-4199/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, urlencoded-form]

--- a/tests/bug-4376/meta.yaml
+++ b/tests/bug-4376/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp, vlan]

--- a/tests/bug-4394-pdonly-drop/meta.yaml
+++ b/tests/bug-4394-pdonly-drop/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-4503/meta.yaml
+++ b/tests/bug-4503/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/bug-4571-01/meta.yaml
+++ b/tests/bug-4571-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/bug-4571-02/meta.yaml
+++ b/tests/bug-4571-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, tcp]

--- a/tests/bug-4571-03-pre-8/meta.yaml
+++ b/tests/bug-4571-03-pre-8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, tcp]

--- a/tests/bug-4571-03/meta.yaml
+++ b/tests/bug-4571-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, tcp]

--- a/tests/bug-4571-04/meta.yaml
+++ b/tests/bug-4571-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ipv6, tcp]

--- a/tests/bug-4571-05/meta.yaml
+++ b/tests/bug-4571-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/bug-4571-06-pre-8/meta.yaml
+++ b/tests/bug-4571-06-pre-8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ipv6, tcp]

--- a/tests/bug-4571-06/meta.yaml
+++ b/tests/bug-4571-06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ipv6, tcp]

--- a/tests/bug-4623/meta.yaml
+++ b/tests/bug-4623/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp]

--- a/tests/bug-4663-02/meta.yaml
+++ b/tests/bug-4663-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/bug-4663-03/meta.yaml
+++ b/tests/bug-4663-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip, ssh, tcp]

--- a/tests/bug-4663/meta.yaml
+++ b/tests/bug-4663/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, eth, http, igmp, ip, media, tcp]

--- a/tests/bug-4702-01/meta.yaml
+++ b/tests/bug-4702-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/bug-4702-02/meta.yaml
+++ b/tests/bug-4702-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls]

--- a/tests/bug-4810/meta.yaml
+++ b/tests/bug-4810/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, ppp, pppoes, tcp]

--- a/tests/bug-4877/meta.yaml
+++ b/tests/bug-4877/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/bug-4903/bug-4903-01/meta.yaml
+++ b/tests/bug-4903/bug-4903-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/bug-4903/bug-4903-02/meta.yaml
+++ b/tests/bug-4903/bug-4903-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/bug-4903/bug-4903-03/meta.yaml
+++ b/tests/bug-4903/bug-4903-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/bug-4903/bug-4903-04/meta.yaml
+++ b/tests/bug-4903/bug-4903-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/bug-4953/meta.yaml
+++ b/tests/bug-4953/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, mime_multipart, tcp]

--- a/tests/bug-5066-iponly-cidr-ordering-01/meta.yaml
+++ b/tests/bug-5066-iponly-cidr-ordering-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/bug-5066-iponly-cidr-ordering-02/meta.yaml
+++ b/tests/bug-5066-iponly-cidr-ordering-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/bug-5066-iponly-cidr-ordering-03/meta.yaml
+++ b/tests/bug-5066-iponly-cidr-ordering-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/bug-5066-iponly-cidr-ordering-04/meta.yaml
+++ b/tests/bug-5066-iponly-cidr-ordering-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/bug-5066-iponly-cidr-ordering-05/meta.yaml
+++ b/tests/bug-5066-iponly-cidr-ordering-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/bug-5133/meta.yaml
+++ b/tests/bug-5133/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/bug-5162/meta.yaml
+++ b/tests/bug-5162/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, dcerpc, dns, eth, gss-api, igmp, ip, llmnr, nbns, nbss, ntlmssp, smb, spnego, ssdp, tcp, udp]

--- a/tests/bug-5197/meta.yaml
+++ b/tests/bug-5197/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/bug-5198/meta.yaml
+++ b/tests/bug-5198/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, icmp, ip, vlan]

--- a/tests/bug-5220/bug-5220-1/meta.yaml
+++ b/tests/bug-5220/bug-5220-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/bug-5220/bug-5220-2/meta.yaml
+++ b/tests/bug-5220/bug-5220-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/bug-5220/bug-5220-3/meta.yaml
+++ b/tests/bug-5220/bug-5220-3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/bug-5220/bug-5220-4/meta.yaml
+++ b/tests/bug-5220/bug-5220-4/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/bug-5220/bug-5220-5/meta.yaml
+++ b/tests/bug-5220/bug-5220-5/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/bug-5220/bug-5220-6/meta.yaml
+++ b/tests/bug-5220/bug-5220-6/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/bug-5220/bug-5220-7/meta.yaml
+++ b/tests/bug-5220/bug-5220-7/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/bug-5392/meta.yaml
+++ b/tests/bug-5392/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5437-01/meta.yaml
+++ b/tests/bug-5437-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [erspan, eth, gre, http, ip, tcp]

--- a/tests/bug-5437-02/meta.yaml
+++ b/tests/bug-5437-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [erspan, eth, gre, http, ip, tcp]

--- a/tests/bug-5464-verdict-01/meta.yaml
+++ b/tests/bug-5464-verdict-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5464-verdict-02/meta.yaml
+++ b/tests/bug-5464-verdict-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5464-verdict-03/meta.yaml
+++ b/tests/bug-5464-verdict-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data, data-text-lines, dhcp, dns, eth, http, icmpv6, ip, ipv6, media, nbdgm, nbns, smb, tcp, teredo, udp, xml]

--- a/tests/bug-5464-verdict-04/meta.yaml
+++ b/tests/bug-5464-verdict-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/bug-5464-verdict-05/meta.yaml
+++ b/tests/bug-5464-verdict-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/bug-5464-verdict-06/meta.yaml
+++ b/tests/bug-5464-verdict-06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data, data-text-lines, dhcp, dns, eth, http, icmpv6, ip, ipv6, media, nbdgm, nbns, smb, tcp, teredo, udp, xml]

--- a/tests/bug-5464-verdict-07/meta.yaml
+++ b/tests/bug-5464-verdict-07/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, gre, ip, syslog, udp, vlan]

--- a/tests/bug-5486/meta.yaml
+++ b/tests/bug-5486/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/bug-5578-http-dsize-drop/meta.yaml
+++ b/tests/bug-5578-http-dsize-drop/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, eth, http, igmp, ip, media, tcp]

--- a/tests/bug-5633-gre-01/meta.yaml
+++ b/tests/bug-5633-gre-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, gre, ip, syslog, udp, vlan]

--- a/tests/bug-5633-gre-02/meta.yaml
+++ b/tests/bug-5633-gre-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dns, eth, gre, icmp, ip, ntp, ssh, tcp, udp]

--- a/tests/bug-5713-01/meta.yaml
+++ b/tests/bug-5713-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls]

--- a/tests/bug-5713-02-ja4/meta.yaml
+++ b/tests/bug-5713-02-ja4/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls]

--- a/tests/bug-5758/meta.yaml
+++ b/tests/bug-5758/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp, tls]

--- a/tests/bug-5780-01-http2-header/meta.yaml
+++ b/tests/bug-5780-01-http2-header/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, http2, ip, tcp]

--- a/tests/bug-5802/meta.yaml
+++ b/tests/bug-5802/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sdp, sip, udp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-bypass/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-bypass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-flow/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-packet/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-drop-packet/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-ignore/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-ignore/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-flow/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-packet/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-disabled-pass-packet/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-bypass/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-bypass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-flow/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-packet/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-drop-packet/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-ignore/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-ignore/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-flow/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-packet/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-pass-packet/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-reject/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ids-midstream-enabled-reject/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-bypass/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-bypass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-flow/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-packet/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-drop-packet/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-ignore/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-ignore/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-flow/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-packet/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-pass-packet/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-reject/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-disabled-reject/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-bypass/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-bypass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-flow/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-packet/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-drop-packet/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-ignore/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-ignore/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-flow/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-packet/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-pass-packet/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-reject/meta.yaml
+++ b/tests/bug-5825-midstream-exception-policy/exception-policy-ips-midstream-enabled-reject/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-5867-fp-drop-01/meta.yaml
+++ b/tests/bug-5867-fp-drop-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp]

--- a/tests/bug-5881-01/meta.yaml
+++ b/tests/bug-5881-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp, tls]

--- a/tests/bug-5929-01/meta.yaml
+++ b/tests/bug-5929-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/bug-5929-02/meta.yaml
+++ b/tests/bug-5929-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, http2, ip, tcp]

--- a/tests/bug-6109-reject-policy-ids/meta.yaml
+++ b/tests/bug-6109-reject-policy-ids/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-6149-exception-policy-auto-ids/meta.yaml
+++ b/tests/bug-6149-exception-policy-auto-ids/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/bug-6149-exception-policy-auto-ips/meta.yaml
+++ b/tests/bug-6149-exception-policy-auto-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/bug-6191/meta.yaml
+++ b/tests/bug-6191/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, dcerpc, eth, ip, tcp]

--- a/tests/bug-6207-1/meta.yaml
+++ b/tests/bug-6207-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ip, smtp, tcp]

--- a/tests/bug-6207-2/meta.yaml
+++ b/tests/bug-6207-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ip, smtp, tcp]

--- a/tests/bug-6244-tcp-rst-with-data-02/meta.yaml
+++ b/tests/bug-6244-tcp-rst-with-data-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/bug-6244-tcp-rst-with-data/meta.yaml
+++ b/tests/bug-6244-tcp-rst-with-data/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/bug-6269-01/meta.yaml
+++ b/tests/bug-6269-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, tcp]

--- a/tests/bug-6269-02-ips/meta.yaml
+++ b/tests/bug-6269-02-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, tcp]

--- a/tests/bug-6278-1/meta.yaml
+++ b/tests/bug-6278-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/bug-6278-2/meta.yaml
+++ b/tests/bug-6278-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/bug-6402-01/meta.yaml
+++ b/tests/bug-6402-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, geneve, gre, http, ip, tcp, udp]

--- a/tests/bug-6617/meta.yaml
+++ b/tests/bug-6617/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/bug-6733-syn-packet-flow-output/meta.yaml
+++ b/tests/bug-6733-syn-packet-flow-output/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/bug-6859/meta.yaml
+++ b/tests/bug-6859/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/bug-6875-01/meta.yaml
+++ b/tests/bug-6875-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/bug-7126/meta.yaml
+++ b/tests/bug-7126/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ip, smtp, tcp]

--- a/tests/bug-7146/meta.yaml
+++ b/tests/bug-7146/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip]

--- a/tests/bug-7199/meta.yaml
+++ b/tests/bug-7199/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-7241-01-8plus/meta.yaml
+++ b/tests/bug-7241-01-8plus/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/bug-7241-02-pre8/meta.yaml
+++ b/tests/bug-7241-02-pre8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/bug-7264-tcp-3whs-ack-data-tls-01/meta.yaml
+++ b/tests/bug-7264-tcp-3whs-ack-data-tls-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/bug-7389-01/meta.yaml
+++ b/tests/bug-7389-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/bug-7389-02/meta.yaml
+++ b/tests/bug-7389-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/bug-7389-03/meta.yaml
+++ b/tests/bug-7389-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/bug-7390/meta.yaml
+++ b/tests/bug-7390/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, json, tcp]

--- a/tests/bug-7414-decoder-event-01/meta.yaml
+++ b/tests/bug-7414-decoder-event-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, udp]

--- a/tests/bug-7414-decoder-event-02-ips/meta.yaml
+++ b/tests/bug-7414-decoder-event-02-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, udp]

--- a/tests/bug-7549-01/meta.yaml
+++ b/tests/bug-7549-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-7549-02/meta.yaml
+++ b/tests/bug-7549-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-7552/bug-7552-01/meta.yaml
+++ b/tests/bug-7552/bug-7552-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, http, ip, 'null', tcp]

--- a/tests/bug-7552/bug-7552-02/meta.yaml
+++ b/tests/bug-7552/bug-7552-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, tcp]

--- a/tests/bug-76/meta.yaml
+++ b/tests/bug-76/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/bug-7657-01/meta.yaml
+++ b/tests/bug-7657-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp, urlencoded-form]

--- a/tests/bug-7657-02-ips/meta.yaml
+++ b/tests/bug-7657-02-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp, urlencoded-form]

--- a/tests/bug-7725-01/meta.yaml
+++ b/tests/bug-7725-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/bug-7725-02/meta.yaml
+++ b/tests/bug-7725-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/bug-7725-03/meta.yaml
+++ b/tests/bug-7725-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/bug-7725-04/meta.yaml
+++ b/tests/bug-7725-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/bug-78-http-uri/meta.yaml
+++ b/tests/bug-78-http-uri/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/bug-78-uricontent/meta.yaml
+++ b/tests/bug-78-uricontent/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/bug-7842-01/meta.yaml
+++ b/tests/bug-7842-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-7851-01/meta.yaml
+++ b/tests/bug-7851-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/bug-7964-01/meta.yaml
+++ b/tests/bug-7964-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ipv6]

--- a/tests/bug-7964-02/meta.yaml
+++ b/tests/bug-7964-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ipv6]

--- a/tests/bug-8021-alert-max-verdict-01/meta.yaml
+++ b/tests/bug-8021-alert-max-verdict-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/bug-8021-alert-max-verdict-02/meta.yaml
+++ b/tests/bug-8021-alert-max-verdict-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/bug-8021-alert-max-verdict-ips-03/meta.yaml
+++ b/tests/bug-8021-alert-max-verdict-ips-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, udp]

--- a/tests/bug-8021-ips-pass-verdict-04/meta.yaml
+++ b/tests/bug-8021-ips-pass-verdict-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, udp]

--- a/tests/bug-814/meta.yaml
+++ b/tests/bug-814/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, tcp, vlan]

--- a/tests/bug-8205/bug-8205-g0-t0-u0/meta.yaml
+++ b/tests/bug-8205/bug-8205-g0-t0-u0/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp, udp]

--- a/tests/bug-8205/bug-8205-g0-t0-u1/meta.yaml
+++ b/tests/bug-8205/bug-8205-g0-t0-u1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp, udp]

--- a/tests/bug-8205/bug-8205-g0-t1-u0/meta.yaml
+++ b/tests/bug-8205/bug-8205-g0-t1-u0/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp, udp]

--- a/tests/bug-8205/bug-8205-g0-t1-u1/meta.yaml
+++ b/tests/bug-8205/bug-8205-g0-t1-u1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp, udp]

--- a/tests/bug-8205/bug-8205-g1-t0-u0/meta.yaml
+++ b/tests/bug-8205/bug-8205-g1-t0-u0/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp, udp]

--- a/tests/bug-8205/bug-8205-g1-t0-u1/meta.yaml
+++ b/tests/bug-8205/bug-8205-g1-t0-u1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp, udp]

--- a/tests/bug-8205/bug-8205-g1-t1-u0/meta.yaml
+++ b/tests/bug-8205/bug-8205-g1-t1-u0/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp, udp]

--- a/tests/bug-8205/bug-8205-g1-t1-u1/meta.yaml
+++ b/tests/bug-8205/bug-8205-g1-t1-u1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp, udp]

--- a/tests/bug-8205/bug-8205-g1-tna-una/meta.yaml
+++ b/tests/bug-8205/bug-8205-g1-tna-una/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp, udp]

--- a/tests/bug-8205/bug-8205-gna-t0-u1/meta.yaml
+++ b/tests/bug-8205/bug-8205-gna-t0-u1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp, udp]

--- a/tests/bug-8205/bug-8205-gna-t1-u1/meta.yaml
+++ b/tests/bug-8205/bug-8205-gna-t1-u1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp, udp]

--- a/tests/bug-8205/bug-8205-gna-tna-una/meta.yaml
+++ b/tests/bug-8205/bug-8205-gna-tna-una/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp, udp]

--- a/tests/bug-8224-01/meta.yaml
+++ b/tests/bug-8224-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-8278-krb5-01/meta.yaml
+++ b/tests/bug-8278-krb5-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, krb5, tcp]

--- a/tests/bug-8278-krb5-02/meta.yaml
+++ b/tests/bug-8278-krb5-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, krb5, tcp]

--- a/tests/bug-8278-krb5-03/meta.yaml
+++ b/tests/bug-8278-krb5-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, krb5, tcp]

--- a/tests/bug-8336-01-default-track-only/meta.yaml
+++ b/tests/bug-8336-01-default-track-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls]

--- a/tests/bug-8336-02-bypass/meta.yaml
+++ b/tests/bug-8336-02-bypass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls]

--- a/tests/bug-8336-03-ips/meta.yaml
+++ b/tests/bug-8336-03-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls]

--- a/tests/bug-8336-04-ips-bypass/meta.yaml
+++ b/tests/bug-8336-04-ips-bypass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls]

--- a/tests/bug-8489/bug-8489-01/meta.yaml
+++ b/tests/bug-8489/bug-8489-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/bug-8489/bug-8489-02/meta.yaml
+++ b/tests/bug-8489/bug-8489-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/bug-8489/bug-8489-03/meta.yaml
+++ b/tests/bug-8489/bug-8489-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/bug-8500/meta.yaml
+++ b/tests/bug-8500/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/bug-8505/meta.yaml
+++ b/tests/bug-8505/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/bug-8619/meta.yaml
+++ b/tests/bug-8619/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, udp]

--- a/tests/bug-8621/bug-8621-01/meta.yaml
+++ b/tests/bug-8621/bug-8621-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dhcp, eth, ip, udp]

--- a/tests/bug-8621/bug-8621-02/meta.yaml
+++ b/tests/bug-8621/bug-8621-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dhcp, eth, ip, udp]

--- a/tests/bug-alert-queue-capacity/meta.yaml
+++ b/tests/bug-alert-queue-capacity/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/bug-docs-5030-01/meta.yaml
+++ b/tests/bug-docs-5030-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/bug-docs-5030-02/meta.yaml
+++ b/tests/bug-docs-5030-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/bypass-depth-disabled/meta.yaml
+++ b/tests/bypass-depth-disabled/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509sat]

--- a/tests/bypass-depth-enabled/meta.yaml
+++ b/tests/bypass-depth-enabled/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509sat]

--- a/tests/bypass-quic-enabled/meta.yaml
+++ b/tests/bypass-quic-enabled/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', quic, tls, udp]

--- a/tests/bypass-ssh-enabled/meta.yaml
+++ b/tests/bypass-ssh-enabled/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, ssh, tcp, udp]

--- a/tests/bypass-tls-disabled/meta.yaml
+++ b/tests/bypass-tls-disabled/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509sat]

--- a/tests/bypass-tls-enabled/meta.yaml
+++ b/tests/bypass-tls-enabled/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509sat]

--- a/tests/byte-extract-01/meta.yaml
+++ b/tests/byte-extract-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/classification-config-validate-01/meta.yaml
+++ b/tests/classification-config-validate-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/classification-config-validate-02/meta.yaml
+++ b/tests/classification-config-validate-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/community-id-ipv4/meta.yaml
+++ b/tests/community-id-ipv4/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls]

--- a/tests/community-id-ipv6/meta.yaml
+++ b/tests/community-id-ipv6/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, tcp, tls]

--- a/tests/community-id-sameip/meta.yaml
+++ b/tests/community-id-sameip/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, mysql, tcp]

--- a/tests/compress_ipv6-01/meta.yaml
+++ b/tests/compress_ipv6-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, tcp, vlan]

--- a/tests/compress_ipv6-02/meta.yaml
+++ b/tests/compress_ipv6-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, tcp, vlan]

--- a/tests/compress_ipv6-03/meta.yaml
+++ b/tests/compress_ipv6-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, tcp, vlan]

--- a/tests/cond-log-dns-dig/meta.yaml
+++ b/tests/cond-log-dns-dig/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/cond-log-http-testmyids/meta.yaml
+++ b/tests/cond-log-http-testmyids/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/conf-null-defrag/meta.yaml
+++ b/tests/conf-null-defrag/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/config-includes-array/meta.yaml
+++ b/tests/config-includes-array/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/config-includes/meta.yaml
+++ b/tests/config-includes/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/content-incomplete-hex-t-version-6-strict/meta.yaml
+++ b/tests/content-incomplete-hex-t-version-6-strict/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/content-incomplete-hex-t-version-7-init-errors-fatal/meta.yaml
+++ b/tests/content-incomplete-hex-t-version-7-init-errors-fatal/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/content-incomplete-hex-t-version-7-plus/meta.yaml
+++ b/tests/content-incomplete-hex-t-version-7-plus/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/datajson/datajson-01-ip/meta.yaml
+++ b/tests/datajson/datajson-01-ip/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datajson/datajson-02-multiple/meta.yaml
+++ b/tests/datajson/datajson-02-multiple/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datajson/datajson-03-jsonline/meta.yaml
+++ b/tests/datajson/datajson-03-jsonline/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datajson/datajson-04-hashes/meta.yaml
+++ b/tests/datajson/datajson-04-hashes/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datajson/datajson-05-duplicate/meta.yaml
+++ b/tests/datajson/datajson-05-duplicate/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datajson/datajson-06-remove-key/meta.yaml
+++ b/tests/datajson/datajson-06-remove-key/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datajson/datajson-07-dataset/meta.yaml
+++ b/tests/datajson/datajson-07-dataset/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datajson/datajson-08-invalid-json/meta.yaml
+++ b/tests/datajson/datajson-08-invalid-json/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datajson/datajson-09-jsonformat/meta.yaml
+++ b/tests/datajson/datajson-09-jsonformat/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datajson/datajson-10-remove-nested-key/meta.yaml
+++ b/tests/datajson/datajson-10-remove-nested-key/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datajson/datajson-11-ipv4/meta.yaml
+++ b/tests/datajson/datajson-11-ipv4/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datajson/datajson-12-nonstring-md5/meta.yaml
+++ b/tests/datajson/datajson-12-nonstring-md5/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datajson/datajson-13-nonstring-sha256/meta.yaml
+++ b/tests/datajson/datajson-13-nonstring-sha256/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datajson/datajson-14-nonstring-ipv4/meta.yaml
+++ b/tests/datajson/datajson-14-nonstring-ipv4/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datajson/datajson-15-nonstring-ipv6/meta.yaml
+++ b/tests/datajson/datajson-15-nonstring-ipv6/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datarep-01/meta.yaml
+++ b/tests/datarep-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp, vlan]

--- a/tests/datarep-02/meta.yaml
+++ b/tests/datarep-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp, vlan]

--- a/tests/datarep-03-bad-reputation/meta.yaml
+++ b/tests/datarep-03-bad-reputation/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/dataset-hash-collisions/meta.yaml
+++ b/tests/dataset-hash-collisions/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datasets-01/meta.yaml
+++ b/tests/datasets-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datasets-02-load/meta.yaml
+++ b/tests/datasets-02-load/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datasets-03-set/meta.yaml
+++ b/tests/datasets-03-set/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp, vlan]

--- a/tests/datasets-04-http-dns/meta.yaml
+++ b/tests/datasets-04-http-dns/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, http, ip, tcp, udp, vlan]

--- a/tests/datasets-05-state/meta.yaml
+++ b/tests/datasets-05-state/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp, vlan]

--- a/tests/datasets-06-state-long/meta.yaml
+++ b/tests/datasets-06-state-long/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp, vlan]

--- a/tests/datasets-07-state-ip/meta.yaml
+++ b/tests/datasets-07-state-ip/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp, vlan]

--- a/tests/datasets-08-state-ipv6/meta.yaml
+++ b/tests/datasets-08-state-ipv6/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ipv6, udp, vlan]

--- a/tests/datasets-09-load/meta.yaml
+++ b/tests/datasets-09-load/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datasets-10-unset/meta.yaml
+++ b/tests/datasets-10-unset/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, ip, 'null', tcp]

--- a/tests/datasets-11-longstring/meta.yaml
+++ b/tests/datasets-11-longstring/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, http, ip, 'null', tcp]

--- a/tests/datasets-1m-StringSets/meta.yaml
+++ b/tests/datasets-1m-StringSets/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datasets-bug-5109/meta.yaml
+++ b/tests/datasets-bug-5109/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datasets-invalid-encoding/meta.yaml
+++ b/tests/datasets-invalid-encoding/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datasets-match-subdomain/meta.yaml
+++ b/tests/datasets-match-subdomain/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/datasets-memcap-01/meta.yaml
+++ b/tests/datasets-memcap-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datasets-memcap-02/meta.yaml
+++ b/tests/datasets-memcap-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datasets-pcrexform/meta.yaml
+++ b/tests/datasets-pcrexform/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, ip, 'null', tcp]

--- a/tests/datasets-state-isnotset/meta.yaml
+++ b/tests/datasets-state-isnotset/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp, vlan]

--- a/tests/datasets/datarep-bad-datarep-string/meta.yaml
+++ b/tests/datasets/datarep-bad-datarep-string/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datasets/datarep-bad-datarep-value/meta.yaml
+++ b/tests/datasets/datarep-bad-datarep-value/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datasets/datarep-datasets-mix/meta.yaml
+++ b/tests/datasets/datarep-datasets-mix/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datasets/datasets-absolute-allowed-pre8/meta.yaml
+++ b/tests/datasets/datasets-absolute-allowed-pre8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/datasets/datasets-absolute-allowed-winonly/meta.yaml
+++ b/tests/datasets/datasets-absolute-allowed-winonly/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/datasets/datasets-absolute-allowed/meta.yaml
+++ b/tests/datasets/datasets-absolute-allowed/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/datasets/datasets-absolute-path/meta.yaml
+++ b/tests/datasets/datasets-absolute-path/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/datasets/datasets-datarep-mix/meta.yaml
+++ b/tests/datasets/datasets-datarep-mix/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/datasets/datasets-deny-save/meta.yaml
+++ b/tests/datasets/datasets-deny-save/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/datasets/datasets-load-save-absolute/meta.yaml
+++ b/tests/datasets/datasets-load-save-absolute/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp, vlan]

--- a/tests/datasets/datasets-lua-01/meta.yaml
+++ b/tests/datasets/datasets-lua-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dns, eth, http, icmp, ip, logotypecertextn, ocsp, pkix1explicit, pkix1implicit, pkixalgs, ssh, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/datasets/datasets-lua-02/meta.yaml
+++ b/tests/datasets/datasets-lua-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dns, eth, http, icmp, ip, logotypecertextn, ocsp, pkix1explicit, pkix1implicit, pkixalgs, ssh, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/datasets/datasets-parent-path/meta.yaml
+++ b/tests/datasets/datasets-parent-path/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/datasets/datasets-set-ip/meta.yaml
+++ b/tests/datasets/datasets-set-ip/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, snmp, udp]

--- a/tests/dcerpc-issue-7187-01/meta.yaml
+++ b/tests/dcerpc-issue-7187-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, ip, tcp]

--- a/tests/dcerpc-request-http-response/meta.yaml
+++ b/tests/dcerpc-request-http-response/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp, vlan]

--- a/tests/dcerpc-smb-fail/meta.yaml
+++ b/tests/dcerpc-smb-fail/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, dcerpc, dns, eth, gss-api, igmp, ip, llmnr, nbns, nbss, ntlmssp, smb, spnego, ssdp, tcp, udp]

--- a/tests/dcerpc-smb-test-01/meta.yaml
+++ b/tests/dcerpc-smb-test-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dcerpc, eth, gss-api, ip, nbss, smb, spnego, spnego-krb5, tcp]

--- a/tests/dcerpc/dce-gap-handling/meta.yaml
+++ b/tests/dcerpc/dce-gap-handling/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, ip, spnego, spnego-krb5, tcp]

--- a/tests/dcerpc/dce-logging/meta.yaml
+++ b/tests/dcerpc/dce-logging/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, ip, tcp]

--- a/tests/dcerpc/dcerpc-3109/meta.yaml
+++ b/tests/dcerpc/dcerpc-3109/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, ip, nbss, smb, tcp]

--- a/tests/dcerpc/dcerpc-auth3-5133/meta.yaml
+++ b/tests/dcerpc/dcerpc-auth3-5133/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, ip, tcp]

--- a/tests/dcerpc/dcerpc-bind-no-frag-flag/meta.yaml
+++ b/tests/dcerpc/dcerpc-bind-no-frag-flag/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/dcerpc/dcerpc-ctxids/meta.yaml
+++ b/tests/dcerpc/dcerpc-ctxids/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, gss-api, ip, krb5, nbss, ntlmssp, smb, spnego, spnego-krb5, tcp]

--- a/tests/dcerpc/dcerpc-dce-iface-01/meta.yaml
+++ b/tests/dcerpc/dcerpc-dce-iface-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, ip, spnego, spnego-krb5, tcp]

--- a/tests/dcerpc/dcerpc-dce-iface-02/meta.yaml
+++ b/tests/dcerpc/dcerpc-dce-iface-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, ip, tcp]

--- a/tests/dcerpc/dcerpc-dce-iface-03/meta.yaml
+++ b/tests/dcerpc/dcerpc-dce-iface-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, ip, tcp]

--- a/tests/dcerpc/dcerpc-dce-iface-04/meta.yaml
+++ b/tests/dcerpc/dcerpc-dce-iface-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, ip, tcp]

--- a/tests/dcerpc/dcerpc-dce-iface-many/meta.yaml
+++ b/tests/dcerpc/dcerpc-dce-iface-many/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, ip, tcp]

--- a/tests/dcerpc/dcerpc-dce-opnum/meta.yaml
+++ b/tests/dcerpc/dcerpc-dce-opnum/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, ip, tcp]

--- a/tests/dcerpc/dcerpc-dce-stub-data-02/meta.yaml
+++ b/tests/dcerpc/dcerpc-dce-stub-data-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, ip, raw, tcp]

--- a/tests/dcerpc/dcerpc-dce-stub-data-03/meta.yaml
+++ b/tests/dcerpc/dcerpc-dce-stub-data-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, ip, raw, tcp]

--- a/tests/dcerpc/dcerpc-dce-stub-data-04/meta.yaml
+++ b/tests/dcerpc/dcerpc-dce-stub-data-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, ip, raw, tcp]

--- a/tests/dcerpc/dcerpc-dce-stub-data-05/meta.yaml
+++ b/tests/dcerpc/dcerpc-dce-stub-data-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, ip, raw, tcp]

--- a/tests/dcerpc/dcerpc-dce-stub-data-06/meta.yaml
+++ b/tests/dcerpc/dcerpc-dce-stub-data-06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/dcerpc/dcerpc-dce-stub-data/meta.yaml
+++ b/tests/dcerpc/dcerpc-dce-stub-data/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, ip, tcp]

--- a/tests/dcerpc/dcerpc-dcepayload-15/meta.yaml
+++ b/tests/dcerpc/dcerpc-dcepayload-15/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, ip, raw, tcp]

--- a/tests/dcerpc/dcerpc-dcepayload-16/meta.yaml
+++ b/tests/dcerpc/dcerpc-dcepayload-16/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, ip, raw, tcp]

--- a/tests/dcerpc/dcerpc-dcepayload-17/meta.yaml
+++ b/tests/dcerpc/dcerpc-dcepayload-17/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, ip, raw, tcp]

--- a/tests/dcerpc/dcerpc-dcepayload-18/meta.yaml
+++ b/tests/dcerpc/dcerpc-dcepayload-18/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, ip, raw, tcp]

--- a/tests/dcerpc/dcerpc-dcepayload-19/meta.yaml
+++ b/tests/dcerpc/dcerpc-dcepayload-19/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, ip, raw, tcp]

--- a/tests/dcerpc/dcerpc-dcepayload-20/meta.yaml
+++ b/tests/dcerpc/dcerpc-dcepayload-20/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, ip, raw, tcp]

--- a/tests/dcerpc/dcerpc-dcepayload/meta.yaml
+++ b/tests/dcerpc/dcerpc-dcepayload/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, ip, tcp]

--- a/tests/dcerpc/dcerpc-frames/meta.yaml
+++ b/tests/dcerpc/dcerpc-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, ip, tcp]

--- a/tests/dcerpc/dcerpc-smb-ctxid/meta.yaml
+++ b/tests/dcerpc/dcerpc-smb-ctxid/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/dcerpc/dcerpc-udp-scapy/meta.yaml
+++ b/tests/dcerpc/dcerpc-udp-scapy/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, ip, udp]

--- a/tests/dcerpc/zerologon/meta.yaml
+++ b/tests/dcerpc/zerologon/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/decode-arp-1/meta.yaml
+++ b/tests/decode-arp-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, eth]

--- a/tests/decode-arp-2/meta.yaml
+++ b/tests/decode-arp-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, eth, icmp, ip]

--- a/tests/decode-arp-3/meta.yaml
+++ b/tests/decode-arp-3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, eth, gre, ip, vlan]

--- a/tests/decode-chdlc-01/meta.yaml
+++ b/tests/decode-chdlc-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [chdlc, data-text-lines, http, ip, tcp]

--- a/tests/decode-chdlc-02/meta.yaml
+++ b/tests/decode-chdlc-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [chdlc, data-text-lines, http, ip, tcp]

--- a/tests/decode-dce/meta.yaml
+++ b/tests/decode-dce/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [cfp, dhcp, eth, ip, ipv6, ospf, udp]

--- a/tests/decode-erspan-typeI-01/meta.yaml
+++ b/tests/decode-erspan-typeI-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, erspan, eth, gre, icmp, ip, vlan]

--- a/tests/decode-erspan-typeI-02/meta.yaml
+++ b/tests/decode-erspan-typeI-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, erspan, eth, gre, icmp, ip, vlan]

--- a/tests/decode-erspan-typeII-01/meta.yaml
+++ b/tests/decode-erspan-typeII-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [cdp, data, erspan, eth, gre, icmp, ip, llc]

--- a/tests/decode-etag-01/meta.yaml
+++ b/tests/decode-etag-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [etag, eth, ip, tcp]

--- a/tests/decode-etag-02/meta.yaml
+++ b/tests/decode-etag-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [etag, eth, ip, tcp]

--- a/tests/decode-nsh-type1/meta.yaml
+++ b/tests/decode-nsh-type1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, nsh, udp]

--- a/tests/decode-nsh-type2/meta.yaml
+++ b/tests/decode-nsh-type2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, nsh, udp]

--- a/tests/decode-sctp-01/meta.yaml
+++ b/tests/decode-sctp-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, sctp]

--- a/tests/decode-sll2-01/meta.yaml
+++ b/tests/decode-sll2-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, sll, tcp]

--- a/tests/decode-sll2-02/meta.yaml
+++ b/tests/decode-sll2-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, http, ip, sll, tcp]

--- a/tests/decode-teredo-01/meta.yaml
+++ b/tests/decode-teredo-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data, data-text-lines, dhcp, dns, eth, http, icmpv6, ip, ipv6, media, nbdgm, nbns, smb, tcp, teredo, udp, xml]

--- a/tests/decode-too-many-layers/meta.yaml
+++ b/tests/decode-too-many-layers/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, mpls, pwethcw]

--- a/tests/decode-too-small/meta.yaml
+++ b/tests/decode-too-small/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, gre, ip, ipv6, tcp, udp]

--- a/tests/decode-unknown-1/meta.yaml
+++ b/tests/decode-unknown-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth]

--- a/tests/decode-unknown-2/meta.yaml
+++ b/tests/decode-unknown-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth]

--- a/tests/decode-vntag-01/meta.yaml
+++ b/tests/decode-vntag-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, vlan, vntag]

--- a/tests/decode-vntag-02/meta.yaml
+++ b/tests/decode-vntag-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, vlan, vntag]

--- a/tests/defrag/bug-6887-defrag-eth-vlan-ipv4-tcp-syn/meta.yaml
+++ b/tests/defrag/bug-6887-defrag-eth-vlan-ipv4-tcp-syn/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, vlan]

--- a/tests/defrag/bug-6887-defrag-eth-vlan-ipv6-tcp/meta.yaml
+++ b/tests/defrag/bug-6887-defrag-eth-vlan-ipv6-tcp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ipv6, ipv6.fraghdr, tcp, vlan]

--- a/tests/defrag/bug-6887-defrag-ipv4-tcp-syn/meta.yaml
+++ b/tests/defrag/bug-6887-defrag-ipv4-tcp-syn/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, raw, tcp]

--- a/tests/defrag/bug-6887-defrag-ipv6-tcp/meta.yaml
+++ b/tests/defrag/bug-6887-defrag-ipv6-tcp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ipv6, ipv6.fraghdr, raw, tcp]

--- a/tests/defrag/bug-6887-defrag-ppp-ipv4-tcp-syn/meta.yaml
+++ b/tests/defrag/bug-6887-defrag-ppp-ipv4-tcp-syn/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, ppp, tcp]

--- a/tests/defrag/bug-6887-defrag-ppp-ipv6-tcp/meta.yaml
+++ b/tests/defrag/bug-6887-defrag-ppp-ipv6-tcp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ipv6, ipv6.fraghdr, ppp, tcp]

--- a/tests/defrag/bug-6942-6887-defrag-eth-ip-gre-ppp-ip-udp-data/meta.yaml
+++ b/tests/defrag/bug-6942-6887-defrag-eth-ip-gre-ppp-ip-udp-data/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, gre, ip, ppp, udp]

--- a/tests/derive-counter-01/meta.yaml
+++ b/tests/derive-counter-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp, tls]

--- a/tests/detect-absent-file-multi/meta.yaml
+++ b/tests/detect-absent-file-multi/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/detect-absent-http-request-body/meta.yaml
+++ b/tests/detect-absent-http-request-body/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, ip, 'null', tcp]

--- a/tests/detect-absent-negated-content/meta.yaml
+++ b/tests/detect-absent-negated-content/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/detect-app-layer-protocol-01/meta.yaml
+++ b/tests/detect-app-layer-protocol-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-app-layer-protocol-02/meta.yaml
+++ b/tests/detect-app-layer-protocol-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-app-layer-protocol-03/meta.yaml
+++ b/tests/detect-app-layer-protocol-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/detect-app-layer-protocol-04/meta.yaml
+++ b/tests/detect-app-layer-protocol-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, http2, ip, tcp]

--- a/tests/detect-app-layer-protocol-05/meta.yaml
+++ b/tests/detect-app-layer-protocol-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/detect-app-layer-state-01/meta.yaml
+++ b/tests/detect-app-layer-state-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/detect-bidir-flowbits/meta.yaml
+++ b/tests/detect-bidir-flowbits/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, ip, 'null', tcp, urlencoded-form]

--- a/tests/detect-bidir-impossible/meta.yaml
+++ b/tests/detect-bidir-impossible/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/detect-bidir-ja3/meta.yaml
+++ b/tests/detect-bidir-ja3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/detect-bidir/meta.yaml
+++ b/tests/detect-bidir/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/detect-bsize-0/meta.yaml
+++ b/tests/detect-bsize-0/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, ip, 'null', tcp]

--- a/tests/detect-bsize-01/meta.yaml
+++ b/tests/detect-bsize-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/detect-bypass-udp/meta.yaml
+++ b/tests/detect-bypass-udp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ike, ip, udp, udpencap]

--- a/tests/detect-bypass/meta.yaml
+++ b/tests/detect-bypass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, vlan]

--- a/tests/detect-bytejump-01/meta.yaml
+++ b/tests/detect-bytejump-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp]

--- a/tests/detect-bytejump-02/meta.yaml
+++ b/tests/detect-bytejump-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp]

--- a/tests/detect-bytejump-03/meta.yaml
+++ b/tests/detect-bytejump-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/detect-bytejump-05/meta.yaml
+++ b/tests/detect-bytejump-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp]

--- a/tests/detect-bytejump-06/meta.yaml
+++ b/tests/detect-bytejump-06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp]

--- a/tests/detect-bytejump-07/meta.yaml
+++ b/tests/detect-bytejump-07/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/detect-bytemath-01/meta.yaml
+++ b/tests/detect-bytemath-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp]

--- a/tests/detect-bytemath-02/meta.yaml
+++ b/tests/detect-bytemath-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/detect-bytemath-05/meta.yaml
+++ b/tests/detect-bytemath-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp]

--- a/tests/detect-bytemath-06/meta.yaml
+++ b/tests/detect-bytemath-06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/detect-bytemath-add-04/meta.yaml
+++ b/tests/detect-bytemath-add-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp]

--- a/tests/detect-bytemath-div-01/meta.yaml
+++ b/tests/detect-bytemath-div-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp]

--- a/tests/detect-bytemath-mult-04/meta.yaml
+++ b/tests/detect-bytemath-mult-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp]

--- a/tests/detect-bytemath-sub-03/meta.yaml
+++ b/tests/detect-bytemath-sub-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp]

--- a/tests/detect-bytetest-01/meta.yaml
+++ b/tests/detect-bytetest-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-bytetest-02/meta.yaml
+++ b/tests/detect-bytetest-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, tcp, vlan]

--- a/tests/detect-bytetest-03/meta.yaml
+++ b/tests/detect-bytetest-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp, vlan]

--- a/tests/detect-bytetest-04/meta.yaml
+++ b/tests/detect-bytetest-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp, vlan]

--- a/tests/detect-bytetest-05/meta.yaml
+++ b/tests/detect-bytetest-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp, vlan]

--- a/tests/detect-chksum-01/meta.yaml
+++ b/tests/detect-chksum-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-chksum-02/meta.yaml
+++ b/tests/detect-chksum-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-compress_whitespace-01/meta.yaml
+++ b/tests/detect-compress_whitespace-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/detect-compress_whitespace-02/meta.yaml
+++ b/tests/detect-compress_whitespace-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/detect-content-ends-with-negated-01/meta.yaml
+++ b/tests/detect-content-ends-with-negated-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/detect-content-ends-with-negated-02/meta.yaml
+++ b/tests/detect-content-ends-with-negated-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/detect-content-ends-with-negated-03/meta.yaml
+++ b/tests/detect-content-ends-with-negated-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/detect-content-strip-whitespace-01/meta.yaml
+++ b/tests/detect-content-strip-whitespace-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/detect-dotprefix-01/meta.yaml
+++ b/tests/detect-dotprefix-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/detect-dotprefix-02/meta.yaml
+++ b/tests/detect-dotprefix-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/detect-dotprefix-03/meta.yaml
+++ b/tests/detect-dotprefix-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/detect-email-body_md5-auto/meta.yaml
+++ b/tests/detect-email-body_md5-auto/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data-text-lines, dns, eth, icmp, ip, nbdgm, smb, smtp, tcp, udp]

--- a/tests/detect-email-body_md5-disabled/meta.yaml
+++ b/tests/detect-email-body_md5-disabled/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data-text-lines, dns, eth, icmp, ip, nbdgm, smb, smtp, tcp, udp]

--- a/tests/detect-email-body_md5/meta.yaml
+++ b/tests/detect-email-body_md5/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data-text-lines, dns, eth, icmp, ip, nbdgm, smb, smtp, tcp, udp]

--- a/tests/detect-email-cc/meta.yaml
+++ b/tests/detect-email-cc/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ip, smtp, tcp]

--- a/tests/detect-email-date/meta.yaml
+++ b/tests/detect-email-date/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/detect-email-from/meta.yaml
+++ b/tests/detect-email-from/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/detect-email-msg-id/meta.yaml
+++ b/tests/detect-email-msg-id/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, smtp, tcp]

--- a/tests/detect-email-received/meta.yaml
+++ b/tests/detect-email-received/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ip, smtp, tcp]

--- a/tests/detect-email-subject/meta.yaml
+++ b/tests/detect-email-subject/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/detect-email-to/meta.yaml
+++ b/tests/detect-email-to/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/detect-email-url/meta.yaml
+++ b/tests/detect-email-url/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, smtp, tcp]

--- a/tests/detect-email-x-mailer/meta.yaml
+++ b/tests/detect-email-x-mailer/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, ip, smtp, tcp]

--- a/tests/detect-engine-proto/meta.yaml
+++ b/tests/detect-engine-proto/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-filestore-config-01/meta.yaml
+++ b/tests/detect-filestore-config-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/detect-filestore-config-02/meta.yaml
+++ b/tests/detect-filestore-config-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/detect-filestore-config-03/meta.yaml
+++ b/tests/detect-filestore-config-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, icmp, ip, raw]

--- a/tests/detect-filestore-config-04/meta.yaml
+++ b/tests/detect-filestore-config-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, icmp, ip, raw]

--- a/tests/detect-flow-pkts-either/meta.yaml
+++ b/tests/detect-flow-pkts-either/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data, data-text-lines, dhcp, dns, eth, http, icmpv6, ip, ipv6, media, nbdgm, nbns, smb, tcp, teredo, udp, xml]

--- a/tests/detect-flow-pkts/meta.yaml
+++ b/tests/detect-flow-pkts/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data, data-text-lines, dhcp, dns, eth, http, icmpv6, ip, ipv6, media, nbdgm, nbns, smb, tcp, teredo, udp, xml]

--- a/tests/detect-flowbits/meta.yaml
+++ b/tests/detect-flowbits/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp, vlan]

--- a/tests/detect-ftp/ftp-active-dynamic_port-01/meta.yaml
+++ b/tests/detect-ftp/ftp-active-dynamic_port-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/detect-ftp/ftp-active-dynamic_port-02/meta.yaml
+++ b/tests/detect-ftp/ftp-active-dynamic_port-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/detect-ftp/ftp-command-01/meta.yaml
+++ b/tests/detect-ftp/ftp-command-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/detect-ftp/ftp-command-02/meta.yaml
+++ b/tests/detect-ftp/ftp-command-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/detect-ftp/ftp-command-data-01/meta.yaml
+++ b/tests/detect-ftp/ftp-command-data-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/detect-ftp/ftp-completion-code-01/meta.yaml
+++ b/tests/detect-ftp/ftp-completion-code-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/detect-ftp/ftp-mode-01/meta.yaml
+++ b/tests/detect-ftp/ftp-mode-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/detect-ftp/ftp-mode-02/meta.yaml
+++ b/tests/detect-ftp/ftp-mode-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/detect-ftp/ftp-mode-03/meta.yaml
+++ b/tests/detect-ftp/ftp-mode-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/detect-ftp/ftp-passive-dynamic_port-01/meta.yaml
+++ b/tests/detect-ftp/ftp-passive-dynamic_port-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/detect-ftp/ftp-passive-dynamic_port-02/meta.yaml
+++ b/tests/detect-ftp/ftp-passive-dynamic_port-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/detect-ftp/ftp-reply-01/meta.yaml
+++ b/tests/detect-ftp/ftp-reply-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/detect-ftp/ftp-reply-received-01/meta.yaml
+++ b/tests/detect-ftp/ftp-reply-received-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/detect-ftp/ftp-reply-received-02/meta.yaml
+++ b/tests/detect-ftp/ftp-reply-received-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/detect-ftp/ftp-reply-received-03/meta.yaml
+++ b/tests/detect-ftp/ftp-reply-received-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/detect-hostbits/detect-hostbits-01/meta.yaml
+++ b/tests/detect-hostbits/detect-hostbits-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp, vlan]

--- a/tests/detect-hostbits/detect-hostbits-02/meta.yaml
+++ b/tests/detect-hostbits/detect-hostbits-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp, vlan]

--- a/tests/detect-hostbits/detect-hostbits-03/meta.yaml
+++ b/tests/detect-hostbits/detect-hostbits-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp, vlan]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest01/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest02/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest03/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest04/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest05/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest06/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest07/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest07/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest08/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest08/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest09/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest09/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest10/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest10/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest11/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest11/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest12/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest12/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest13/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest13/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest14/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest14/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest15/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest15/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest16/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest16/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest21/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest21/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest22/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest22/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest23/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest23/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest24/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest24/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest25/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest25/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest26/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest26/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest27/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest27/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest28/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest28/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest29/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest29/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/DetectEngineHttpRawUriTest30/meta.yaml
+++ b/tests/detect-http-uri/DetectEngineHttpRawUriTest30/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig01/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig02/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig03/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig04/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig05/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig06/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig07/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig07/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig08/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig08/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig09/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig09/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig12/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig12/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig13/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig13/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig14/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig14/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig15/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig15/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig16/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig16/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig17/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig17/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig18/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig18/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig19/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig19/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig20/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig20/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig21/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig21/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig22/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig22/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig23/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig23/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig24/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig24/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig25/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig25/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig26/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig26/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig27/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig27/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig28/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig28/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig29/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig29/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig30/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig30/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig31/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig31/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig32/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig32/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig33/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig33/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig34/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig34/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig35/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig35/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig36/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig36/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig37/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig37/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-http-uri/UriTestSig38/meta.yaml
+++ b/tests/detect-http-uri/UriTestSig38/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp]

--- a/tests/detect-icmp-id-01/meta.yaml
+++ b/tests/detect-icmp-id-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, icmp, ip]

--- a/tests/detect-icmp-id-02/meta.yaml
+++ b/tests/detect-icmp-id-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, icmp, ip]

--- a/tests/detect-icmp-seq/meta.yaml
+++ b/tests/detect-icmp-seq/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, icmp, ip]

--- a/tests/detect-ip_proto-01/meta.yaml
+++ b/tests/detect-ip_proto-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/detect-ipopts-02/meta.yaml
+++ b/tests/detect-ipopts-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp]

--- a/tests/detect-ipopts/meta.yaml
+++ b/tests/detect-ipopts/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp]

--- a/tests/detect-itype-prefilter/meta.yaml
+++ b/tests/detect-itype-prefilter/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/detect-itype/meta.yaml
+++ b/tests/detect-itype/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/detect-ldap-attribute/meta.yaml
+++ b/tests/detect-ldap-attribute/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, tcp]

--- a/tests/detect-ldap-dn/meta.yaml
+++ b/tests/detect-ldap-dn/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, tcp]

--- a/tests/detect-ldap-operation/meta.yaml
+++ b/tests/detect-ldap-operation/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, tcp]

--- a/tests/detect-ldap-result/meta.yaml
+++ b/tests/detect-ldap-result/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, tcp]

--- a/tests/detect-pcre/detect-pcre-01/meta.yaml
+++ b/tests/detect-pcre/detect-pcre-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, vlan]

--- a/tests/detect-pcre/detect-pcre-02/meta.yaml
+++ b/tests/detect-pcre/detect-pcre-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, http, ip, sll, tcp]

--- a/tests/detect-pcre/detect-pcre-03/meta.yaml
+++ b/tests/detect-pcre/detect-pcre-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp, vlan]

--- a/tests/detect-pcre/detect-pcre-04/meta.yaml
+++ b/tests/detect-pcre/detect-pcre-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, tcp, vlan]

--- a/tests/detect-pcre/detect-pcre-05/meta.yaml
+++ b/tests/detect-pcre/detect-pcre-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, tcp, vlan]

--- a/tests/detect-pcre/detect-pcre-06/meta.yaml
+++ b/tests/detect-pcre/detect-pcre-06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, tcp, vlan]

--- a/tests/detect-pcrexform-01/meta.yaml
+++ b/tests/detect-pcrexform-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/detect-pcrexform-02/meta.yaml
+++ b/tests/detect-pcrexform-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/detect-pcrexform-04/meta.yaml
+++ b/tests/detect-pcrexform-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/detect-pcrexform-05/meta.yaml
+++ b/tests/detect-pcrexform-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/detect-pcrexform-06/meta.yaml
+++ b/tests/detect-pcrexform-06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/detect-strip_whitespace-01/meta.yaml
+++ b/tests/detect-strip_whitespace-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/detect-strip_whitespace-02/meta.yaml
+++ b/tests/detect-strip_whitespace-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/detect-to_lowercase-01/meta.yaml
+++ b/tests/detect-to_lowercase-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/detect-to_lowercase-02/meta.yaml
+++ b/tests/detect-to_lowercase-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/detect-to_uppercase-01/meta.yaml
+++ b/tests/detect-to_uppercase-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/detect-to_uppercase-02/meta.yaml
+++ b/tests/detect-to_uppercase-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/detect-ttl-ipv6/meta.yaml
+++ b/tests/detect-ttl-ipv6/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, icmpv6, ipv6, ipv6.dstopts]

--- a/tests/detect-ttl/meta.yaml
+++ b/tests/detect-ttl/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, rfb, tcp]

--- a/tests/detect-udp-flow-rule-01/meta.yaml
+++ b/tests/detect-udp-flow-rule-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sdp, sip, udp]

--- a/tests/detect-udp-flow-rule-02-ips/meta.yaml
+++ b/tests/detect-udp-flow-rule-02-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sdp, sip, udp]

--- a/tests/detect-udp-flow-rule-02/meta.yaml
+++ b/tests/detect-udp-flow-rule-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sdp, sip, udp]

--- a/tests/detect-vlan-id/meta.yaml
+++ b/tests/detect-vlan-id/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, icmp, ip, vlan]

--- a/tests/detect-vlan-layers/meta.yaml
+++ b/tests/detect-vlan-layers/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, icmp, ip, vlan]

--- a/tests/detect-xor-key/detect-xor-key-01/meta.yaml
+++ b/tests/detect-xor-key/detect-xor-key-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-xor-key/detect-xor-key-02/meta.yaml
+++ b/tests/detect-xor-key/detect-xor-key-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-xor-key/detect-xor-key-03/meta.yaml
+++ b/tests/detect-xor-key/detect-xor-key-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-xor-key/detect-xor-key-04/meta.yaml
+++ b/tests/detect-xor-key/detect-xor-key-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-xor-key/detect-xor-key-05/meta.yaml
+++ b/tests/detect-xor-key/detect-xor-key-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-xor-key/detect-xor-key-06/meta.yaml
+++ b/tests/detect-xor-key/detect-xor-key-06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-xor-key/detect-xor-key-07/meta.yaml
+++ b/tests/detect-xor-key/detect-xor-key-07/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-xor-key/detect-xor-key-08/meta.yaml
+++ b/tests/detect-xor-key/detect-xor-key-08/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-xor-key/detect-xor-key-09/meta.yaml
+++ b/tests/detect-xor-key/detect-xor-key-09/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-xor-key/detect-xor-key-10/meta.yaml
+++ b/tests/detect-xor-key/detect-xor-key-10/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-xor-key/detect-xor-key-11/meta.yaml
+++ b/tests/detect-xor-key/detect-xor-key-11/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-xor-key/detect-xor-key-12/meta.yaml
+++ b/tests/detect-xor-key/detect-xor-key-12/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-xor-key/detect-xor-key-13/meta.yaml
+++ b/tests/detect-xor-key/detect-xor-key-13/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-xor-key/detect-xor-key-14/meta.yaml
+++ b/tests/detect-xor-key/detect-xor-key-14/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-xor-key/detect-xor-key-15/meta.yaml
+++ b/tests/detect-xor-key/detect-xor-key-15/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-xor-key/detect-xor-key-16/meta.yaml
+++ b/tests/detect-xor-key/detect-xor-key-16/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/detect-xor/meta.yaml
+++ b/tests/detect-xor/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, ip, 'null', tcp]

--- a/tests/detection_filter-distinct-dstport-no-dups/meta.yaml
+++ b/tests/detection_filter-distinct-dstport-no-dups/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/detection_filter-distinct-dstport/meta.yaml
+++ b/tests/detection_filter-distinct-dstport/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/detection_filter-distinct-srcport-no-dups/meta.yaml
+++ b/tests/detection_filter-distinct-srcport-no-dups/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/detection_filter-distinct-srcport/meta.yaml
+++ b/tests/detection_filter-distinct-srcport/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/dhcp-eve-extended-option-60/meta.yaml
+++ b/tests/dhcp-eve-extended-option-60/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dhcp, eth, ip, udp]

--- a/tests/dhcp-eve-extended/meta.yaml
+++ b/tests/dhcp-eve-extended/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dhcp, eth, ip, udp]

--- a/tests/dhcp-option-52-overload-both/meta.yaml
+++ b/tests/dhcp-option-52-overload-both/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dhcp, eth, ip, udp]

--- a/tests/dhcp-option-52-overload/meta.yaml
+++ b/tests/dhcp-option-52-overload/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dhcp, eth, ip, udp]

--- a/tests/dhcp-request-flood/meta.yaml
+++ b/tests/dhcp-request-flood/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dhcp, eth, ip, udp]

--- a/tests/dnp3/dnp3-del-measure/meta.yaml
+++ b/tests/dnp3/dnp3-del-measure/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dnp3/dnp3-dnp3_data-alert/meta.yaml
+++ b/tests/dnp3/dnp3-dnp3_data-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dnp3/dnp3-dnp3_func-alert/meta.yaml
+++ b/tests/dnp3/dnp3-dnp3_func-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dnp3/dnp3-dnp3_obj-alert/meta.yaml
+++ b/tests/dnp3/dnp3-dnp3_obj-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dnp3/dnp3-en-spon/meta.yaml
+++ b/tests/dnp3/dnp3-en-spon/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dnp3/dnp3-eve/meta.yaml
+++ b/tests/dnp3/dnp3-eve/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dnp3/dnp3-file-del/meta.yaml
+++ b/tests/dnp3/dnp3-file-del/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dnp3/dnp3-file-read/meta.yaml
+++ b/tests/dnp3/dnp3-file-read/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dnp3/dnp3-file-write/meta.yaml
+++ b/tests/dnp3/dnp3-file-write/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dnp3/dnp3-flood/meta.yaml
+++ b/tests/dnp3/dnp3-flood/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, ip, raw, tcp]

--- a/tests/dnp3/dnp3-ind-keyword/meta.yaml
+++ b/tests/dnp3/dnp3-ind-keyword/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dnp3/dnp3-lua/meta.yaml
+++ b/tests/dnp3/dnp3-lua/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dnp3/dnp3-max-objects/meta.yaml
+++ b/tests/dnp3/dnp3-max-objects/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dnp3/dnp3-max-points/meta.yaml
+++ b/tests/dnp3/dnp3-max-points/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dnp3/dnp3-select-operate/meta.yaml
+++ b/tests/dnp3/dnp3-select-operate/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dnp3/dnp3-toclient-start/meta.yaml
+++ b/tests/dnp3/dnp3-toclient-start/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dnp3/dnp3-too-long-reassembly-request/meta.yaml
+++ b/tests/dnp3/dnp3-too-long-reassembly-request/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dnp3/dnp3-too-long-reassembly-response/meta.yaml
+++ b/tests/dnp3/dnp3-too-long-reassembly-response/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dnp3/dnp3-write/meta.yaml
+++ b/tests/dnp3/dnp3-write/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dnp3, eth, ip, tcp]

--- a/tests/dns-eve-type-filtering/meta.yaml
+++ b/tests/dns-eve-type-filtering/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns-eve-v2-udp-nxdomain-soa/meta.yaml
+++ b/tests/dns-eve-v2-udp-nxdomain-soa/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns-lua-rules-pre8/meta.yaml
+++ b/tests/dns-lua-rules-pre8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns-lua-rules/meta.yaml
+++ b/tests/dns-lua-rules/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns-opcode/meta.yaml
+++ b/tests/dns-opcode/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns-over-http2-limit/meta.yaml
+++ b/tests/dns-over-http2-limit/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, dns, http, http2, ip, 'null', tcp]

--- a/tests/dns-over-http2-post/meta.yaml
+++ b/tests/dns-over-http2-post/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, http, http2, ip, tcp]

--- a/tests/dns-over-http2-progress/meta.yaml
+++ b/tests/dns-over-http2-progress/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, http, http2, ip, tcp]

--- a/tests/dns-over-http2/meta.yaml
+++ b/tests/dns-over-http2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, http, http2, ip, tcp]

--- a/tests/dns-reversed-tcp-1/meta.yaml
+++ b/tests/dns-reversed-tcp-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp]

--- a/tests/dns-reversed-udp-1/meta.yaml
+++ b/tests/dns-reversed-udp-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns-tcp-ts-gap/meta.yaml
+++ b/tests/dns-tcp-ts-gap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp]

--- a/tests/dns-udp-junkrequest-first/meta.yaml
+++ b/tests/dns-udp-junkrequest-first/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns-udp-nxdomain-soa/meta.yaml
+++ b/tests/dns-udp-nxdomain-soa/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns-udp-z-flag-fp/meta.yaml
+++ b/tests/dns-udp-z-flag-fp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/bug-1158/meta.yaml
+++ b/tests/dns/bug-1158/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, nbns, udp]

--- a/tests/dns/bug-856/meta.yaml
+++ b/tests/dns/bug-856/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/bug-990/meta.yaml
+++ b/tests/dns/bug-990/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-additionals-rdata/meta.yaml
+++ b/tests/dns/dns-additionals-rdata/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, ip, raw, udp]

--- a/tests/dns/dns-additionals-rrname/meta.yaml
+++ b/tests/dns/dns-additionals-rrname/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-answer-emptydata/meta.yaml
+++ b/tests/dns/dns-answer-emptydata/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, gss-api, ip, 'null', spnego-krb5, tcp]

--- a/tests/dns/dns-answer-name/meta.yaml
+++ b/tests/dns/dns-answer-name/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-corrupt-additionals/meta.yaml
+++ b/tests/dns/dns-corrupt-additionals/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, ip, raw, udp]

--- a/tests/dns/dns-dcerpc-reversed/meta.yaml
+++ b/tests/dns/dns-dcerpc-reversed/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp, vlan]

--- a/tests/dns/dns-eve-empty-format/meta.yaml
+++ b/tests/dns/dns-eve-empty-format/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-eve-log-https-only/meta.yaml
+++ b/tests/dns/dns-eve-log-https-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-eve/meta.yaml
+++ b/tests/dns/dns-eve/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-forward-pointer/meta.yaml
+++ b/tests/dns/dns-forward-pointer/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-frames/meta.yaml
+++ b/tests/dns/dns-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp, udp]

--- a/tests/dns/dns-incomplete/meta.yaml
+++ b/tests/dns/dns-incomplete/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, ip, 'null', tcp]

--- a/tests/dns/dns-invalid-opcode/meta.yaml
+++ b/tests/dns/dns-invalid-opcode/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-ptr/meta.yaml
+++ b/tests/dns/dns-ptr/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-query-name/meta.yaml
+++ b/tests/dns/dns-query-name/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-query/dns-detect-query-01/meta.yaml
+++ b/tests/dns/dns-query/dns-detect-query-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-query/dns-detect-query-02/meta.yaml
+++ b/tests/dns/dns-query/dns-detect-query-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-query/dns-detect-query-03/meta.yaml
+++ b/tests/dns/dns-query/dns-detect-query-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp]

--- a/tests/dns/dns-query/dns-detect-query-04/meta.yaml
+++ b/tests/dns/dns-query/dns-detect-query-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-query/dns-detect-query-05/meta.yaml
+++ b/tests/dns/dns-query/dns-detect-query-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-rcode/meta.yaml
+++ b/tests/dns/dns-rcode/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-response-mx/meta.yaml
+++ b/tests/dns/dns-response-mx/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-response-rrname-sticky-buffer/meta.yaml
+++ b/tests/dns/dns-response-rrname-sticky-buffer/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-rrtype-index/meta.yaml
+++ b/tests/dns/dns-rrtype-index/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-rrtype/meta.yaml
+++ b/tests/dns/dns-rrtype/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-single-request/meta.yaml
+++ b/tests/dns/dns-single-request/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-sshfp/meta.yaml
+++ b/tests/dns/dns-sshfp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-tcp-multirequest-buffer/meta.yaml
+++ b/tests/dns/dns-tcp-multirequest-buffer/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp]

--- a/tests/dns/dns-tcp-www-google-com/meta.yaml
+++ b/tests/dns/dns-tcp-www-google-com/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp]

--- a/tests/dns/dns-truncated-rname/meta.yaml
+++ b/tests/dns/dns-truncated-rname/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/dns/dns-udp-double-request-response/meta.yaml
+++ b/tests/dns/dns-udp-double-request-response/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-udp-eve-dig/meta.yaml
+++ b/tests/dns/dns-udp-eve-dig/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-udp-eve-log-aaaa-only/meta.yaml
+++ b/tests/dns/dns-udp-eve-log-aaaa-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-udp-eve-log-answer-only/meta.yaml
+++ b/tests/dns/dns-udp-eve-log-answer-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-udp-eve-log-mx-only/meta.yaml
+++ b/tests/dns/dns-udp-eve-log-mx-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-udp-eve-log-query-only/meta.yaml
+++ b/tests/dns/dns-udp-eve-log-query-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-udp-eve-log-srv/meta.yaml
+++ b/tests/dns/dns-udp-eve-log-srv/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, ip, raw, udp]

--- a/tests/dns/dns-udp-eve-txt/meta.yaml
+++ b/tests/dns/dns-udp-eve-txt/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-udp-null/meta.yaml
+++ b/tests/dns/dns-udp-null/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-udp-unsolicited-response/meta.yaml
+++ b/tests/dns/dns-udp-unsolicited-response/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/dns-z-bit/meta.yaml
+++ b/tests/dns/dns-z-bit/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/task-7018-dns-ips-stream-rule/meta.yaml
+++ b/tests/dns/task-7018-dns-ips-stream-rule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp]

--- a/tests/dns/task-7018-ids-dns-keywords/meta.yaml
+++ b/tests/dns/task-7018-ids-dns-keywords/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp]

--- a/tests/dns/task-7018-ids-dns-stream-rule/meta.yaml
+++ b/tests/dns/task-7018-ids-dns-stream-rule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp]

--- a/tests/dns/task-7018-ips-dns-keywords/meta.yaml
+++ b/tests/dns/task-7018-ips-dns-keywords/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp]

--- a/tests/dns/v2/bug-1158/meta.yaml
+++ b/tests/dns/v2/bug-1158/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, nbns, udp]

--- a/tests/dns/v2/bug-856/meta.yaml
+++ b/tests/dns/v2/bug-856/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/v2/bug-990/meta.yaml
+++ b/tests/dns/v2/bug-990/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/v2/dns-eve-log-https-only/meta.yaml
+++ b/tests/dns/v2/dns-eve-log-https-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/v2/dns-eve/meta.yaml
+++ b/tests/dns/v2/dns-eve/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/v2/dns-incomplete/meta.yaml
+++ b/tests/dns/v2/dns-incomplete/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, ip, 'null', tcp]

--- a/tests/dns/v2/dns-invalid-opcode/meta.yaml
+++ b/tests/dns/v2/dns-invalid-opcode/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/v2/dns-single-request/meta.yaml
+++ b/tests/dns/v2/dns-single-request/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/v2/dns-tcp-multirequest-buffer/meta.yaml
+++ b/tests/dns/v2/dns-tcp-multirequest-buffer/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp]

--- a/tests/dns/v2/dns-tcp-www-google-com/meta.yaml
+++ b/tests/dns/v2/dns-tcp-www-google-com/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp]

--- a/tests/dns/v2/dns-udp-double-request-response/meta.yaml
+++ b/tests/dns/v2/dns-udp-double-request-response/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/v2/dns-udp-eve-dig/meta.yaml
+++ b/tests/dns/v2/dns-udp-eve-dig/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/v2/dns-udp-eve-log-aaaa-only/meta.yaml
+++ b/tests/dns/v2/dns-udp-eve-log-aaaa-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/v2/dns-udp-eve-log-answer-only/meta.yaml
+++ b/tests/dns/v2/dns-udp-eve-log-answer-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/v2/dns-udp-eve-log-mx-only/meta.yaml
+++ b/tests/dns/v2/dns-udp-eve-log-mx-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/v2/dns-udp-eve-log-query-only/meta.yaml
+++ b/tests/dns/v2/dns-udp-eve-log-query-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/v2/dns-udp-eve-log-srv/meta.yaml
+++ b/tests/dns/v2/dns-udp-eve-log-srv/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, ip, raw, udp]

--- a/tests/dns/v2/dns-udp-eve-txt/meta.yaml
+++ b/tests/dns/v2/dns-udp-eve-txt/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/v2/dns-udp-null/meta.yaml
+++ b/tests/dns/v2/dns-udp-null/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/v2/dns-udp-unsolicited-response/meta.yaml
+++ b/tests/dns/v2/dns-udp-unsolicited-response/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/dns/v2/dns-z-bit/meta.yaml
+++ b/tests/dns/v2/dns-z-bit/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/domain-keyword/meta.yaml
+++ b/tests/domain-keyword/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/drop-protocol-change/meta.yaml
+++ b/tests/drop-protocol-change/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, http2, ip, tcp]

--- a/tests/dropped-flow-applayer-event-logged-dcerpc/meta.yaml
+++ b/tests/dropped-flow-applayer-event-logged-dcerpc/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, ip, nbss, smb, tcp]

--- a/tests/dropped-flow-applayer-event-logged-http/meta.yaml
+++ b/tests/dropped-flow-applayer-event-logged-http/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/dropped-flow-applayer-event-logged-smb/meta.yaml
+++ b/tests/dropped-flow-applayer-event-logged-smb/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/elephant-flow-detection/meta.yaml
+++ b/tests/elephant-flow-detection/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/elephant-flow-engine-analysis/meta.yaml
+++ b/tests/elephant-flow-engine-analysis/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/elephant-flow-tracking/meta.yaml
+++ b/tests/elephant-flow-tracking/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/engine-state/detect-engine-state-01/meta.yaml
+++ b/tests/engine-state/detect-engine-state-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/engine-state/detect-engine-state-02/meta.yaml
+++ b/tests/engine-state/detect-engine-state-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, mime_multipart, tcp]

--- a/tests/engine-state/detect-engine-state-03/meta.yaml
+++ b/tests/engine-state/detect-engine-state-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, mime_multipart, tcp]

--- a/tests/engine-state/detect-engine-state-04/meta.yaml
+++ b/tests/engine-state/detect-engine-state-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, mime_multipart, tcp]

--- a/tests/engine-state/detect-engine-state-05/meta.yaml
+++ b/tests/engine-state/detect-engine-state-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, mime_multipart, tcp]

--- a/tests/enip-alert/meta.yaml
+++ b/tests/enip-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [enip, eth, ip, tcp]

--- a/tests/enip-frames/meta.yaml
+++ b/tests/enip-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, cipio, enip, eth, ip, llc, lldp, stp, tcp, udp]

--- a/tests/enip-keywords-suricata8/meta.yaml
+++ b/tests/enip-keywords-suricata8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, cipio, enip, eth, ip, llc, lldp, stp, tcp, udp]

--- a/tests/enip-keywords/meta.yaml
+++ b/tests/enip-keywords/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, cipio, enip, eth, ip, llc, lldp, stp, tcp, udp]

--- a/tests/enip-log-identity/meta.yaml
+++ b/tests/enip-log-identity/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [enip, eth, ip, tcp]

--- a/tests/enip-stats-udp/meta.yaml
+++ b/tests/enip-stats-udp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [enip, eth, ip, tcp]

--- a/tests/entropy/entropy-01/meta.yaml
+++ b/tests/entropy/entropy-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/entropy/entropy-03/meta.yaml
+++ b/tests/entropy/entropy-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/ethernet-eve/meta.yaml
+++ b/tests/ethernet-eve/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, dns, eth, http, ip, ipv6, mdns, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/eve-alert-metadata-defaults/meta.yaml
+++ b/tests/eve-alert-metadata-defaults/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/eve-alert-metadata-enable-rule/meta.yaml
+++ b/tests/eve-alert-metadata-enable-rule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/eve-alert-metadata-off/meta.yaml
+++ b/tests/eve-alert-metadata-off/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/eve-flow-esp/meta.yaml
+++ b/tests/eve-flow-esp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [esp, eth, ip, ipv6]

--- a/tests/eve-flow-vlan-02/meta.yaml
+++ b/tests/eve-flow-vlan-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, icmp, ip, vlan]

--- a/tests/eve-flow-vlan/meta.yaml
+++ b/tests/eve-flow-vlan/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, icmp, ip, vlan]

--- a/tests/eve-ip-version-4/meta.yaml
+++ b/tests/eve-ip-version-4/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/eve-ip-version-6/meta.yaml
+++ b/tests/eve-ip-version-6/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, udp, vlan]

--- a/tests/eve-metadata-01-alert/meta.yaml
+++ b/tests/eve-metadata-01-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/eve-metadata-02-pass/meta.yaml
+++ b/tests/eve-metadata-02-pass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/eve-metadata-03-noalert/meta.yaml
+++ b/tests/eve-metadata-03-noalert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/eve-metadata-04-flowvar/meta.yaml
+++ b/tests/eve-metadata-04-flowvar/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/eve-metadata/meta.yaml
+++ b/tests/eve-metadata/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/eve-overlap-payload-01/meta.yaml
+++ b/tests/eve-overlap-payload-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/eve-overlap-payload-02-policy-oldlinux/meta.yaml
+++ b/tests/eve-overlap-payload-02-policy-oldlinux/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/eve-overlap-payload-03-ips/meta.yaml
+++ b/tests/eve-overlap-payload-03-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/eve-overlap-payload-04-partial-overlap/meta.yaml
+++ b/tests/eve-overlap-payload-04-partial-overlap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/eve-overlap-payload-05-gap/meta.yaml
+++ b/tests/eve-overlap-payload-05-gap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/eve-payload-01-tcp-exact-overlap/meta.yaml
+++ b/tests/eve-payload-01-tcp-exact-overlap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/eve-payload-02-tcp-exact-overlap-policy-oldlinux/meta.yaml
+++ b/tests/eve-payload-02-tcp-exact-overlap-policy-oldlinux/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/eve-payload-03-tcp-exact-overlap-ips/meta.yaml
+++ b/tests/eve-payload-03-tcp-exact-overlap-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/eve-payload-04-partial-overlap/meta.yaml
+++ b/tests/eve-payload-04-partial-overlap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/eve-payload-05-tcp-data-gap/meta.yaml
+++ b/tests/eve-payload-05-tcp-data-gap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/eve-payload-06-tcp-data-leading-gap/meta.yaml
+++ b/tests/eve-payload-06-tcp-data-leading-gap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/eve-payload-07-http-gap/meta.yaml
+++ b/tests/eve-payload-07-http-gap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, http, ip, 'null', tcp]

--- a/tests/eve-suricata-version/meta.yaml
+++ b/tests/eve-suricata-version/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, dns, eth, http, ip, ipv6, mdns, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/eve-tag-01/meta.yaml
+++ b/tests/eve-tag-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data-text-lines, dns, eth, icmp, ip, nbdgm, smb, smtp, tcp, udp]

--- a/tests/eve-tag-02/meta.yaml
+++ b/tests/eve-tag-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, dns, eth, ip, ssh, tcp, udp]

--- a/tests/eve-tag-03/meta.yaml
+++ b/tests/eve-tag-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, dns, eth, ip, ssh, tcp, udp]

--- a/tests/eve-tag-04/meta.yaml
+++ b/tests/eve-tag-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, dns, eth, ip, ssh, tcp, udp]

--- a/tests/eve-tag-05/meta.yaml
+++ b/tests/eve-tag-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, dns, eth, ip, ssh, tcp, udp]

--- a/tests/eve-tag-06/meta.yaml
+++ b/tests/eve-tag-06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, dns, eth, ip, ssh, tcp, udp]

--- a/tests/eve-tag-07/meta.yaml
+++ b/tests/eve-tag-07/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, dns, eth, ip, ssh, tcp, udp]

--- a/tests/event-rules-6.0.20/meta.yaml
+++ b/tests/event-rules-6.0.20/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/event-rules-7.0.0/meta.yaml
+++ b/tests/event-rules-7.0.0/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/event-rules-7.0.1/meta.yaml
+++ b/tests/event-rules-7.0.1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/event-rules-7.0.2/meta.yaml
+++ b/tests/event-rules-7.0.2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/event-rules-7.0.3/meta.yaml
+++ b/tests/event-rules-7.0.3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/event-rules-7.0.4/meta.yaml
+++ b/tests/event-rules-7.0.4/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/event-rules-7.0.5/meta.yaml
+++ b/tests/event-rules-7.0.5/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/event-rules-7.0.6/meta.yaml
+++ b/tests/event-rules-7.0.6/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/event-rules-7.0.7/meta.yaml
+++ b/tests/event-rules-7.0.7/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/event-rules-7.0.8/meta.yaml
+++ b/tests/event-rules-7.0.8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/event-rules-7.0.9/meta.yaml
+++ b/tests/event-rules-7.0.9/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/exception-policy-applayer-01/meta.yaml
+++ b/tests/exception-policy-applayer-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/exception-policy-applayer-02/meta.yaml
+++ b/tests/exception-policy-applayer-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/exception-policy-applayer-03/meta.yaml
+++ b/tests/exception-policy-applayer-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, udp]

--- a/tests/exception-policy-default-01/meta.yaml
+++ b/tests/exception-policy-default-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/exception-policy-default-02/meta.yaml
+++ b/tests/exception-policy-default-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/exception-policy-default-03/meta.yaml
+++ b/tests/exception-policy-default-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/exception-policy-default-04/meta.yaml
+++ b/tests/exception-policy-default-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/exception-policy-defrag-01/meta.yaml
+++ b/tests/exception-policy-defrag-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-01/meta.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-02/meta.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-03/meta.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-04/meta.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-05/meta.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-06/meta.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/exception-policy-master-switch/exception-policy-master-switch-07/meta.yaml
+++ b/tests/exception-policy-master-switch/exception-policy-master-switch-07/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/exception-policy-midstream-01/meta.yaml
+++ b/tests/exception-policy-midstream-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/exception-policy-midstream-02/meta.yaml
+++ b/tests/exception-policy-midstream-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, imap, ip, smtp, tcp]

--- a/tests/exception-policy-midstream-03/meta.yaml
+++ b/tests/exception-policy-midstream-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/exception-policy-midstream-04/meta.yaml
+++ b/tests/exception-policy-midstream-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/exception-policy-midstream-05/meta.yaml
+++ b/tests/exception-policy-midstream-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/exception-policy-midstream-06/meta.yaml
+++ b/tests/exception-policy-midstream-06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/exception-policy-midstream-07/meta.yaml
+++ b/tests/exception-policy-midstream-07/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/exception-policy-reject-action-01/meta.yaml
+++ b/tests/exception-policy-reject-action-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/exception-policy-simulated-flow-memcap/meta.yaml
+++ b/tests/exception-policy-simulated-flow-memcap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, eth, ip, ipv6, mdns, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/exception-policy-stream-reassembly-memcap-01/meta.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/exception-policy-stream-reassembly-memcap-02/meta.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/exception-policy-stream-reassembly-memcap-03/meta.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/exception-policy-stream-reassembly-memcap-04/meta.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/exception-policy-stream-reassembly-memcap-05/meta.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/exception-policy-stream-reassembly-memcap-06/meta.yaml
+++ b/tests/exception-policy-stream-reassembly-memcap-06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/exception-policy-stream-ssn-memcap-01/meta.yaml
+++ b/tests/exception-policy-stream-ssn-memcap-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/feature-5976-zero-stats-01/meta.yaml
+++ b/tests/feature-5976-zero-stats-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/feature-5976-zero-stats-02/meta.yaml
+++ b/tests/feature-5976-zero-stats-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/file-data-depth-inspection-alert/meta.yaml
+++ b/tests/file-data-depth-inspection-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, smtp, tcp]

--- a/tests/file-data-depth-inspection/meta.yaml
+++ b/tests/file-data-depth-inspection/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, smtp, tcp]

--- a/tests/file-data-prefilter/meta.yaml
+++ b/tests/file-data-prefilter/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, smtp, tcp]

--- a/tests/file-force-hash-invalid/meta.yaml
+++ b/tests/file-force-hash-invalid/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/file-match-crossed/meta.yaml
+++ b/tests/file-match-crossed/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ipv6, mime_multipart, tcp]

--- a/tests/fileext-01/meta.yaml
+++ b/tests/fileext-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/fileext-02/meta.yaml
+++ b/tests/fileext-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/filemagic-01/meta.yaml
+++ b/tests/filemagic-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/filemagic-flowbits-02/meta.yaml
+++ b/tests/filemagic-flowbits-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/filemagic-flowbits-03/meta.yaml
+++ b/tests/filemagic-flowbits-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/filemagic-flowbits/meta.yaml
+++ b/tests/filemagic-flowbits/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/filemd5/meta.yaml
+++ b/tests/filemd5/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/filename-01/meta.yaml
+++ b/tests/filename-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/filesize-keyword/meta.yaml
+++ b/tests/filesize-keyword/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [gss-api, ip, nbss, ntlmssp, sll, smb, spnego, tcp]

--- a/tests/filestore-5408/meta.yaml
+++ b/tests/filestore-5408/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [adp, data, data-text-lines, eth, http, icmp, ip, sflow, tcp, tls, udp]

--- a/tests/filestore-alert-log/meta.yaml
+++ b/tests/filestore-alert-log/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, png, tcp, vlan]

--- a/tests/filestore-dont/meta.yaml
+++ b/tests/filestore-dont/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, http, ip, mime_multipart, 'null', tcp]

--- a/tests/filestore-filecontainer-http/meta.yaml
+++ b/tests/filestore-filecontainer-http/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, png, tcp, vlan]

--- a/tests/filestore-filecontainer-smb/meta.yaml
+++ b/tests/filestore-filecontainer-smb/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dcerpc, eth, ip, nbss, ntlmssp, smb, tcp, vlan]

--- a/tests/filestore-filecontainer-smb1-data-offset/meta.yaml
+++ b/tests/filestore-filecontainer-smb1-data-offset/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/filestore-filecontainer-smb1-padding/meta.yaml
+++ b/tests/filestore-filecontainer-smb1-padding/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/filestore-ftp-active-mode/meta.yaml
+++ b/tests/filestore-ftp-active-mode/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, dns, eth, ftp, ftp-data, ip, tcp, udp]

--- a/tests/filestore-ftp-passive-mode/meta.yaml
+++ b/tests/filestore-ftp-passive-mode/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/filestore-issue-5868/meta.yaml
+++ b/tests/filestore-issue-5868/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/filestore-v2.1-forced/meta.yaml
+++ b/tests/filestore-v2.1-forced/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/filestore-v2.2-forced-with-open-files/meta.yaml
+++ b/tests/filestore-v2.2-forced-with-open-files/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/filestore-v2.3-fserror/meta.yaml
+++ b/tests/filestore-v2.3-fserror/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/filestore-v2.4-forced-with-meta/meta.yaml
+++ b/tests/filestore-v2.4-forced-with-meta/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/filestore-v2.5-both-enabled/meta.yaml
+++ b/tests/filestore-v2.5-both-enabled/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/filestore-v2.6-stream-depth/meta.yaml
+++ b/tests/filestore-v2.6-stream-depth/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/filestore-v2.7-stream-depth/meta.yaml
+++ b/tests/filestore-v2.7-stream-depth/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/filestore-v2.8-stream-depth/meta.yaml
+++ b/tests/filestore-v2.8-stream-depth/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/filestore-v2.9-stream-depth/meta.yaml
+++ b/tests/filestore-v2.9-stream-depth/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/firewall/ruletype-firewall-01-flow-start/meta.yaml
+++ b/tests/firewall/ruletype-firewall-01-flow-start/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-02-flow-start/meta.yaml
+++ b/tests/firewall/ruletype-firewall-02-flow-start/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-03-ruleset-vs-ping/meta.yaml
+++ b/tests/firewall/ruletype-firewall-03-ruleset-vs-ping/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/firewall/ruletype-firewall-04-ruleset-vs-sni/meta.yaml
+++ b/tests/firewall/ruletype-firewall-04-ruleset-vs-sni/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-05-ruleset-vs-sni/meta.yaml
+++ b/tests/firewall/ruletype-firewall-05-ruleset-vs-sni/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-06-ruleset-pass-per-packet/meta.yaml
+++ b/tests/firewall/ruletype-firewall-06-ruleset-pass-per-packet/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-07-ruleset-pass-per-flow/meta.yaml
+++ b/tests/firewall/ruletype-firewall-07-ruleset-pass-per-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-08-ruleset-default-packet-policy/meta.yaml
+++ b/tests/firewall/ruletype-firewall-08-ruleset-default-packet-policy/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-09-ruleset-default-app-policy/meta.yaml
+++ b/tests/firewall/ruletype-firewall-09-ruleset-default-app-policy/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-10-ruleset-packet-drop-vs-app/meta.yaml
+++ b/tests/firewall/ruletype-firewall-10-ruleset-packet-drop-vs-app/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-100-fw-accept-flow-td-drop-noalert/meta.yaml
+++ b/tests/firewall/ruletype-firewall-100-fw-accept-flow-td-drop-noalert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-101-fw-accept-flow-td-pkt-drop-noalert/meta.yaml
+++ b/tests/firewall/ruletype-firewall-101-fw-accept-flow-td-pkt-drop-noalert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-102-fw-accept-flow-td-pkt-drop/meta.yaml
+++ b/tests/firewall/ruletype-firewall-102-fw-accept-flow-td-pkt-drop/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-103-default-app-policy-drop-alert/meta.yaml
+++ b/tests/firewall/ruletype-firewall-103-default-app-policy-drop-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/firewall/ruletype-firewall-104-default-app-policy-missed-rule-alert/meta.yaml
+++ b/tests/firewall/ruletype-firewall-104-default-app-policy-missed-rule-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-105-default-packet-policy-alert-app-rule/meta.yaml
+++ b/tests/firewall/ruletype-firewall-105-default-packet-policy-alert-app-rule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-106-default-app-policy-accept-flow-alert/meta.yaml
+++ b/tests/firewall/ruletype-firewall-106-default-app-policy-accept-flow-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-107-default-app-policy-missed-rule-accept-tx-alert/meta.yaml
+++ b/tests/firewall/ruletype-firewall-107-default-app-policy-missed-rule-accept-tx-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-108-default-app-policy-missed-rule-accept-tx-alert/meta.yaml
+++ b/tests/firewall/ruletype-firewall-108-default-app-policy-missed-rule-accept-tx-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-109-dns-lte/meta.yaml
+++ b/tests/firewall/ruletype-firewall-109-dns-lte/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/firewall/ruletype-firewall-11-ruleset-pass-vs-fw/meta.yaml
+++ b/tests/firewall/ruletype-firewall-11-ruleset-pass-vs-fw/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-110-dns-lte/meta.yaml
+++ b/tests/firewall/ruletype-firewall-110-dns-lte/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/firewall/ruletype-firewall-111-ftp-download-active/meta.yaml
+++ b/tests/firewall/ruletype-firewall-111-ftp-download-active/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/firewall/ruletype-firewall-112-ftp-download-passive/meta.yaml
+++ b/tests/firewall/ruletype-firewall-112-ftp-download-passive/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/firewall/ruletype-firewall-113-ftp-upload-active/meta.yaml
+++ b/tests/firewall/ruletype-firewall-113-ftp-upload-active/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/firewall/ruletype-firewall-114-ftp-upload-passive/meta.yaml
+++ b/tests/firewall/ruletype-firewall-114-ftp-upload-passive/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/firewall/ruletype-firewall-115-ftp-download-active-user/meta.yaml
+++ b/tests/firewall/ruletype-firewall-115-ftp-download-active-user/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/firewall/ruletype-firewall-116-ftp-all-data-ipv4/meta.yaml
+++ b/tests/firewall/ruletype-firewall-116-ftp-all-data-ipv4/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/firewall/ruletype-firewall-117-ftp-all-data-ipv6/meta.yaml
+++ b/tests/firewall/ruletype-firewall-117-ftp-all-data-ipv6/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ipv6, tcp]

--- a/tests/firewall/ruletype-firewall-118-ftp-stou-no-filename-active/meta.yaml
+++ b/tests/firewall/ruletype-firewall-118-ftp-stou-no-filename-active/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/firewall/ruletype-firewall-119-ftp-non-anonymous-default-allow/meta.yaml
+++ b/tests/firewall/ruletype-firewall-119-ftp-non-anonymous-default-allow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/firewall/ruletype-firewall-12-ruleset-accept-flowbit/meta.yaml
+++ b/tests/firewall/ruletype-firewall-12-ruleset-accept-flowbit/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-120-ftp-drop-by-dynamic-port/meta.yaml
+++ b/tests/firewall/ruletype-firewall-120-ftp-drop-by-dynamic-port/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/firewall/ruletype-firewall-121-ftp-bounce/meta.yaml
+++ b/tests/firewall/ruletype-firewall-121-ftp-bounce/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/firewall/ruletype-firewall-13-ruleset-accept-flowbit/meta.yaml
+++ b/tests/firewall/ruletype-firewall-13-ruleset-accept-flowbit/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-14-ruleset-pass-vs-fw/meta.yaml
+++ b/tests/firewall/ruletype-firewall-14-ruleset-pass-vs-fw/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-15-state-keyword/meta.yaml
+++ b/tests/firewall/ruletype-firewall-15-state-keyword/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-16-http-per-hook/meta.yaml
+++ b/tests/firewall/ruletype-firewall-16-http-per-hook/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-17-http-txbits-multi-tx/meta.yaml
+++ b/tests/firewall/ruletype-firewall-17-http-txbits-multi-tx/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, image-gif, ip, tcp]

--- a/tests/firewall/ruletype-firewall-18-http-per-hook/meta.yaml
+++ b/tests/firewall/ruletype-firewall-18-http-per-hook/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-19-http-per-hook/meta.yaml
+++ b/tests/firewall/ruletype-firewall-19-http-per-hook/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-20-http-per-hook/meta.yaml
+++ b/tests/firewall/ruletype-firewall-20-http-per-hook/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-21-http-accept-tx/meta.yaml
+++ b/tests/firewall/ruletype-firewall-21-http-accept-tx/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, image-gif, ip, tcp]

--- a/tests/firewall/ruletype-firewall-22-http-accept-tx-with-td/meta.yaml
+++ b/tests/firewall/ruletype-firewall-22-http-accept-tx-with-td/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, image-gif, ip, tcp]

--- a/tests/firewall/ruletype-firewall-23-dns-per-hook/meta.yaml
+++ b/tests/firewall/ruletype-firewall-23-dns-per-hook/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/firewall/ruletype-firewall-24-dnstcp-per-hook/meta.yaml
+++ b/tests/firewall/ruletype-firewall-24-dnstcp-per-hook/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp, udp]

--- a/tests/firewall/ruletype-firewall-25-tcp-udp/meta.yaml
+++ b/tests/firewall/ruletype-firewall-25-tcp-udp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp, udp]

--- a/tests/firewall/ruletype-firewall-26-drop-rule/meta.yaml
+++ b/tests/firewall/ruletype-firewall-26-drop-rule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-27-http-drop-rule/meta.yaml
+++ b/tests/firewall/ruletype-firewall-27-http-drop-rule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-28-http-drop-flow-rule/meta.yaml
+++ b/tests/firewall/ruletype-firewall-28-http-drop-flow-rule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-29-http-drop-flow-rule/meta.yaml
+++ b/tests/firewall/ruletype-firewall-29-http-drop-flow-rule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-30-fw-accept-td-drop/meta.yaml
+++ b/tests/firewall/ruletype-firewall-30-fw-accept-td-drop/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-31-retrans-of-drop/meta.yaml
+++ b/tests/firewall/ruletype-firewall-31-retrans-of-drop/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp, vlan]

--- a/tests/firewall/ruletype-firewall-32-proto-detect-ssh/meta.yaml
+++ b/tests/firewall/ruletype-firewall-32-proto-detect-ssh/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/firewall/ruletype-firewall-33-ssh/meta.yaml
+++ b/tests/firewall/ruletype-firewall-33-ssh/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/firewall/ruletype-firewall-34-ssh-sw/meta.yaml
+++ b/tests/firewall/ruletype-firewall-34-ssh-sw/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/firewall/ruletype-firewall-35-ssh-sw/meta.yaml
+++ b/tests/firewall/ruletype-firewall-35-ssh-sw/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/firewall/ruletype-firewall-36-minimal/meta.yaml
+++ b/tests/firewall/ruletype-firewall-36-minimal/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/firewall/ruletype-firewall-37-minimal-bad/meta.yaml
+++ b/tests/firewall/ruletype-firewall-37-minimal-bad/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/firewall/ruletype-firewall-38-ssh-vs-telnet/meta.yaml
+++ b/tests/firewall/ruletype-firewall-38-ssh-vs-telnet/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, telnet]

--- a/tests/firewall/ruletype-firewall-39-pre-stream/meta.yaml
+++ b/tests/firewall/ruletype-firewall-39-pre-stream/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-40-pre-stream-wscale/meta.yaml
+++ b/tests/firewall/ruletype-firewall-40-pre-stream-wscale/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-41-pre-flow/meta.yaml
+++ b/tests/firewall/ruletype-firewall-41-pre-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-42-pre-flow-notrack/meta.yaml
+++ b/tests/firewall/ruletype-firewall-42-pre-flow-notrack/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-43-tls-cert-chain/meta.yaml
+++ b/tests/firewall/ruletype-firewall-43-tls-cert-chain/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-44-yaml-config-only/meta.yaml
+++ b/tests/firewall/ruletype-firewall-44-yaml-config-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/firewall/ruletype-firewall-45-iprep-8285/meta.yaml
+++ b/tests/firewall/ruletype-firewall-45-iprep-8285/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-46-iprep-8285/meta.yaml
+++ b/tests/firewall/ruletype-firewall-46-iprep-8285/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-47-iprep-8285/meta.yaml
+++ b/tests/firewall/ruletype-firewall-47-iprep-8285/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-48-iprep-8285/meta.yaml
+++ b/tests/firewall/ruletype-firewall-48-iprep-8285/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-49-reject-app/meta.yaml
+++ b/tests/firewall/ruletype-firewall-49-reject-app/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-50-ruleset-vs-ping/meta.yaml
+++ b/tests/firewall/ruletype-firewall-50-ruleset-vs-ping/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, icmp, ip]

--- a/tests/firewall/ruletype-firewall-51-tls-cert-chain/meta.yaml
+++ b/tests/firewall/ruletype-firewall-51-tls-cert-chain/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-52-snmp-v2/meta.yaml
+++ b/tests/firewall/ruletype-firewall-52-snmp-v2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, snmp, udp]

--- a/tests/firewall/ruletype-firewall-53-snmp-v3/meta.yaml
+++ b/tests/firewall/ruletype-firewall-53-snmp-v3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, snmp, udp]

--- a/tests/firewall/ruletype-firewall-54-snmp-v1-trap/meta.yaml
+++ b/tests/firewall/ruletype-firewall-54-snmp-v1-trap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, snmp, udp]

--- a/tests/firewall/ruletype-firewall-55-snmp-v1-trap-default/meta.yaml
+++ b/tests/firewall/ruletype-firewall-55-snmp-v1-trap-default/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, snmp, udp]

--- a/tests/firewall/ruletype-firewall-56-ntp/meta.yaml
+++ b/tests/firewall/ruletype-firewall-56-ntp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ntp, udp]

--- a/tests/firewall/ruletype-firewall-57-dns-datarep/meta.yaml
+++ b/tests/firewall/ruletype-firewall-57-dns-datarep/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/firewall/ruletype-firewall-58-missing-hook-vs-td/meta.yaml
+++ b/tests/firewall/ruletype-firewall-58-missing-hook-vs-td/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/firewall/ruletype-firewall-59-tls-default-policy/meta.yaml
+++ b/tests/firewall/ruletype-firewall-59-tls-default-policy/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-60-no-app-rules/meta.yaml
+++ b/tests/firewall/ruletype-firewall-60-no-app-rules/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-61-snmp-v1-trap-scope-packet/meta.yaml
+++ b/tests/firewall/ruletype-firewall-61-snmp-v1-trap-scope-packet/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, snmp, udp]

--- a/tests/firewall/ruletype-firewall-62-icmp-icode/meta.yaml
+++ b/tests/firewall/ruletype-firewall-62-icmp-icode/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/firewall/ruletype-firewall-63-dns-opcode/meta.yaml
+++ b/tests/firewall/ruletype-firewall-63-dns-opcode/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/firewall/ruletype-firewall-64-http-pcre-urilen-dataset/meta.yaml
+++ b/tests/firewall/ruletype-firewall-64-http-pcre-urilen-dataset/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-65-multi-action/meta.yaml
+++ b/tests/firewall/ruletype-firewall-65-multi-action/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-66-multi-action-no-pass/meta.yaml
+++ b/tests/firewall/ruletype-firewall-66-multi-action-no-pass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-67-accept-flow-td-response-body/meta.yaml
+++ b/tests/firewall/ruletype-firewall-67-accept-flow-td-response-body/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-68-config-default-policy-tls/meta.yaml
+++ b/tests/firewall/ruletype-firewall-68-config-default-policy-tls/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-69-config-default-policy-tls-accept/meta.yaml
+++ b/tests/firewall/ruletype-firewall-69-config-default-policy-tls-accept/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-70-config-default-policy-http/meta.yaml
+++ b/tests/firewall/ruletype-firewall-70-config-default-policy-http/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-71-reject-app-default-policy/meta.yaml
+++ b/tests/firewall/ruletype-firewall-71-reject-app-default-policy/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-72-config-default-policy-http/meta.yaml
+++ b/tests/firewall/ruletype-firewall-72-config-default-policy-http/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-73-config-default-policy-http/meta.yaml
+++ b/tests/firewall/ruletype-firewall-73-config-default-policy-http/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-74-config-default-policy-dns/meta.yaml
+++ b/tests/firewall/ruletype-firewall-74-config-default-policy-dns/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/firewall/ruletype-firewall-75-config-default-policy-http-accept-tx/meta.yaml
+++ b/tests/firewall/ruletype-firewall-75-config-default-policy-http-accept-tx/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-76-config-default-policy-http-accept-tx-td/meta.yaml
+++ b/tests/firewall/ruletype-firewall-76-config-default-policy-http-accept-tx-td/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-77-ruleset-default-packet-policy/meta.yaml
+++ b/tests/firewall/ruletype-firewall-77-ruleset-default-packet-policy/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-78-ruleset-default-packet-policy-accept/meta.yaml
+++ b/tests/firewall/ruletype-firewall-78-ruleset-default-packet-policy-accept/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-79-ruleset-default-packet-policy-accept-hook/meta.yaml
+++ b/tests/firewall/ruletype-firewall-79-ruleset-default-packet-policy-accept-hook/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-80-ruleset-default-packet-policy-accept-hook-no-rules/meta.yaml
+++ b/tests/firewall/ruletype-firewall-80-ruleset-default-packet-policy-accept-hook-no-rules/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-81-ruleset-default-packet-policy-accept-hook-all/meta.yaml
+++ b/tests/firewall/ruletype-firewall-81-ruleset-default-packet-policy-accept-hook-all/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-82-ruleset-default-app-policy-accept-flow/meta.yaml
+++ b/tests/firewall/ruletype-firewall-82-ruleset-default-app-policy-accept-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-83-ruleset-default-packet-policy-accept-flow/meta.yaml
+++ b/tests/firewall/ruletype-firewall-83-ruleset-default-packet-policy-accept-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-84-ruleset-default-app-policy-tls-request-started/meta.yaml
+++ b/tests/firewall/ruletype-firewall-84-ruleset-default-app-policy-tls-request-started/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-85-packet-filter-accept-flow-with-td/meta.yaml
+++ b/tests/firewall/ruletype-firewall-85-packet-filter-accept-flow-with-td/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-86-packet-filter-accept-flow-pass-with-td/meta.yaml
+++ b/tests/firewall/ruletype-firewall-86-packet-filter-accept-flow-pass-with-td/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-87-broken-default-policy/meta.yaml
+++ b/tests/firewall/ruletype-firewall-87-broken-default-policy/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-88-default-accept-tx-pipeline/meta.yaml
+++ b/tests/firewall/ruletype-firewall-88-default-accept-tx-pipeline/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-89-defaults-over-drop/meta.yaml
+++ b/tests/firewall/ruletype-firewall-89-defaults-over-drop/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-89-lt-sni/meta.yaml
+++ b/tests/firewall/ruletype-firewall-89-lt-sni/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-90-ban-replace-keyword/meta.yaml
+++ b/tests/firewall/ruletype-firewall-90-ban-replace-keyword/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-90-lt-sni-mix/meta.yaml
+++ b/tests/firewall/ruletype-firewall-90-lt-sni-mix/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-91-ban-replace-from-fw-mode/meta.yaml
+++ b/tests/firewall/ruletype-firewall-91-ban-replace-from-fw-mode/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-91-lt-ua/meta.yaml
+++ b/tests/firewall/ruletype-firewall-91-lt-ua/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-92-ban-bypass-keyword/meta.yaml
+++ b/tests/firewall/ruletype-firewall-92-ban-bypass-keyword/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-92-lt-ua-mix/meta.yaml
+++ b/tests/firewall/ruletype-firewall-92-lt-ua-mix/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-93-lt-ua-mix-accept-hook/meta.yaml
+++ b/tests/firewall/ruletype-firewall-93-lt-ua-mix-accept-hook/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-94-config-default-policy-http/meta.yaml
+++ b/tests/firewall/ruletype-firewall-94-config-default-policy-http/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-95-ruleset-default-packet-policy-accept-hook-alert/meta.yaml
+++ b/tests/firewall/ruletype-firewall-95-ruleset-default-packet-policy-accept-hook-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-96-lt-response-body-no-match/meta.yaml
+++ b/tests/firewall/ruletype-firewall-96-lt-response-body-no-match/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/firewall/ruletype-firewall-97-fw-accept-flow-td-drop/meta.yaml
+++ b/tests/firewall/ruletype-firewall-97-fw-accept-flow-td-drop/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-98-fw-accept-pass-flow-td-drop/meta.yaml
+++ b/tests/firewall/ruletype-firewall-98-fw-accept-pass-flow-td-drop/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/firewall/ruletype-firewall-99-pkt-fw-accept-pass-flow-td-drop/meta.yaml
+++ b/tests/firewall/ruletype-firewall-99-pkt-fw-accept-pass-flow-td-drop/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/flow-drop-iponly-01/meta.yaml
+++ b/tests/flow-drop-iponly-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/flow-drop-iponly-02/meta.yaml
+++ b/tests/flow-drop-iponly-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, icmp, ip, udp]

--- a/tests/flow-pkt-recursion/ids-middleware-pkt-flows-recursion-excluded/meta.yaml
+++ b/tests/flow-pkt-recursion/ids-middleware-pkt-flows-recursion-excluded/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip, ipv6]

--- a/tests/flow-pkt-recursion/ids-middleware-pkt-flows-recursion-included/meta.yaml
+++ b/tests/flow-pkt-recursion/ids-middleware-pkt-flows-recursion-included/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip, ipv6]

--- a/tests/flow-pkt-recursion/ids-tunnel-pkt-flows-recursion-excluded/meta.yaml
+++ b/tests/flow-pkt-recursion/ids-tunnel-pkt-flows-recursion-excluded/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip, ipv6]

--- a/tests/flow-pkt-recursion/ids-tunnel-pkt-flows-recursion-included/meta.yaml
+++ b/tests/flow-pkt-recursion/ids-tunnel-pkt-flows-recursion-included/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip, ipv6]

--- a/tests/flow-pkt-recursion/ips-middleware-pkt-flows-recursion-excluded/meta.yaml
+++ b/tests/flow-pkt-recursion/ips-middleware-pkt-flows-recursion-excluded/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip, ipv6]

--- a/tests/flow-pkt-recursion/ips-middleware-pkt-flows-recursion-included/meta.yaml
+++ b/tests/flow-pkt-recursion/ips-middleware-pkt-flows-recursion-included/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip, ipv6]

--- a/tests/flow-pkt-recursion/ips-tunnel-pkt-flows-recursion-excluded/meta.yaml
+++ b/tests/flow-pkt-recursion/ips-tunnel-pkt-flows-recursion-excluded/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip, ipv6]

--- a/tests/flow-pkt-recursion/ips-tunnel-pkt-flows-recursion-included/meta.yaml
+++ b/tests/flow-pkt-recursion/ips-tunnel-pkt-flows-recursion-included/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip, ipv6]

--- a/tests/flow-tx-cnt/meta.yaml
+++ b/tests/flow-tx-cnt/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, spnego-krb5, tcp]

--- a/tests/flowbit-oring/meta.yaml
+++ b/tests/flowbit-oring/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/flowbits-invalid-01/meta.yaml
+++ b/tests/flowbits-invalid-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/flowbits-invalid-02/meta.yaml
+++ b/tests/flowbits-invalid-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/flowbits-invalid-04/meta.yaml
+++ b/tests/flowbits-invalid-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/flowbits-invalid-05/meta.yaml
+++ b/tests/flowbits-invalid-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/flowbits-invalid-07/meta.yaml
+++ b/tests/flowbits-invalid-07/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/flowbits-invalid-08/meta.yaml
+++ b/tests/flowbits-invalid-08/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/flowbits-invalid-10/meta.yaml
+++ b/tests/flowbits-invalid-10/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/flowbits-invalid-11/meta.yaml
+++ b/tests/flowbits-invalid-11/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/flowbits-prefilter-01/meta.yaml
+++ b/tests/flowbits-prefilter-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/flowbits-prefilter-02-auto/meta.yaml
+++ b/tests/flowbits-prefilter-02-auto/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/flowbits-prefilter-03/meta.yaml
+++ b/tests/flowbits-prefilter-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/flowbits-prefilter-04-pkt-auto/meta.yaml
+++ b/tests/flowbits-prefilter-04-pkt-auto/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/flowbits-prefilter-05-onedir/meta.yaml
+++ b/tests/flowbits-prefilter-05-onedir/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/flowbits-prefilter-06-opdir/meta.yaml
+++ b/tests/flowbits-prefilter-06-opdir/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/flowbits-prefilter-07-tx-onedir/meta.yaml
+++ b/tests/flowbits-prefilter-07-tx-onedir/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/flowbits-prefilter-08-tx-opdir/meta.yaml
+++ b/tests/flowbits-prefilter-08-tx-opdir/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/flowbits-prefilter-09-iponly-onedir/meta.yaml
+++ b/tests/flowbits-prefilter-09-iponly-onedir/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/flowbits-prefilter-10-iponly-opdir/meta.yaml
+++ b/tests/flowbits-prefilter-10-iponly-opdir/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/flowbits-prefilter-11-pkt-auto/meta.yaml
+++ b/tests/flowbits-prefilter-11-pkt-auto/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/flowbits-prefilter-12-toggle/meta.yaml
+++ b/tests/flowbits-prefilter-12-toggle/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/flowbits-prefilter-13-tx-onedir-toggle/meta.yaml
+++ b/tests/flowbits-prefilter-13-tx-onedir-toggle/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/flowbits-toggle-pre-9/meta.yaml
+++ b/tests/flowbits-toggle-pre-9/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/flowint-isnotset/meta.yaml
+++ b/tests/flowint-isnotset/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data, data-text-lines, dns, eth, http, icmpv6, image-jfif, ip, ipv6, ipv6.hopopts, llc, llmnr, media, nbdgm, nbns, ocsp, pkix1explicit, pkix1implicit, pkixalgs, png, smb, stp, tcp, tls, udp, x509, x509af, x509ce, x509sat]

--- a/tests/from_base64-01/meta.yaml
+++ b/tests/from_base64-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, tcp]

--- a/tests/from_base64-02/meta.yaml
+++ b/tests/from_base64-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/from_base64-03/meta.yaml
+++ b/tests/from_base64-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, tcp]

--- a/tests/from_base64-04/meta.yaml
+++ b/tests/from_base64-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, ip, smtp, tcp]

--- a/tests/ftp-epsv/meta.yaml
+++ b/tests/ftp-epsv/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/ftp-port-memcap/meta.yaml
+++ b/tests/ftp-port-memcap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ftp, ip, 'null', tcp]

--- a/tests/ftp-quit/meta.yaml
+++ b/tests/ftp-quit/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/ftp-retr-bypass-baseline/meta.yaml
+++ b/tests/ftp-retr-bypass-baseline/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/ftp-retr-bypass-realserver/meta.yaml
+++ b/tests/ftp-retr-bypass-realserver/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/ftp/ftp-bounce/meta.yaml
+++ b/tests/ftp/ftp-bounce/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/ftp/ftp-download-active/meta.yaml
+++ b/tests/ftp/ftp-download-active/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/ftp/ftp-download-passive/meta.yaml
+++ b/tests/ftp/ftp-download-passive/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/ftp/ftp-invalid-config/meta.yaml
+++ b/tests/ftp/ftp-invalid-config/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/ftp/ftp-too-long-command-buffered/meta.yaml
+++ b/tests/ftp/ftp-too-long-command-buffered/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/ftp/ftp-too-long-command-first/meta.yaml
+++ b/tests/ftp/ftp-too-long-command-first/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/ftp/ftp-too-long-command-higher-limit/meta.yaml
+++ b/tests/ftp/ftp-too-long-command-higher-limit/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/ftp/ftp-too-long-command/meta.yaml
+++ b/tests/ftp/ftp-too-long-command/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/ftp/ftp-too-long-response/meta.yaml
+++ b/tests/ftp/ftp-too-long-response/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/ftp/ftp-upload-active/meta.yaml
+++ b/tests/ftp/ftp-upload-active/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/ftp/ftp-upload-passive/meta.yaml
+++ b/tests/ftp/ftp-upload-passive/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ftp, ftp-data, ip, tcp]

--- a/tests/geneve-decoder/meta.yaml
+++ b/tests/geneve-decoder/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, eth, geneve, icmp, ip, udp]

--- a/tests/geoip/meta.yaml
+++ b/tests/geoip/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/http-all-headers/meta.yaml
+++ b/tests/http-all-headers/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/http-async-cli/meta.yaml
+++ b/tests/http-async-cli/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/http-async-srv/meta.yaml
+++ b/tests/http-async-srv/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, http, ip, 'null', tcp]

--- a/tests/http-async/meta.yaml
+++ b/tests/http-async/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, http, ip, 'null', tcp]

--- a/tests/http-auth-bearer/meta.yaml
+++ b/tests/http-auth-bearer/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, http, ip, 'null', tcp]

--- a/tests/http-auth-unrecognized/meta.yaml
+++ b/tests/http-auth-unrecognized/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, ip, 'null', tcp]

--- a/tests/http-body-inspect/meta.yaml
+++ b/tests/http-body-inspect/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-brotli-ce/meta.yaml
+++ b/tests/http-brotli-ce/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, json, tcp]

--- a/tests/http-chunked/meta.yaml
+++ b/tests/http-chunked/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-close-headers/meta.yaml
+++ b/tests/http-close-headers/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-connect/http-connect-fail/meta.yaml
+++ b/tests/http-connect/http-connect-fail/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp, tls]

--- a/tests/http-connect/http-connect-fragmented/meta.yaml
+++ b/tests/http-connect/http-connect-fragmented/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/http-connect/http-connect-simple/meta.yaml
+++ b/tests/http-connect/http-connect-simple/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, http, ip, 'null', tcp]

--- a/tests/http-connect/http-connect-tls/meta.yaml
+++ b/tests/http-connect/http-connect-tls/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, http, ip, 'null', tcp, tls]

--- a/tests/http-connection-toclient/meta.yaml
+++ b/tests/http-connection-toclient/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/http-data-after-09/meta.yaml
+++ b/tests/http-data-after-09/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, 'null', tcp]

--- a/tests/http-double-encoded-uri/meta.yaml
+++ b/tests/http-double-encoded-uri/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/http-encoding-gzip-uncompressed/meta.yaml
+++ b/tests/http-encoding-gzip-uncompressed/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-encoding-identity/meta.yaml
+++ b/tests/http-encoding-identity/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, http, ip, 'null', tcp]

--- a/tests/http-evader/http-evader-000/meta.yaml
+++ b/tests/http-evader/http-evader-000/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-001/meta.yaml
+++ b/tests/http-evader/http-evader-001/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-002/meta.yaml
+++ b/tests/http-evader/http-evader-002/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-003/meta.yaml
+++ b/tests/http-evader/http-evader-003/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-004/meta.yaml
+++ b/tests/http-evader/http-evader-004/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-005/meta.yaml
+++ b/tests/http-evader/http-evader-005/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-006/meta.yaml
+++ b/tests/http-evader/http-evader-006/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-007/meta.yaml
+++ b/tests/http-evader/http-evader-007/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-008/meta.yaml
+++ b/tests/http-evader/http-evader-008/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-009/meta.yaml
+++ b/tests/http-evader/http-evader-009/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-010/meta.yaml
+++ b/tests/http-evader/http-evader-010/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-011/meta.yaml
+++ b/tests/http-evader/http-evader-011/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-012/meta.yaml
+++ b/tests/http-evader/http-evader-012/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-013/meta.yaml
+++ b/tests/http-evader/http-evader-013/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-014/meta.yaml
+++ b/tests/http-evader/http-evader-014/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-015/meta.yaml
+++ b/tests/http-evader/http-evader-015/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-016/meta.yaml
+++ b/tests/http-evader/http-evader-016/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-017/meta.yaml
+++ b/tests/http-evader/http-evader-017/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-018/meta.yaml
+++ b/tests/http-evader/http-evader-018/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-019/meta.yaml
+++ b/tests/http-evader/http-evader-019/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-020/meta.yaml
+++ b/tests/http-evader/http-evader-020/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-021/meta.yaml
+++ b/tests/http-evader/http-evader-021/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-022/meta.yaml
+++ b/tests/http-evader/http-evader-022/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-023/meta.yaml
+++ b/tests/http-evader/http-evader-023/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-024/meta.yaml
+++ b/tests/http-evader/http-evader-024/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-025/meta.yaml
+++ b/tests/http-evader/http-evader-025/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-026/meta.yaml
+++ b/tests/http-evader/http-evader-026/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-027/meta.yaml
+++ b/tests/http-evader/http-evader-027/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-028/meta.yaml
+++ b/tests/http-evader/http-evader-028/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-029/meta.yaml
+++ b/tests/http-evader/http-evader-029/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-030/meta.yaml
+++ b/tests/http-evader/http-evader-030/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-031/meta.yaml
+++ b/tests/http-evader/http-evader-031/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-032/meta.yaml
+++ b/tests/http-evader/http-evader-032/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-033/meta.yaml
+++ b/tests/http-evader/http-evader-033/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-034/meta.yaml
+++ b/tests/http-evader/http-evader-034/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-035/meta.yaml
+++ b/tests/http-evader/http-evader-035/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-036/meta.yaml
+++ b/tests/http-evader/http-evader-036/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-037/meta.yaml
+++ b/tests/http-evader/http-evader-037/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-038/meta.yaml
+++ b/tests/http-evader/http-evader-038/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-039/meta.yaml
+++ b/tests/http-evader/http-evader-039/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-040/meta.yaml
+++ b/tests/http-evader/http-evader-040/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-041/meta.yaml
+++ b/tests/http-evader/http-evader-041/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-042/meta.yaml
+++ b/tests/http-evader/http-evader-042/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-043/meta.yaml
+++ b/tests/http-evader/http-evader-043/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-044/meta.yaml
+++ b/tests/http-evader/http-evader-044/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-045/meta.yaml
+++ b/tests/http-evader/http-evader-045/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-046/meta.yaml
+++ b/tests/http-evader/http-evader-046/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-047/meta.yaml
+++ b/tests/http-evader/http-evader-047/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-048/meta.yaml
+++ b/tests/http-evader/http-evader-048/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-049/meta.yaml
+++ b/tests/http-evader/http-evader-049/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-050/meta.yaml
+++ b/tests/http-evader/http-evader-050/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-051/meta.yaml
+++ b/tests/http-evader/http-evader-051/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-052/meta.yaml
+++ b/tests/http-evader/http-evader-052/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-053/meta.yaml
+++ b/tests/http-evader/http-evader-053/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-054/meta.yaml
+++ b/tests/http-evader/http-evader-054/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-055/meta.yaml
+++ b/tests/http-evader/http-evader-055/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-056/meta.yaml
+++ b/tests/http-evader/http-evader-056/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-057/meta.yaml
+++ b/tests/http-evader/http-evader-057/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-058/meta.yaml
+++ b/tests/http-evader/http-evader-058/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-059/meta.yaml
+++ b/tests/http-evader/http-evader-059/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-060/meta.yaml
+++ b/tests/http-evader/http-evader-060/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-061/meta.yaml
+++ b/tests/http-evader/http-evader-061/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-062/meta.yaml
+++ b/tests/http-evader/http-evader-062/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-063/meta.yaml
+++ b/tests/http-evader/http-evader-063/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-064/meta.yaml
+++ b/tests/http-evader/http-evader-064/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-065/meta.yaml
+++ b/tests/http-evader/http-evader-065/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-066/meta.yaml
+++ b/tests/http-evader/http-evader-066/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-067/meta.yaml
+++ b/tests/http-evader/http-evader-067/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-068/meta.yaml
+++ b/tests/http-evader/http-evader-068/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-069/meta.yaml
+++ b/tests/http-evader/http-evader-069/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-070/meta.yaml
+++ b/tests/http-evader/http-evader-070/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-071/meta.yaml
+++ b/tests/http-evader/http-evader-071/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-072/meta.yaml
+++ b/tests/http-evader/http-evader-072/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-073/meta.yaml
+++ b/tests/http-evader/http-evader-073/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-074/meta.yaml
+++ b/tests/http-evader/http-evader-074/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-075/meta.yaml
+++ b/tests/http-evader/http-evader-075/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-076/meta.yaml
+++ b/tests/http-evader/http-evader-076/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-077/meta.yaml
+++ b/tests/http-evader/http-evader-077/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-078/meta.yaml
+++ b/tests/http-evader/http-evader-078/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-079/meta.yaml
+++ b/tests/http-evader/http-evader-079/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-080/meta.yaml
+++ b/tests/http-evader/http-evader-080/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-081/meta.yaml
+++ b/tests/http-evader/http-evader-081/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-082/meta.yaml
+++ b/tests/http-evader/http-evader-082/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-083/meta.yaml
+++ b/tests/http-evader/http-evader-083/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-084/meta.yaml
+++ b/tests/http-evader/http-evader-084/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-085/meta.yaml
+++ b/tests/http-evader/http-evader-085/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-086/meta.yaml
+++ b/tests/http-evader/http-evader-086/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-087/meta.yaml
+++ b/tests/http-evader/http-evader-087/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-088/meta.yaml
+++ b/tests/http-evader/http-evader-088/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-089/meta.yaml
+++ b/tests/http-evader/http-evader-089/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-090/meta.yaml
+++ b/tests/http-evader/http-evader-090/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-091/meta.yaml
+++ b/tests/http-evader/http-evader-091/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-092/meta.yaml
+++ b/tests/http-evader/http-evader-092/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-093/meta.yaml
+++ b/tests/http-evader/http-evader-093/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-094/meta.yaml
+++ b/tests/http-evader/http-evader-094/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-095/meta.yaml
+++ b/tests/http-evader/http-evader-095/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-096/meta.yaml
+++ b/tests/http-evader/http-evader-096/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-097/meta.yaml
+++ b/tests/http-evader/http-evader-097/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-098/meta.yaml
+++ b/tests/http-evader/http-evader-098/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-099/meta.yaml
+++ b/tests/http-evader/http-evader-099/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-100/meta.yaml
+++ b/tests/http-evader/http-evader-100/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-101/meta.yaml
+++ b/tests/http-evader/http-evader-101/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-102/meta.yaml
+++ b/tests/http-evader/http-evader-102/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-103/meta.yaml
+++ b/tests/http-evader/http-evader-103/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-104/meta.yaml
+++ b/tests/http-evader/http-evader-104/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-105/meta.yaml
+++ b/tests/http-evader/http-evader-105/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-106/meta.yaml
+++ b/tests/http-evader/http-evader-106/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-107/meta.yaml
+++ b/tests/http-evader/http-evader-107/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-108/meta.yaml
+++ b/tests/http-evader/http-evader-108/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-109/meta.yaml
+++ b/tests/http-evader/http-evader-109/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-110/meta.yaml
+++ b/tests/http-evader/http-evader-110/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-111/meta.yaml
+++ b/tests/http-evader/http-evader-111/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-112/meta.yaml
+++ b/tests/http-evader/http-evader-112/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-113/meta.yaml
+++ b/tests/http-evader/http-evader-113/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-114/meta.yaml
+++ b/tests/http-evader/http-evader-114/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-115/meta.yaml
+++ b/tests/http-evader/http-evader-115/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-116-lzma/meta.yaml
+++ b/tests/http-evader/http-evader-116-lzma/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-117/meta.yaml
+++ b/tests/http-evader/http-evader-117/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-118/meta.yaml
+++ b/tests/http-evader/http-evader-118/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-119/meta.yaml
+++ b/tests/http-evader/http-evader-119/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-120/meta.yaml
+++ b/tests/http-evader/http-evader-120/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-121/meta.yaml
+++ b/tests/http-evader/http-evader-121/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-122/meta.yaml
+++ b/tests/http-evader/http-evader-122/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-123/meta.yaml
+++ b/tests/http-evader/http-evader-123/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-124/meta.yaml
+++ b/tests/http-evader/http-evader-124/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-125/meta.yaml
+++ b/tests/http-evader/http-evader-125/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-126/meta.yaml
+++ b/tests/http-evader/http-evader-126/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-127/meta.yaml
+++ b/tests/http-evader/http-evader-127/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-128/meta.yaml
+++ b/tests/http-evader/http-evader-128/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-129/meta.yaml
+++ b/tests/http-evader/http-evader-129/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-130/meta.yaml
+++ b/tests/http-evader/http-evader-130/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-131/meta.yaml
+++ b/tests/http-evader/http-evader-131/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-132/meta.yaml
+++ b/tests/http-evader/http-evader-132/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-133/meta.yaml
+++ b/tests/http-evader/http-evader-133/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-134/meta.yaml
+++ b/tests/http-evader/http-evader-134/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-135/meta.yaml
+++ b/tests/http-evader/http-evader-135/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-136/meta.yaml
+++ b/tests/http-evader/http-evader-136/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-137/meta.yaml
+++ b/tests/http-evader/http-evader-137/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-138/meta.yaml
+++ b/tests/http-evader/http-evader-138/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-139/meta.yaml
+++ b/tests/http-evader/http-evader-139/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-140/meta.yaml
+++ b/tests/http-evader/http-evader-140/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-141/meta.yaml
+++ b/tests/http-evader/http-evader-141/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-142/meta.yaml
+++ b/tests/http-evader/http-evader-142/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-143/meta.yaml
+++ b/tests/http-evader/http-evader-143/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-144/meta.yaml
+++ b/tests/http-evader/http-evader-144/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-145/meta.yaml
+++ b/tests/http-evader/http-evader-145/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-146/meta.yaml
+++ b/tests/http-evader/http-evader-146/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-147/meta.yaml
+++ b/tests/http-evader/http-evader-147/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-148/meta.yaml
+++ b/tests/http-evader/http-evader-148/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-149/meta.yaml
+++ b/tests/http-evader/http-evader-149/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-150/meta.yaml
+++ b/tests/http-evader/http-evader-150/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-151/meta.yaml
+++ b/tests/http-evader/http-evader-151/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-152/meta.yaml
+++ b/tests/http-evader/http-evader-152/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-153/meta.yaml
+++ b/tests/http-evader/http-evader-153/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-154/meta.yaml
+++ b/tests/http-evader/http-evader-154/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-155/meta.yaml
+++ b/tests/http-evader/http-evader-155/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-156/meta.yaml
+++ b/tests/http-evader/http-evader-156/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-157/meta.yaml
+++ b/tests/http-evader/http-evader-157/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-158/meta.yaml
+++ b/tests/http-evader/http-evader-158/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-159/meta.yaml
+++ b/tests/http-evader/http-evader-159/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-160/meta.yaml
+++ b/tests/http-evader/http-evader-160/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-161/meta.yaml
+++ b/tests/http-evader/http-evader-161/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-162/meta.yaml
+++ b/tests/http-evader/http-evader-162/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-163/meta.yaml
+++ b/tests/http-evader/http-evader-163/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-164/meta.yaml
+++ b/tests/http-evader/http-evader-164/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-165/meta.yaml
+++ b/tests/http-evader/http-evader-165/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-166/meta.yaml
+++ b/tests/http-evader/http-evader-166/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-167/meta.yaml
+++ b/tests/http-evader/http-evader-167/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-168/meta.yaml
+++ b/tests/http-evader/http-evader-168/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-169/meta.yaml
+++ b/tests/http-evader/http-evader-169/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-170/meta.yaml
+++ b/tests/http-evader/http-evader-170/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-171/meta.yaml
+++ b/tests/http-evader/http-evader-171/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-172/meta.yaml
+++ b/tests/http-evader/http-evader-172/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-173/meta.yaml
+++ b/tests/http-evader/http-evader-173/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-174/meta.yaml
+++ b/tests/http-evader/http-evader-174/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-175/meta.yaml
+++ b/tests/http-evader/http-evader-175/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-176/meta.yaml
+++ b/tests/http-evader/http-evader-176/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-177/meta.yaml
+++ b/tests/http-evader/http-evader-177/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-178/meta.yaml
+++ b/tests/http-evader/http-evader-178/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-179/meta.yaml
+++ b/tests/http-evader/http-evader-179/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-180/meta.yaml
+++ b/tests/http-evader/http-evader-180/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-181/meta.yaml
+++ b/tests/http-evader/http-evader-181/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-182/meta.yaml
+++ b/tests/http-evader/http-evader-182/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-183/meta.yaml
+++ b/tests/http-evader/http-evader-183/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-184/meta.yaml
+++ b/tests/http-evader/http-evader-184/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-185/meta.yaml
+++ b/tests/http-evader/http-evader-185/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-186/meta.yaml
+++ b/tests/http-evader/http-evader-186/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-187/meta.yaml
+++ b/tests/http-evader/http-evader-187/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-188/meta.yaml
+++ b/tests/http-evader/http-evader-188/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-189/meta.yaml
+++ b/tests/http-evader/http-evader-189/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-190/meta.yaml
+++ b/tests/http-evader/http-evader-190/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-191/meta.yaml
+++ b/tests/http-evader/http-evader-191/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-192/meta.yaml
+++ b/tests/http-evader/http-evader-192/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-193/meta.yaml
+++ b/tests/http-evader/http-evader-193/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-194/meta.yaml
+++ b/tests/http-evader/http-evader-194/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-195/meta.yaml
+++ b/tests/http-evader/http-evader-195/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-196/meta.yaml
+++ b/tests/http-evader/http-evader-196/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-197/meta.yaml
+++ b/tests/http-evader/http-evader-197/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-198/meta.yaml
+++ b/tests/http-evader/http-evader-198/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-199/meta.yaml
+++ b/tests/http-evader/http-evader-199/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-200/meta.yaml
+++ b/tests/http-evader/http-evader-200/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-201/meta.yaml
+++ b/tests/http-evader/http-evader-201/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-202/meta.yaml
+++ b/tests/http-evader/http-evader-202/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-203/meta.yaml
+++ b/tests/http-evader/http-evader-203/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-204/meta.yaml
+++ b/tests/http-evader/http-evader-204/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-205/meta.yaml
+++ b/tests/http-evader/http-evader-205/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-206/meta.yaml
+++ b/tests/http-evader/http-evader-206/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-207/meta.yaml
+++ b/tests/http-evader/http-evader-207/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-208/meta.yaml
+++ b/tests/http-evader/http-evader-208/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-209/meta.yaml
+++ b/tests/http-evader/http-evader-209/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-210/meta.yaml
+++ b/tests/http-evader/http-evader-210/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-211/meta.yaml
+++ b/tests/http-evader/http-evader-211/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-212/meta.yaml
+++ b/tests/http-evader/http-evader-212/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-213/meta.yaml
+++ b/tests/http-evader/http-evader-213/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-214/meta.yaml
+++ b/tests/http-evader/http-evader-214/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-215/meta.yaml
+++ b/tests/http-evader/http-evader-215/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-216/meta.yaml
+++ b/tests/http-evader/http-evader-216/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-217/meta.yaml
+++ b/tests/http-evader/http-evader-217/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-218/meta.yaml
+++ b/tests/http-evader/http-evader-218/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-219/meta.yaml
+++ b/tests/http-evader/http-evader-219/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-220/meta.yaml
+++ b/tests/http-evader/http-evader-220/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-221/meta.yaml
+++ b/tests/http-evader/http-evader-221/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-222/meta.yaml
+++ b/tests/http-evader/http-evader-222/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-223/meta.yaml
+++ b/tests/http-evader/http-evader-223/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-224/meta.yaml
+++ b/tests/http-evader/http-evader-224/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-225/meta.yaml
+++ b/tests/http-evader/http-evader-225/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-226/meta.yaml
+++ b/tests/http-evader/http-evader-226/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-227/meta.yaml
+++ b/tests/http-evader/http-evader-227/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-228/meta.yaml
+++ b/tests/http-evader/http-evader-228/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-229/meta.yaml
+++ b/tests/http-evader/http-evader-229/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-230/meta.yaml
+++ b/tests/http-evader/http-evader-230/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-231/meta.yaml
+++ b/tests/http-evader/http-evader-231/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-232/meta.yaml
+++ b/tests/http-evader/http-evader-232/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-233/meta.yaml
+++ b/tests/http-evader/http-evader-233/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-234/meta.yaml
+++ b/tests/http-evader/http-evader-234/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-235/meta.yaml
+++ b/tests/http-evader/http-evader-235/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-236/meta.yaml
+++ b/tests/http-evader/http-evader-236/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-237/meta.yaml
+++ b/tests/http-evader/http-evader-237/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-238/meta.yaml
+++ b/tests/http-evader/http-evader-238/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-239/meta.yaml
+++ b/tests/http-evader/http-evader-239/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-240/meta.yaml
+++ b/tests/http-evader/http-evader-240/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-241/meta.yaml
+++ b/tests/http-evader/http-evader-241/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-242/meta.yaml
+++ b/tests/http-evader/http-evader-242/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-243/meta.yaml
+++ b/tests/http-evader/http-evader-243/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-244/meta.yaml
+++ b/tests/http-evader/http-evader-244/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-245/meta.yaml
+++ b/tests/http-evader/http-evader-245/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-246/meta.yaml
+++ b/tests/http-evader/http-evader-246/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-247/meta.yaml
+++ b/tests/http-evader/http-evader-247/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-248/meta.yaml
+++ b/tests/http-evader/http-evader-248/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-249/meta.yaml
+++ b/tests/http-evader/http-evader-249/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-250/meta.yaml
+++ b/tests/http-evader/http-evader-250/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-251/meta.yaml
+++ b/tests/http-evader/http-evader-251/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-252/meta.yaml
+++ b/tests/http-evader/http-evader-252/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-253/meta.yaml
+++ b/tests/http-evader/http-evader-253/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-254/meta.yaml
+++ b/tests/http-evader/http-evader-254/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-255/meta.yaml
+++ b/tests/http-evader/http-evader-255/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-256/meta.yaml
+++ b/tests/http-evader/http-evader-256/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-257/meta.yaml
+++ b/tests/http-evader/http-evader-257/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-258/meta.yaml
+++ b/tests/http-evader/http-evader-258/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-259/meta.yaml
+++ b/tests/http-evader/http-evader-259/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-260/meta.yaml
+++ b/tests/http-evader/http-evader-260/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-261/meta.yaml
+++ b/tests/http-evader/http-evader-261/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-262/meta.yaml
+++ b/tests/http-evader/http-evader-262/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-263/meta.yaml
+++ b/tests/http-evader/http-evader-263/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-264/meta.yaml
+++ b/tests/http-evader/http-evader-264/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-265/meta.yaml
+++ b/tests/http-evader/http-evader-265/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-266/meta.yaml
+++ b/tests/http-evader/http-evader-266/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-267/meta.yaml
+++ b/tests/http-evader/http-evader-267/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-268/meta.yaml
+++ b/tests/http-evader/http-evader-268/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-269/meta.yaml
+++ b/tests/http-evader/http-evader-269/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-270/meta.yaml
+++ b/tests/http-evader/http-evader-270/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-271/meta.yaml
+++ b/tests/http-evader/http-evader-271/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-272/meta.yaml
+++ b/tests/http-evader/http-evader-272/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-273/meta.yaml
+++ b/tests/http-evader/http-evader-273/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-274/meta.yaml
+++ b/tests/http-evader/http-evader-274/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-275/meta.yaml
+++ b/tests/http-evader/http-evader-275/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-276/meta.yaml
+++ b/tests/http-evader/http-evader-276/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-277/meta.yaml
+++ b/tests/http-evader/http-evader-277/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-278/meta.yaml
+++ b/tests/http-evader/http-evader-278/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-279/meta.yaml
+++ b/tests/http-evader/http-evader-279/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-280/meta.yaml
+++ b/tests/http-evader/http-evader-280/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-281/meta.yaml
+++ b/tests/http-evader/http-evader-281/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-282/meta.yaml
+++ b/tests/http-evader/http-evader-282/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-283/meta.yaml
+++ b/tests/http-evader/http-evader-283/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-284/meta.yaml
+++ b/tests/http-evader/http-evader-284/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-285/meta.yaml
+++ b/tests/http-evader/http-evader-285/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-286/meta.yaml
+++ b/tests/http-evader/http-evader-286/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-287/meta.yaml
+++ b/tests/http-evader/http-evader-287/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-288/meta.yaml
+++ b/tests/http-evader/http-evader-288/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-289/meta.yaml
+++ b/tests/http-evader/http-evader-289/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-290/meta.yaml
+++ b/tests/http-evader/http-evader-290/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-291/meta.yaml
+++ b/tests/http-evader/http-evader-291/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-292/meta.yaml
+++ b/tests/http-evader/http-evader-292/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-293/meta.yaml
+++ b/tests/http-evader/http-evader-293/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-294/meta.yaml
+++ b/tests/http-evader/http-evader-294/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-295/meta.yaml
+++ b/tests/http-evader/http-evader-295/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-296/meta.yaml
+++ b/tests/http-evader/http-evader-296/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-297/meta.yaml
+++ b/tests/http-evader/http-evader-297/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-298/meta.yaml
+++ b/tests/http-evader/http-evader-298/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-299/meta.yaml
+++ b/tests/http-evader/http-evader-299/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-300/meta.yaml
+++ b/tests/http-evader/http-evader-300/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-301/meta.yaml
+++ b/tests/http-evader/http-evader-301/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-302/meta.yaml
+++ b/tests/http-evader/http-evader-302/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-303/meta.yaml
+++ b/tests/http-evader/http-evader-303/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-304/meta.yaml
+++ b/tests/http-evader/http-evader-304/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-305/meta.yaml
+++ b/tests/http-evader/http-evader-305/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-306/meta.yaml
+++ b/tests/http-evader/http-evader-306/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-307/meta.yaml
+++ b/tests/http-evader/http-evader-307/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-308/meta.yaml
+++ b/tests/http-evader/http-evader-308/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-309/meta.yaml
+++ b/tests/http-evader/http-evader-309/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-310/meta.yaml
+++ b/tests/http-evader/http-evader-310/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-311/meta.yaml
+++ b/tests/http-evader/http-evader-311/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-312/meta.yaml
+++ b/tests/http-evader/http-evader-312/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-313/meta.yaml
+++ b/tests/http-evader/http-evader-313/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-314/meta.yaml
+++ b/tests/http-evader/http-evader-314/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-315/meta.yaml
+++ b/tests/http-evader/http-evader-315/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-316/meta.yaml
+++ b/tests/http-evader/http-evader-316/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-317/meta.yaml
+++ b/tests/http-evader/http-evader-317/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-318/meta.yaml
+++ b/tests/http-evader/http-evader-318/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-319/meta.yaml
+++ b/tests/http-evader/http-evader-319/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-320/meta.yaml
+++ b/tests/http-evader/http-evader-320/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-321/meta.yaml
+++ b/tests/http-evader/http-evader-321/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-322/meta.yaml
+++ b/tests/http-evader/http-evader-322/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-323/meta.yaml
+++ b/tests/http-evader/http-evader-323/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-324/meta.yaml
+++ b/tests/http-evader/http-evader-324/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-325/meta.yaml
+++ b/tests/http-evader/http-evader-325/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-326/meta.yaml
+++ b/tests/http-evader/http-evader-326/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-327/meta.yaml
+++ b/tests/http-evader/http-evader-327/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-328/meta.yaml
+++ b/tests/http-evader/http-evader-328/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-329/meta.yaml
+++ b/tests/http-evader/http-evader-329/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-330/meta.yaml
+++ b/tests/http-evader/http-evader-330/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-331/meta.yaml
+++ b/tests/http-evader/http-evader-331/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-332/meta.yaml
+++ b/tests/http-evader/http-evader-332/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-333/meta.yaml
+++ b/tests/http-evader/http-evader-333/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-334/meta.yaml
+++ b/tests/http-evader/http-evader-334/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-335/meta.yaml
+++ b/tests/http-evader/http-evader-335/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-336/meta.yaml
+++ b/tests/http-evader/http-evader-336/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-337/meta.yaml
+++ b/tests/http-evader/http-evader-337/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-338/meta.yaml
+++ b/tests/http-evader/http-evader-338/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-339/meta.yaml
+++ b/tests/http-evader/http-evader-339/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-340/meta.yaml
+++ b/tests/http-evader/http-evader-340/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-341/meta.yaml
+++ b/tests/http-evader/http-evader-341/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-342/meta.yaml
+++ b/tests/http-evader/http-evader-342/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-343/meta.yaml
+++ b/tests/http-evader/http-evader-343/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-344/meta.yaml
+++ b/tests/http-evader/http-evader-344/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-345/meta.yaml
+++ b/tests/http-evader/http-evader-345/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-346/meta.yaml
+++ b/tests/http-evader/http-evader-346/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-347/meta.yaml
+++ b/tests/http-evader/http-evader-347/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-348/meta.yaml
+++ b/tests/http-evader/http-evader-348/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-349/meta.yaml
+++ b/tests/http-evader/http-evader-349/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-350/meta.yaml
+++ b/tests/http-evader/http-evader-350/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-351/meta.yaml
+++ b/tests/http-evader/http-evader-351/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-352/meta.yaml
+++ b/tests/http-evader/http-evader-352/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-353/meta.yaml
+++ b/tests/http-evader/http-evader-353/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-354/meta.yaml
+++ b/tests/http-evader/http-evader-354/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-355/meta.yaml
+++ b/tests/http-evader/http-evader-355/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-356/meta.yaml
+++ b/tests/http-evader/http-evader-356/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-357/meta.yaml
+++ b/tests/http-evader/http-evader-357/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-358/meta.yaml
+++ b/tests/http-evader/http-evader-358/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-359/meta.yaml
+++ b/tests/http-evader/http-evader-359/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-360/meta.yaml
+++ b/tests/http-evader/http-evader-360/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-361/meta.yaml
+++ b/tests/http-evader/http-evader-361/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-362/meta.yaml
+++ b/tests/http-evader/http-evader-362/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-363/meta.yaml
+++ b/tests/http-evader/http-evader-363/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-364/meta.yaml
+++ b/tests/http-evader/http-evader-364/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-365/meta.yaml
+++ b/tests/http-evader/http-evader-365/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-366/meta.yaml
+++ b/tests/http-evader/http-evader-366/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-367/meta.yaml
+++ b/tests/http-evader/http-evader-367/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-368/meta.yaml
+++ b/tests/http-evader/http-evader-368/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-369/meta.yaml
+++ b/tests/http-evader/http-evader-369/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-370/meta.yaml
+++ b/tests/http-evader/http-evader-370/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-371/meta.yaml
+++ b/tests/http-evader/http-evader-371/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-372/meta.yaml
+++ b/tests/http-evader/http-evader-372/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-373/meta.yaml
+++ b/tests/http-evader/http-evader-373/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-374/meta.yaml
+++ b/tests/http-evader/http-evader-374/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-375/meta.yaml
+++ b/tests/http-evader/http-evader-375/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-376/meta.yaml
+++ b/tests/http-evader/http-evader-376/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-377/meta.yaml
+++ b/tests/http-evader/http-evader-377/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-378/meta.yaml
+++ b/tests/http-evader/http-evader-378/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-379/meta.yaml
+++ b/tests/http-evader/http-evader-379/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-380/meta.yaml
+++ b/tests/http-evader/http-evader-380/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-381/meta.yaml
+++ b/tests/http-evader/http-evader-381/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-382/meta.yaml
+++ b/tests/http-evader/http-evader-382/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-383/meta.yaml
+++ b/tests/http-evader/http-evader-383/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-384/meta.yaml
+++ b/tests/http-evader/http-evader-384/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-385/meta.yaml
+++ b/tests/http-evader/http-evader-385/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-386/meta.yaml
+++ b/tests/http-evader/http-evader-386/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-387/meta.yaml
+++ b/tests/http-evader/http-evader-387/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-388/meta.yaml
+++ b/tests/http-evader/http-evader-388/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-389/meta.yaml
+++ b/tests/http-evader/http-evader-389/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-390/meta.yaml
+++ b/tests/http-evader/http-evader-390/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-391/meta.yaml
+++ b/tests/http-evader/http-evader-391/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-392/meta.yaml
+++ b/tests/http-evader/http-evader-392/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-393/meta.yaml
+++ b/tests/http-evader/http-evader-393/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-394/meta.yaml
+++ b/tests/http-evader/http-evader-394/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-395/meta.yaml
+++ b/tests/http-evader/http-evader-395/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-396/meta.yaml
+++ b/tests/http-evader/http-evader-396/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-397/meta.yaml
+++ b/tests/http-evader/http-evader-397/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-398/meta.yaml
+++ b/tests/http-evader/http-evader-398/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-399/meta.yaml
+++ b/tests/http-evader/http-evader-399/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-400/meta.yaml
+++ b/tests/http-evader/http-evader-400/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-401/meta.yaml
+++ b/tests/http-evader/http-evader-401/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-402/meta.yaml
+++ b/tests/http-evader/http-evader-402/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-403/meta.yaml
+++ b/tests/http-evader/http-evader-403/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-404/meta.yaml
+++ b/tests/http-evader/http-evader-404/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-405/meta.yaml
+++ b/tests/http-evader/http-evader-405/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-406/meta.yaml
+++ b/tests/http-evader/http-evader-406/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-407/meta.yaml
+++ b/tests/http-evader/http-evader-407/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-408/meta.yaml
+++ b/tests/http-evader/http-evader-408/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-409/meta.yaml
+++ b/tests/http-evader/http-evader-409/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-410/meta.yaml
+++ b/tests/http-evader/http-evader-410/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-411/meta.yaml
+++ b/tests/http-evader/http-evader-411/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-412/meta.yaml
+++ b/tests/http-evader/http-evader-412/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-413/meta.yaml
+++ b/tests/http-evader/http-evader-413/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-414/meta.yaml
+++ b/tests/http-evader/http-evader-414/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-415/meta.yaml
+++ b/tests/http-evader/http-evader-415/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-416/meta.yaml
+++ b/tests/http-evader/http-evader-416/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-417/meta.yaml
+++ b/tests/http-evader/http-evader-417/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-418/meta.yaml
+++ b/tests/http-evader/http-evader-418/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-419/meta.yaml
+++ b/tests/http-evader/http-evader-419/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-420/meta.yaml
+++ b/tests/http-evader/http-evader-420/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-421/meta.yaml
+++ b/tests/http-evader/http-evader-421/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-422/meta.yaml
+++ b/tests/http-evader/http-evader-422/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-423/meta.yaml
+++ b/tests/http-evader/http-evader-423/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-424/meta.yaml
+++ b/tests/http-evader/http-evader-424/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-425/meta.yaml
+++ b/tests/http-evader/http-evader-425/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-426/meta.yaml
+++ b/tests/http-evader/http-evader-426/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-427/meta.yaml
+++ b/tests/http-evader/http-evader-427/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-428/meta.yaml
+++ b/tests/http-evader/http-evader-428/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-429/meta.yaml
+++ b/tests/http-evader/http-evader-429/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-430/meta.yaml
+++ b/tests/http-evader/http-evader-430/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-431/meta.yaml
+++ b/tests/http-evader/http-evader-431/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-432/meta.yaml
+++ b/tests/http-evader/http-evader-432/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-433/meta.yaml
+++ b/tests/http-evader/http-evader-433/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-434/meta.yaml
+++ b/tests/http-evader/http-evader-434/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-435/meta.yaml
+++ b/tests/http-evader/http-evader-435/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-436/meta.yaml
+++ b/tests/http-evader/http-evader-436/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-437/meta.yaml
+++ b/tests/http-evader/http-evader-437/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-438/meta.yaml
+++ b/tests/http-evader/http-evader-438/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-439/meta.yaml
+++ b/tests/http-evader/http-evader-439/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-440/meta.yaml
+++ b/tests/http-evader/http-evader-440/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-441/meta.yaml
+++ b/tests/http-evader/http-evader-441/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-442/meta.yaml
+++ b/tests/http-evader/http-evader-442/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-443/meta.yaml
+++ b/tests/http-evader/http-evader-443/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-444/meta.yaml
+++ b/tests/http-evader/http-evader-444/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-445/meta.yaml
+++ b/tests/http-evader/http-evader-445/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-446/meta.yaml
+++ b/tests/http-evader/http-evader-446/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-447/meta.yaml
+++ b/tests/http-evader/http-evader-447/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-448/meta.yaml
+++ b/tests/http-evader/http-evader-448/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-449/meta.yaml
+++ b/tests/http-evader/http-evader-449/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-450/meta.yaml
+++ b/tests/http-evader/http-evader-450/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-451/meta.yaml
+++ b/tests/http-evader/http-evader-451/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-452/meta.yaml
+++ b/tests/http-evader/http-evader-452/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-453/meta.yaml
+++ b/tests/http-evader/http-evader-453/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-454/meta.yaml
+++ b/tests/http-evader/http-evader-454/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-455/meta.yaml
+++ b/tests/http-evader/http-evader-455/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-456/meta.yaml
+++ b/tests/http-evader/http-evader-456/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-457/meta.yaml
+++ b/tests/http-evader/http-evader-457/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-458/meta.yaml
+++ b/tests/http-evader/http-evader-458/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-459/meta.yaml
+++ b/tests/http-evader/http-evader-459/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-460/meta.yaml
+++ b/tests/http-evader/http-evader-460/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-461/meta.yaml
+++ b/tests/http-evader/http-evader-461/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-462/meta.yaml
+++ b/tests/http-evader/http-evader-462/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-463/meta.yaml
+++ b/tests/http-evader/http-evader-463/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-464/meta.yaml
+++ b/tests/http-evader/http-evader-464/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-465/meta.yaml
+++ b/tests/http-evader/http-evader-465/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-466/meta.yaml
+++ b/tests/http-evader/http-evader-466/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-467/meta.yaml
+++ b/tests/http-evader/http-evader-467/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-468/meta.yaml
+++ b/tests/http-evader/http-evader-468/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-469/meta.yaml
+++ b/tests/http-evader/http-evader-469/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-470/meta.yaml
+++ b/tests/http-evader/http-evader-470/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-471/meta.yaml
+++ b/tests/http-evader/http-evader-471/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-472/meta.yaml
+++ b/tests/http-evader/http-evader-472/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-473/meta.yaml
+++ b/tests/http-evader/http-evader-473/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-474/meta.yaml
+++ b/tests/http-evader/http-evader-474/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-475/meta.yaml
+++ b/tests/http-evader/http-evader-475/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-476/meta.yaml
+++ b/tests/http-evader/http-evader-476/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-477/meta.yaml
+++ b/tests/http-evader/http-evader-477/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-478/meta.yaml
+++ b/tests/http-evader/http-evader-478/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-479/meta.yaml
+++ b/tests/http-evader/http-evader-479/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-480/meta.yaml
+++ b/tests/http-evader/http-evader-480/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-481/meta.yaml
+++ b/tests/http-evader/http-evader-481/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-482/meta.yaml
+++ b/tests/http-evader/http-evader-482/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-483/meta.yaml
+++ b/tests/http-evader/http-evader-483/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-484/meta.yaml
+++ b/tests/http-evader/http-evader-484/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-485/meta.yaml
+++ b/tests/http-evader/http-evader-485/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-486/meta.yaml
+++ b/tests/http-evader/http-evader-486/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-487/meta.yaml
+++ b/tests/http-evader/http-evader-487/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-488/meta.yaml
+++ b/tests/http-evader/http-evader-488/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-489/meta.yaml
+++ b/tests/http-evader/http-evader-489/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-490/meta.yaml
+++ b/tests/http-evader/http-evader-490/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-491/meta.yaml
+++ b/tests/http-evader/http-evader-491/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-492/meta.yaml
+++ b/tests/http-evader/http-evader-492/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-493/meta.yaml
+++ b/tests/http-evader/http-evader-493/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-494/meta.yaml
+++ b/tests/http-evader/http-evader-494/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-495/meta.yaml
+++ b/tests/http-evader/http-evader-495/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-496/meta.yaml
+++ b/tests/http-evader/http-evader-496/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-497/meta.yaml
+++ b/tests/http-evader/http-evader-497/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-498/meta.yaml
+++ b/tests/http-evader/http-evader-498/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-499/meta.yaml
+++ b/tests/http-evader/http-evader-499/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-500/meta.yaml
+++ b/tests/http-evader/http-evader-500/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-evader/http-evader-501/meta.yaml
+++ b/tests/http-evader/http-evader-501/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-event-chunk/meta.yaml
+++ b/tests/http-event-chunk/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, http, ip, media, 'null', tcp]

--- a/tests/http-gap-beyond-body/meta.yaml
+++ b/tests/http-gap-beyond-body/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, http, ip, 'null', tcp]

--- a/tests/http-gap-double/meta.yaml
+++ b/tests/http-gap-double/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, http, ip, 'null', tcp]

--- a/tests/http-gap-simple-frames-ips/meta.yaml
+++ b/tests/http-gap-simple-frames-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, http, ip, 'null', tcp]

--- a/tests/http-gap-simple-frames/meta.yaml
+++ b/tests/http-gap-simple-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, http, ip, 'null', tcp]

--- a/tests/http-gap-simple/meta.yaml
+++ b/tests/http-gap-simple/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, http, ip, 'null', tcp]

--- a/tests/http-gap-whole-body/meta.yaml
+++ b/tests/http-gap-whole-body/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, http, ip, 'null', tcp]

--- a/tests/http-ipv6/meta.yaml
+++ b/tests/http-ipv6/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, ipv6, 'null', tcp]

--- a/tests/http-mime-truncated/meta.yaml
+++ b/tests/http-mime-truncated/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, media, mime_multipart, tcp]

--- a/tests/http-missing-protocol/meta.yaml
+++ b/tests/http-missing-protocol/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-multiple-cl/meta.yaml
+++ b/tests/http-multiple-cl/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, http, ip, 'null', tcp]

--- a/tests/http-multiple100/meta.yaml
+++ b/tests/http-multiple100/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, mime_multipart, tcp]

--- a/tests/http-not09-file/meta.yaml
+++ b/tests/http-not09-file/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/http-not09-spaces/meta.yaml
+++ b/tests/http-not09-spaces/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/http-not09/meta.yaml
+++ b/tests/http-not09/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/http-options-method/meta.yaml
+++ b/tests/http-options-method/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-pipeline-files-with-gap/meta.yaml
+++ b/tests/http-pipeline-files-with-gap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, image-jfif, ip, tcp]

--- a/tests/http-post-data-decompression/meta.yaml
+++ b/tests/http-post-data-decompression/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, urlencoded-form]

--- a/tests/http-post-file/meta.yaml
+++ b/tests/http-post-file/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, http, ipv6, json, 'null', tcp]

--- a/tests/http-protocol-inspect-v2/meta.yaml
+++ b/tests/http-protocol-inspect-v2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, dns, eth, http, ip, tcp, udp, xml]

--- a/tests/http-protocol-nodup/meta.yaml
+++ b/tests/http-protocol-nodup/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/http-range-file/meta.yaml
+++ b/tests/http-range-file/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, media, tcp]

--- a/tests/http-range-multiflows/meta.yaml
+++ b/tests/http-range-multiflows/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, media, 'null', tcp]

--- a/tests/http-range/meta.yaml
+++ b/tests/http-range/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/http-raw-header/meta.yaml
+++ b/tests/http-raw-header/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/http-request-header-multi/meta.yaml
+++ b/tests/http-request-header-multi/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/http-request-header/meta.yaml
+++ b/tests/http-request-header/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/http-request-invalid/meta.yaml
+++ b/tests/http-request-invalid/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, ssdp, tcp, udp, urlencoded-form]

--- a/tests/http-request-line-packet/meta.yaml
+++ b/tests/http-request-line-packet/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp, vlan]

--- a/tests/http-request-line/meta.yaml
+++ b/tests/http-request-line/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/http-response-line/meta.yaml
+++ b/tests/http-response-line/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, tcp, vlan]

--- a/tests/http-sha256-drop-02/meta.yaml
+++ b/tests/http-sha256-drop-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, media, tcp]

--- a/tests/http-sha256-drop/meta.yaml
+++ b/tests/http-sha256-drop/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, eth, http, igmp, ip, media, tcp]

--- a/tests/http-sticky-location/meta.yaml
+++ b/tests/http-sticky-location/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, cms, data, data-text-lines, db-lsp-disc, dhcp, dns, eth, http, icmp, image-gif, image-jfif, ip, json, llmnr, logotypecertextn, media, msnms, nbdgm, nbns, nbss, ns_cert_exts, pkix1explicit, pkix1implicit, png, portcontrol, rtcp, smb, snmp, ssdp, tcp, tls, udp, urlencoded-form, x509, x509ce, x509sat, xml]

--- a/tests/http-sticky-server/meta.yaml
+++ b/tests/http-sticky-server/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, cms, data, data-text-lines, db-lsp-disc, dhcp, dns, eth, http, icmp, image-gif, image-jfif, ip, json, llmnr, logotypecertextn, media, msnms, nbdgm, nbns, nbss, ns_cert_exts, pkix1explicit, pkix1implicit, png, portcontrol, rtcp, smb, snmp, ssdp, tcp, tls, udp, urlencoded-form, x509, x509ce, x509sat, xml]

--- a/tests/http-sticky-start/meta.yaml
+++ b/tests/http-sticky-start/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/http-uri-spaces/meta.yaml
+++ b/tests/http-uri-spaces/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, ip, 'null', tcp]

--- a/tests/http-urldecode-body/meta.yaml
+++ b/tests/http-urldecode-body/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, ip, ipv6, 'null', tcp, urlencoded-form]

--- a/tests/http-xff-eve-forward-extra-data/meta.yaml
+++ b/tests/http-xff-eve-forward-extra-data/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/http-xff-eve-forward-overwrite/meta.yaml
+++ b/tests/http-xff-eve-forward-overwrite/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/http-xff-eve-reverse-extra-data/meta.yaml
+++ b/tests/http-xff-eve-reverse-extra-data/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/http-xff-eve-reverse-overwrite/meta.yaml
+++ b/tests/http-xff-eve-reverse-overwrite/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/http1-noint-status/meta.yaml
+++ b/tests/http1-noint-status/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, http, ip, 'null', tcp]

--- a/tests/http2-authority-mismatch/meta.yaml
+++ b/tests/http2-authority-mismatch/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, http2, ip, tcp]

--- a/tests/http2-basic/meta.yaml
+++ b/tests/http2-basic/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http2, ipv6, tcp]

--- a/tests/http2-bugfixes/meta.yaml
+++ b/tests/http2-bugfixes/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http2, ip, tcp, tls]

--- a/tests/http2-compression-bug/meta.yaml
+++ b/tests/http2-compression-bug/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http2, ip, tcp, tls]

--- a/tests/http2-continuation/meta.yaml
+++ b/tests/http2-continuation/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, http2, ip, 'null', tcp]

--- a/tests/http2-deflate/meta.yaml
+++ b/tests/http2-deflate/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, http, http2, ip, 'null', tcp]

--- a/tests/http2-disabled/meta.yaml
+++ b/tests/http2-disabled/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, http2, ip, tcp]

--- a/tests/http2-errorcode/meta.yaml
+++ b/tests/http2-errorcode/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, grpc, http, http2, ip, 'null', protobuf, tcp]

--- a/tests/http2-files-6/meta.yaml
+++ b/tests/http2-files-6/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http2, ipv6, tcp]

--- a/tests/http2-files/meta.yaml
+++ b/tests/http2-files/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http2, ipv6, tcp]

--- a/tests/http2-frames/meta.yaml
+++ b/tests/http2-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, http2, ip, tcp]

--- a/tests/http2-header/meta.yaml
+++ b/tests/http2-header/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http2, ipv6, tcp]

--- a/tests/http2-host/meta.yaml
+++ b/tests/http2-host/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http2, ip, tcp, tls]

--- a/tests/http2-keywords/meta.yaml
+++ b/tests/http2-keywords/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http2, ipv6, tcp]

--- a/tests/http2-keywords2/meta.yaml
+++ b/tests/http2-keywords2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, http2, ip, tcp]

--- a/tests/http2-long-frame/meta.yaml
+++ b/tests/http2-long-frame/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http2, ip, tcp]

--- a/tests/http2-range/meta.yaml
+++ b/tests/http2-range/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, http2, ip, 'null', tcp]

--- a/tests/http2-upgrade/meta.yaml
+++ b/tests/http2-upgrade/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, http2, ip, tcp]

--- a/tests/http2-userinfo-authority/meta.yaml
+++ b/tests/http2-userinfo-authority/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, http2, ip, tcp]

--- a/tests/http2-window-index/meta.yaml
+++ b/tests/http2-window-index/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http2, ipv6, tcp]

--- a/tests/icmp-hdr-01/meta.yaml
+++ b/tests/icmp-hdr-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, icmp, ip]

--- a/tests/icmp-hdr-02/meta.yaml
+++ b/tests/icmp-hdr-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, icmp, ip]

--- a/tests/igmp/igmp-v1-v2-rgmp-01/meta.yaml
+++ b/tests/igmp/igmp-v1-v2-rgmp-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, igmp, ip, rgmp]

--- a/tests/igmp/igmp-v1-v2-rgmp-02-decoder-events/meta.yaml
+++ b/tests/igmp/igmp-v1-v2-rgmp-02-decoder-events/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, igmp, ip, rgmp]

--- a/tests/igmp/igmp-v3-queries-01/meta.yaml
+++ b/tests/igmp/igmp-v3-queries-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, igmp, ip]

--- a/tests/ikev1-duplicate-proposals/meta.yaml
+++ b/tests/ikev1-duplicate-proposals/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ike, ip, udp]

--- a/tests/ikev1-rules/meta.yaml
+++ b/tests/ikev1-rules/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ike, ip, udp]

--- a/tests/ikev1-transforms/meta.yaml
+++ b/tests/ikev1-transforms/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ike, ip, udp]

--- a/tests/ikev1/meta.yaml
+++ b/tests/ikev1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ike, ip, udp]

--- a/tests/ikev2-weak-dh/meta.yaml
+++ b/tests/ikev2-weak-dh/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ike, ip, raw, udp]

--- a/tests/imap-detection/meta.yaml
+++ b/tests/imap-detection/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, imap, ip, smtp, tcp]

--- a/tests/iponly-midstream-01/meta.yaml
+++ b/tests/iponly-midstream-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/ipopts-esec/meta.yaml
+++ b/tests/ipopts-esec/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/iprep-02/meta.yaml
+++ b/tests/iprep-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/iprep-03-bug-6834/meta.yaml
+++ b/tests/iprep-03-bug-6834/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/iprep-04-bug-6834-any/meta.yaml
+++ b/tests/iprep-04-bug-6834-any/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/iprep-05-bug-6834-both/meta.yaml
+++ b/tests/iprep-05-bug-6834-both/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/iprep-06-bug-6834-dst/meta.yaml
+++ b/tests/iprep-06-bug-6834-dst/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/iprep-07-bug-6834-src-cidr/meta.yaml
+++ b/tests/iprep-07-bug-6834-src-cidr/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/iprep-08-bug-6834-any-cidr/meta.yaml
+++ b/tests/iprep-08-bug-6834-any-cidr/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/iprep-09-bug-6834-both-cidr/meta.yaml
+++ b/tests/iprep-09-bug-6834-both-cidr/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/iprep-10-bug-6834-dst-cidr/meta.yaml
+++ b/tests/iprep-10-bug-6834-dst-cidr/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/iprep-11-isset/meta.yaml
+++ b/tests/iprep-11-isset/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/iprep-12-rule-types/meta.yaml
+++ b/tests/iprep-12-rule-types/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/ips-state-1/meta.yaml
+++ b/tests/ips-state-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp, tls]

--- a/tests/ips/firewall-01-tcp-pkt-state-flowbits/meta.yaml
+++ b/tests/ips/firewall-01-tcp-pkt-state-flowbits/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/ips/firewall-02-tcp-pkt-state-flow/meta.yaml
+++ b/tests/ips/firewall-02-tcp-pkt-state-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/ips/firewall-03-tcp-tls-enforce/meta.yaml
+++ b/tests/ips/firewall-03-tcp-tls-enforce/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/ips/firewall-04-tls-sni-enforce/meta.yaml
+++ b/tests/ips/firewall-04-tls-sni-enforce/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/ips/firewall-06-tls-sni-enforce/meta.yaml
+++ b/tests/ips/firewall-06-tls-sni-enforce/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/ipv4-hdr-keyword/meta.yaml
+++ b/tests/ipv4-hdr-keyword/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, udp, vlan]

--- a/tests/ipv4-truncated/meta.yaml
+++ b/tests/ipv4-truncated/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, udp]

--- a/tests/ipv6-evasion/ipv6-atomic-fragments-toobig/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-atomic-fragments-toobig/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-covert-dstopts/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-covert-dstopts/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, icmpv6, ipv6, ipv6.dstopts]

--- a/tests/ipv6-evasion/ipv6-dos-with-ext-headers-1/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-dos-with-ext-headers-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-dos-with-ext-headers-2/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-dos-with-ext-headers-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.dstopts, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-dos-with-ext-headers-3/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-dos-with-ext-headers-3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, icmpv6, ipv6, ipv6.dstopts, ipv6.hopopts, udp]

--- a/tests/ipv6-evasion/ipv6-dos-with-ext-headers-4/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-dos-with-ext-headers-4/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.dstopts, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-dos-with-ext-headers-5/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-dos-with-ext-headers-5/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ah, data, eth, icmpv6, ipv6, ipv6.hopopts, quic, tcp, udp]

--- a/tests/ipv6-evasion/ipv6-dos-with-ext-headers-6/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-dos-with-ext-headers-6/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts, ntp, udp]

--- a/tests/ipv6-evasion/ipv6-dos-with-ext-headers-7/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-dos-with-ext-headers-7/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-kill-router-gateway/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-kill-router-gateway/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, icmpv6, ipv6, ipv6.hopopts, tcp]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-1/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-10/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-10/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-11/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-11/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-12/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-12/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-15/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-15/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-16/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-16/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-17/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-17/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-18/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-18/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-2/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-22/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-22/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts, tcp]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-23/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-23/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-24/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-24/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-25/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-25/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts, tcp]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-26/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-26/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts, tcp]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-27/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-27/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-28/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-28/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts, mdns, udp]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-29/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-29/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-3/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-30/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-30/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-31/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-31/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-32/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-32/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-33/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-33/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-35/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-35/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-36/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-36/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-4/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-4/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-6/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-6/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-7/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-7/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-8/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts]

--- a/tests/ipv6-evasion/ipv6-malformed-fragments-9/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-malformed-fragments-9/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts, mdns, udp]

--- a/tests/ipv6-evasion/ipv6-rsmurf/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-rsmurf/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6]

--- a/tests/ipv6-evasion/ipv6-smurf/meta.yaml
+++ b/tests/ipv6-evasion/ipv6-smurf/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.hopopts, mdns, udp]

--- a/tests/ipv6-hdr-keyword-01/meta.yaml
+++ b/tests/ipv6-hdr-keyword-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, udp, vlan]

--- a/tests/ipv6-hdr-keyword-02/meta.yaml
+++ b/tests/ipv6-hdr-keyword-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, ipv6.dstopts, ipv6.hopopts, ipv6.routing, udp, vlan]

--- a/tests/irc/meta.yaml
+++ b/tests/irc/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, irc, tcp]

--- a/tests/issue-3267-tcphdr/meta.yaml
+++ b/tests/issue-3267-tcphdr/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/issue-3277-nfsv2-filestore/meta.yaml
+++ b/tests/issue-3277-nfsv2-filestore/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, mount, nfs, portmap, rpc, udp]

--- a/tests/issue-3341-tcphdr-01/meta.yaml
+++ b/tests/issue-3341-tcphdr-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, ip, sll, tcp, tls]

--- a/tests/issue-3703/meta.yaml
+++ b/tests/issue-3703/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/issue-4220-01-ids/meta.yaml
+++ b/tests/issue-4220-01-ids/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ip, smtp, tcp]

--- a/tests/issue-4220-02-ips/meta.yaml
+++ b/tests/issue-4220-02-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ip, smtp, tcp]

--- a/tests/issue-4280-iprep/meta.yaml
+++ b/tests/issue-4280-iprep/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/issue-4407/meta.yaml
+++ b/tests/issue-4407/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/issue-5466-alert-then-pass-01/meta.yaml
+++ b/tests/issue-5466-alert-then-pass-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip, ssh, tcp]

--- a/tests/issue-5466-alert-then-pass-02/meta.yaml
+++ b/tests/issue-5466-alert-then-pass-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/issue-5466-alert-then-pass-03-drop-pass/meta.yaml
+++ b/tests/issue-5466-alert-then-pass-03-drop-pass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip, ssh, tcp]

--- a/tests/issue-5466-alert-then-pass-04-drop-alert/meta.yaml
+++ b/tests/issue-5466-alert-then-pass-04-drop-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip, ssh, tcp]

--- a/tests/issue-7847-01/meta.yaml
+++ b/tests/issue-7847-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/issue-7847-02/meta.yaml
+++ b/tests/issue-7847-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/issue-8031-01-isdataat/meta.yaml
+++ b/tests/issue-8031-01-isdataat/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/issues/bug-8333-geoip/meta.yaml
+++ b/tests/issues/bug-8333-geoip/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/issues/bug-8333-iprep/meta.yaml
+++ b/tests/issues/bug-8333-iprep/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/issues/issue-4759.1/meta.yaml
+++ b/tests/issues/issue-4759.1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp]

--- a/tests/issues/issue-4759/meta.yaml
+++ b/tests/issues/issue-4759/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp]

--- a/tests/ja3-lua-rules-quic/meta.yaml
+++ b/tests/ja3-lua-rules-quic/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', quic, tls, udp]

--- a/tests/ja4-cl-handshake/meta.yaml
+++ b/tests/ja4-cl-handshake/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509sat]

--- a/tests/ja4-quic-7.0.x-01/meta.yaml
+++ b/tests/ja4-quic-7.0.x-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, quic, tls, udp]

--- a/tests/ja4-quic-7.0.x-02/meta.yaml
+++ b/tests/ja4-quic-7.0.x-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, quic, tls, udp]

--- a/tests/ja4-quic/meta.yaml
+++ b/tests/ja4-quic/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, quic, tls, udp]

--- a/tests/ja4-rules-7.0.x-01/meta.yaml
+++ b/tests/ja4-rules-7.0.x-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, quic, tcp, tls, udp]

--- a/tests/ja4-rules-7.0.x-02/meta.yaml
+++ b/tests/ja4-rules-7.0.x-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, quic, tcp, tls, udp]

--- a/tests/ja4-rules-bug-7010/meta.yaml
+++ b/tests/ja4-rules-bug-7010/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, quic, tcp, tls, udp]

--- a/tests/ja4-rules-disabled/meta.yaml
+++ b/tests/ja4-rules-disabled/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, quic, tcp, tls, udp]

--- a/tests/ja4-rules-invalid/meta.yaml
+++ b/tests/ja4-rules-invalid/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/ja4-rules-requires-off/meta.yaml
+++ b/tests/ja4-rules-requires-off/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, quic, tcp, tls, udp]

--- a/tests/ja4-rules-requires/meta.yaml
+++ b/tests/ja4-rules-requires/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, quic, tcp, tls, udp]

--- a/tests/ja4-rules/meta.yaml
+++ b/tests/ja4-rules/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, quic, tcp, tls, udp]

--- a/tests/ja4-sv-handshake/meta.yaml
+++ b/tests/ja4-sv-handshake/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509sat]

--- a/tests/ja4-tls-7.0.x/meta.yaml
+++ b/tests/ja4-tls-7.0.x/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/ja4-tls-quic/meta.yaml
+++ b/tests/ja4-tls-quic/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, quic, tcp, tls, udp]

--- a/tests/ja4-tls/meta.yaml
+++ b/tests/ja4-tls/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/krb5-kerberoasting/meta.yaml
+++ b/tests/krb5-kerberoasting/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, krb5, tcp]

--- a/tests/krb5-krb5_msg_type-enum/meta.yaml
+++ b/tests/krb5-krb5_msg_type-enum/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, krb5, tcp]

--- a/tests/krb5-krb5_msg_type/meta.yaml
+++ b/tests/krb5-krb5_msg_type/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, krb5, tcp]

--- a/tests/krb5-probing/meta.yaml
+++ b/tests/krb5-probing/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, krb5, tcp]

--- a/tests/krb5-request-frag-log/meta.yaml
+++ b/tests/krb5-request-frag-log/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, krb5, ldap, ntlmssp, tcp]

--- a/tests/ldap-abandon/meta.yaml
+++ b/tests/ldap-abandon/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, tcp]

--- a/tests/ldap-add/meta.yaml
+++ b/tests/ldap-add/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, tcp]

--- a/tests/ldap-bind/meta.yaml
+++ b/tests/ldap-bind/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, tcp]

--- a/tests/ldap-compare/meta.yaml
+++ b/tests/ldap-compare/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, tcp]

--- a/tests/ldap-delete/meta.yaml
+++ b/tests/ldap-delete/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, tcp]

--- a/tests/ldap-extended/meta.yaml
+++ b/tests/ldap-extended/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, tcp]

--- a/tests/ldap-frames/meta.yaml
+++ b/tests/ldap-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, udp]

--- a/tests/ldap-modify-dn/meta.yaml
+++ b/tests/ldap-modify-dn/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, tcp]

--- a/tests/ldap-modify/meta.yaml
+++ b/tests/ldap-modify/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, tcp]

--- a/tests/ldap-search/meta.yaml
+++ b/tests/ldap-search/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, tcp]

--- a/tests/ldap-starttls/meta.yaml
+++ b/tests/ldap-starttls/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, ldap, tcp, tls, x509, x509ce, x509sat]

--- a/tests/ldap-udp/meta.yaml
+++ b/tests/ldap-udp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, udp]

--- a/tests/ldap-unbind/meta.yaml
+++ b/tests/ldap-unbind/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, tcp]

--- a/tests/ldap-unsolicited/meta.yaml
+++ b/tests/ldap-unsolicited/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ldap, tcp]

--- a/tests/like-ip-only-01/meta.yaml
+++ b/tests/like-ip-only-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, krb5, ldap, ntlmssp, tcp]

--- a/tests/linktype-228/meta.yaml
+++ b/tests/linktype-228/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp, tls]

--- a/tests/linktype_name/meta.yaml
+++ b/tests/linktype_name/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dns, eth, http, icmp, ip, logotypecertextn, ocsp, pkix1explicit, pkix1implicit, pkixalgs, ssh, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/list-frames/meta.yaml
+++ b/tests/list-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/llmnr/llmnr-authority-additional/meta.yaml
+++ b/tests/llmnr/llmnr-authority-additional/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, llmnr, udp]

--- a/tests/llmnr/llmnr-hostname-match/meta.yaml
+++ b/tests/llmnr/llmnr-hostname-match/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, llmnr, udp]

--- a/tests/llmnr/llmnr-invalid-opcode/meta.yaml
+++ b/tests/llmnr/llmnr-invalid-opcode/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, llmnr, udp]

--- a/tests/llmnr/llmnr-sticky-buffers/meta.yaml
+++ b/tests/llmnr/llmnr-sticky-buffers/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, llmnr, udp]

--- a/tests/llmnr/llmnr-tcp-reassembly/meta.yaml
+++ b/tests/llmnr/llmnr-tcp-reassembly/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp]

--- a/tests/llmnr/llmnr-tcp/meta.yaml
+++ b/tests/llmnr/llmnr-tcp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp]

--- a/tests/llmnr/llmnr-udp/meta.yaml
+++ b/tests/llmnr/llmnr-udp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, llmnr, udp]

--- a/tests/lua-byte-extract-pre8/meta.yaml
+++ b/tests/lua-byte-extract-pre8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua-byte-extract/meta.yaml
+++ b/tests/lua-byte-extract/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua-detect-http-01/meta.yaml
+++ b/tests/lua-detect-http-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua-flowfunctions/meta.yaml
+++ b/tests/lua-flowfunctions/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua-flowstats/meta.yaml
+++ b/tests/lua-flowstats/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua-flowtuple/meta.yaml
+++ b/tests/lua-flowtuple/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, http2, ip, tcp]

--- a/tests/lua-match-scrule/meta.yaml
+++ b/tests/lua-match-scrule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua-memleak-pre8/meta.yaml
+++ b/tests/lua-memleak-pre8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua-memleak/meta.yaml
+++ b/tests/lua-memleak/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua-output-dns/meta.yaml
+++ b/tests/lua-output-dns/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/lua-output-http-02/meta.yaml
+++ b/tests/lua-output-http-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua-output-http-03/meta.yaml
+++ b/tests/lua-output-http-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/lua-output-http-pre8/meta.yaml
+++ b/tests/lua-output-http-pre8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua-output-http/meta.yaml
+++ b/tests/lua-output-http/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua-output-smtp-pre8/meta.yaml
+++ b/tests/lua-output-smtp-pre8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data-text-lines, dns, eth, icmp, ip, nbdgm, smb, smtp, tcp, udp]

--- a/tests/lua-output-smtp/meta.yaml
+++ b/tests/lua-output-smtp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data-text-lines, dns, eth, icmp, ip, nbdgm, smb, smtp, tcp, udp]

--- a/tests/lua-output-stats-pre8/meta.yaml
+++ b/tests/lua-output-stats-pre8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/lua-output-stats/meta.yaml
+++ b/tests/lua-output-stats/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/lua-output-streaming-pre8/meta.yaml
+++ b/tests/lua-output-streaming-pre8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/lua-output-streaming/meta.yaml
+++ b/tests/lua-output-streaming/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/lua-sandbox-alloclimit-bypass/meta.yaml
+++ b/tests/lua-sandbox-alloclimit-bypass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/lua-scfileinfo-pre8/meta.yaml
+++ b/tests/lua-scfileinfo-pre8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, vlan]

--- a/tests/lua-scfileinfo/meta.yaml
+++ b/tests/lua-scfileinfo/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, vlan]

--- a/tests/lua-scflowstats-pre8/meta.yaml
+++ b/tests/lua-scflowstats-pre8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua-scflowtuple-pre8/meta.yaml
+++ b/tests/lua-scflowtuple-pre8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua-scpackettuple-pre8/meta.yaml
+++ b/tests/lua-scpackettuple-pre8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua-scpackettuple/meta.yaml
+++ b/tests/lua-scpackettuple/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua-scrule-ids-pre8/meta.yaml
+++ b/tests/lua-scrule-ids-pre8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua-scrule-ids/meta.yaml
+++ b/tests/lua-scrule-ids/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua/lua-bad-script/meta.yaml
+++ b/tests/lua/lua-bad-script/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/lua/lua-base64/meta.yaml
+++ b/tests/lua/lua-base64/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/lua/lua-blocked-function-1/meta.yaml
+++ b/tests/lua/lua-blocked-function-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua/lua-fastlog/meta.yaml
+++ b/tests/lua/lua-fastlog/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua/lua-flowintlib/meta.yaml
+++ b/tests/lua/lua-flowintlib/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua/lua-gc-nil/meta.yaml
+++ b/tests/lua/lua-gc-nil/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/lua/lua-hashlib-output/meta.yaml
+++ b/tests/lua/lua-hashlib-output/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/lua/lua-hashlib/meta.yaml
+++ b/tests/lua/lua-hashlib/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/lua/lua-instruction-limit/meta.yaml
+++ b/tests/lua/lua-instruction-limit/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua/lua-memory-limit/meta.yaml
+++ b/tests/lua/lua-memory-limit/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/lua/lua-ntp-output/meta.yaml
+++ b/tests/lua/lua-ntp-output/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ntp, udp]

--- a/tests/lua/lua-ntp-rules/meta.yaml
+++ b/tests/lua/lua-ntp-rules/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ntp, udp]

--- a/tests/lua/lua-overflow-escape-8556/meta.yaml
+++ b/tests/lua/lua-overflow-escape-8556/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, urlencoded-form]

--- a/tests/lua/lua-packetlib-01/meta.yaml
+++ b/tests/lua/lua-packetlib-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/lua/lua-packetlib-02-restricted-funcs-allowed/meta.yaml
+++ b/tests/lua/lua-packetlib-02-restricted-funcs-allowed/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/lua/lua-packetlib-03/meta.yaml
+++ b/tests/lua/lua-packetlib-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/lua/lua-packetlib-04-icmp-spdp/meta.yaml
+++ b/tests/lua/lua-packetlib-04-icmp-spdp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, icmp, ip]

--- a/tests/lua/lua-packetlib-05-default-enabled/meta.yaml
+++ b/tests/lua/lua-packetlib-05-default-enabled/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/lua/lua-scflowvarget/meta.yaml
+++ b/tests/lua/lua-scflowvarget/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, json, tcp]

--- a/tests/lua/lua-scflowvarset/meta.yaml
+++ b/tests/lua/lua-scflowvarset/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, json, tcp]

--- a/tests/lua/lua-smtplib/meta.yaml
+++ b/tests/lua/lua-smtplib/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ip, smtp, tcp]

--- a/tests/lua/lua-tlslib-01/meta.yaml
+++ b/tests/lua/lua-tlslib-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, dns, eth, http, ip, ipv6, mdns, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/lua/lua-tlslib-02/meta.yaml
+++ b/tests/lua/lua-tlslib-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/lua/lua-transform-01/meta.yaml
+++ b/tests/lua/lua-transform-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, urlencoded-form]

--- a/tests/lua/lua-transform-02/meta.yaml
+++ b/tests/lua/lua-transform-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/lua/lua-transform-03/meta.yaml
+++ b/tests/lua/lua-transform-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/lua/lua-transform-04/meta.yaml
+++ b/tests/lua/lua-transform-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, urlencoded-form]

--- a/tests/lua/lua-transform-05/meta.yaml
+++ b/tests/lua/lua-transform-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, urlencoded-form]

--- a/tests/lua/lua-transform-06/meta.yaml
+++ b/tests/lua/lua-transform-06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, urlencoded-form]

--- a/tests/lua/lua-transform-07/meta.yaml
+++ b/tests/lua/lua-transform-07/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, urlencoded-form]

--- a/tests/lua/lua-transform-08/meta.yaml
+++ b/tests/lua/lua-transform-08/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, urlencoded-form]

--- a/tests/lua/lua-transform-09/meta.yaml
+++ b/tests/lua/lua-transform-09/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, urlencoded-form]

--- a/tests/lua/lua-transform-10-bug-8173/meta.yaml
+++ b/tests/lua/lua-transform-10-bug-8173/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, json, tcp, xml]

--- a/tests/lua/lua-transform-11-bug-8173/meta.yaml
+++ b/tests/lua/lua-transform-11-bug-8173/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, json, tcp]

--- a/tests/mac-eve-multiple-disabled/meta.yaml
+++ b/tests/mac-eve-multiple-disabled/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/mac-eve-multiple-swap/meta.yaml
+++ b/tests/mac-eve-multiple-swap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, tcp]

--- a/tests/mac-eve-multiple/meta.yaml
+++ b/tests/mac-eve-multiple/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/mac-eve-packet/meta.yaml
+++ b/tests/mac-eve-packet/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/mac-eve-single-disabled/meta.yaml
+++ b/tests/mac-eve-single-disabled/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/mac-eve-single/meta.yaml
+++ b/tests/mac-eve-single/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/mdns/meta.yaml
+++ b/tests/mdns/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmpv6, ipv6, ipv6.fraghdr, ipv6.hopopts, mdns, udp]

--- a/tests/memcap-pressure/meta.yaml
+++ b/tests/memcap-pressure/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/mime/mime-dec-parse-full-msg-test01/meta.yaml
+++ b/tests/mime/mime-dec-parse-full-msg-test01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/mime/mime-dec-parse-full-msg-test02/meta.yaml
+++ b/tests/mime/mime-dec-parse-full-msg-test02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/mime/mime-dec-parse-line-test01/meta.yaml
+++ b/tests/mime/mime-dec-parse-line-test01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/mime/mime-dec-parse-line-test02/meta.yaml
+++ b/tests/mime/mime-dec-parse-line-test02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/mime/mime-dec-parse-long-filename01/meta.yaml
+++ b/tests/mime/mime-dec-parse-long-filename01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/mime/mime-dec-parse-long-filename02/meta.yaml
+++ b/tests/mime/mime-dec-parse-long-filename02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/mime/mime-dec-parse-odd-len/meta.yaml
+++ b/tests/mime/mime-dec-parse-odd-len/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/mime/mime-dec-parse-rem-sp/meta.yaml
+++ b/tests/mime/mime-dec-parse-rem-sp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/mime/mime-dec-parse-small-rem-inp/meta.yaml
+++ b/tests/mime/mime-dec-parse-small-rem-inp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/mime/mime-dec-very-small-inp/meta.yaml
+++ b/tests/mime/mime-dec-very-small-inp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/mime/mime-quoted-printable/meta.yaml
+++ b/tests/mime/mime-quoted-printable/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ip, smtp, tcp]

--- a/tests/mime/mime-stream-depth/meta.yaml
+++ b/tests/mime/mime-stream-depth/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp]

--- a/tests/modbus/meta.yaml
+++ b/tests/modbus/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, modbus, tcp]

--- a/tests/mqtt-binary-message/meta.yaml
+++ b/tests/mqtt-binary-message/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-connect-rules-2/meta.yaml
+++ b/tests/mqtt-connect-rules-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-connect-rules-3/meta.yaml
+++ b/tests/mqtt-connect-rules-3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-connect-rules/meta.yaml
+++ b/tests/mqtt-connect-rules/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-events-invalid-qos/meta.yaml
+++ b/tests/mqtt-events-invalid-qos/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-events-missing-connect/meta.yaml
+++ b/tests/mqtt-events-missing-connect/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, ipv6, json, mqtt, tcp, tls]

--- a/tests/mqtt-events-unassigned-msgtype/meta.yaml
+++ b/tests/mqtt-events-unassigned-msgtype/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-events-unintroduced/meta.yaml
+++ b/tests/mqtt-events-unintroduced/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-frames-truncated/meta.yaml
+++ b/tests/mqtt-frames-truncated/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, mqtt, tcp]

--- a/tests/mqtt-frames-xpdu/meta.yaml
+++ b/tests/mqtt-frames-xpdu/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-frames/meta.yaml
+++ b/tests/mqtt-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-limit-1/meta.yaml
+++ b/tests/mqtt-limit-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-limit-2/meta.yaml
+++ b/tests/mqtt-limit-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-limit-3/meta.yaml
+++ b/tests/mqtt-limit-3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-limit-log-1/meta.yaml
+++ b/tests/mqtt-limit-log-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-limit-log-2/meta.yaml
+++ b/tests/mqtt-limit-log-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-limit-log-3/meta.yaml
+++ b/tests/mqtt-limit-log-3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-limit-log-fail/meta.yaml
+++ b/tests/mqtt-limit-log-fail/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-midstream-split/meta.yaml
+++ b/tests/mqtt-midstream-split/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, mqtt, tcp]

--- a/tests/mqtt-ping/meta.yaml
+++ b/tests/mqtt-ping/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, mqtt, tcp]

--- a/tests/mqtt-pub-rules/meta.yaml
+++ b/tests/mqtt-pub-rules/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-sub-rules/meta.yaml
+++ b/tests/mqtt-sub-rules/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt-unsub-rules/meta.yaml
+++ b/tests/mqtt-unsub-rules/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt31-pub-qos1/meta.yaml
+++ b/tests/mqtt31-pub-qos1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt31-pub-qos2/meta.yaml
+++ b/tests/mqtt31-pub-qos2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt31-pub-userpass-auto-clientid/meta.yaml
+++ b/tests/mqtt31-pub-userpass-auto-clientid/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt31-pub-userpass/meta.yaml
+++ b/tests/mqtt31-pub-userpass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt31-sub-userpass/meta.yaml
+++ b/tests/mqtt31-sub-userpass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt31-unsub-qos1/meta.yaml
+++ b/tests/mqtt31-unsub-qos1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt31-unsub-qos2/meta.yaml
+++ b/tests/mqtt31-unsub-qos2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt31-unsub-userpass/meta.yaml
+++ b/tests/mqtt31-unsub-userpass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt311-pub-qos1/meta.yaml
+++ b/tests/mqtt311-pub-qos1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt311-pub-qos2/meta.yaml
+++ b/tests/mqtt311-pub-qos2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt311-pub-userpass-auto-clientid/meta.yaml
+++ b/tests/mqtt311-pub-userpass-auto-clientid/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt311-pub-userpass/meta.yaml
+++ b/tests/mqtt311-pub-userpass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt311-sub-userpass/meta.yaml
+++ b/tests/mqtt311-sub-userpass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt311-unsub-qos1/meta.yaml
+++ b/tests/mqtt311-unsub-qos1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt311-unsub-qos2/meta.yaml
+++ b/tests/mqtt311-unsub-qos2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt311-unsub-userpass/meta.yaml
+++ b/tests/mqtt311-unsub-userpass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt5-excessiveproplen/meta.yaml
+++ b/tests/mqtt5-excessiveproplen/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt5-pub-mosquittoprops/meta.yaml
+++ b/tests/mqtt5-pub-mosquittoprops/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt5-pub-qos1/meta.yaml
+++ b/tests/mqtt5-pub-qos1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt5-pub-qos2/meta.yaml
+++ b/tests/mqtt5-pub-qos2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt5-pub-userpass-auto-clientid/meta.yaml
+++ b/tests/mqtt5-pub-userpass-auto-clientid/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt5-pub-userpass/meta.yaml
+++ b/tests/mqtt5-pub-userpass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt5-sub-customauth/meta.yaml
+++ b/tests/mqtt5-sub-customauth/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt5-sub-mosquittoprops/meta.yaml
+++ b/tests/mqtt5-sub-mosquittoprops/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt5-sub-userpass/meta.yaml
+++ b/tests/mqtt5-sub-userpass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt5-unsub-qos1/meta.yaml
+++ b/tests/mqtt5-unsub-qos1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt5-unsub-qos2/meta.yaml
+++ b/tests/mqtt5-unsub-qos2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/mqtt5-unsub-userpass/meta.yaml
+++ b/tests/mqtt5-unsub-userpass/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, mqtt, tcp]

--- a/tests/multi-tenant-01/meta.yaml
+++ b/tests/multi-tenant-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/multi-tenant-02-test/meta.yaml
+++ b/tests/multi-tenant-02-test/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/multi-tenant-03-pcap/meta.yaml
+++ b/tests/multi-tenant-03-pcap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, png, tcp, vlan]

--- a/tests/netflow-eve/meta.yaml
+++ b/tests/netflow-eve/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/netflow_compress_ipv6/meta.yaml
+++ b/tests/netflow_compress_ipv6/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, tcp, vlan]

--- a/tests/nfs-bug-5140/meta.yaml
+++ b/tests/nfs-bug-5140/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, mount, nfs, portmap, rpc, udp]

--- a/tests/nfs-udp-only/meta.yaml
+++ b/tests/nfs-udp-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, mount, nfs, portmap, rpc, udp]

--- a/tests/nfs2-log/meta.yaml
+++ b/tests/nfs2-log/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, mount, nfs, portmap, rpc, udp]

--- a/tests/nfs3-01/meta.yaml
+++ b/tests/nfs3-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, mount, nfs, portmap, rpc, udp]

--- a/tests/nfs3-procedure/meta.yaml
+++ b/tests/nfs3-procedure/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, mount, nfs, portmap, rpc, tcp, udp]

--- a/tests/nfs3-readdirplus/meta.yaml
+++ b/tests/nfs3-readdirplus/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, nfs, rpc, tcp]

--- a/tests/nfs4-01/meta.yaml
+++ b/tests/nfs4-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, nfs, rpc, tcp]

--- a/tests/nfs4-log/meta.yaml
+++ b/tests/nfs4-log/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, nfs, rpc, tcp]

--- a/tests/ntp-keywords/meta.yaml
+++ b/tests/ntp-keywords/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ntp, udp]

--- a/tests/output-eve-anomaly-01/meta.yaml
+++ b/tests/output-eve-anomaly-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip, prp]

--- a/tests/output-eve-anomaly-02/meta.yaml
+++ b/tests/output-eve-anomaly-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/output-eve-anomaly-03/meta.yaml
+++ b/tests/output-eve-anomaly-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/output-eve-anomaly-04/meta.yaml
+++ b/tests/output-eve-anomaly-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/output-eve-anomaly-05/meta.yaml
+++ b/tests/output-eve-anomaly-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/output-eve-anomaly-packethdr/meta.yaml
+++ b/tests/output-eve-anomaly-packethdr/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip, prp]

--- a/tests/output-eve-dhcp-01/meta.yaml
+++ b/tests/output-eve-dhcp-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dhcp, eth, ip, udp]

--- a/tests/output-eve-fileinfo/meta.yaml
+++ b/tests/output-eve-fileinfo/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/output-eve-ftp-data/meta.yaml
+++ b/tests/output-eve-ftp-data/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, data-text-lines, dhcp, dhcpv6, dns, eth, ftp, ftp-data, http, icmpv6, igmp, ip, ipv6, ipv6.hopopts, llmnr, nbns, ssdp, tcp, teredo, udp, xml]

--- a/tests/output-eve-ftp/meta.yaml
+++ b/tests/output-eve-ftp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ftp, ip, tcp]

--- a/tests/output-eve-rdp-01/meta.yaml
+++ b/tests/output-eve-rdp-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [cotp, data, eth, ip, rdp, t124, t125, tcp]

--- a/tests/output-eve-smb-01/meta.yaml
+++ b/tests/output-eve-smb-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, gss-api, ip, nbss, ntlmssp, sll, smb, spnego, tcp]

--- a/tests/output-eve-tftp-01/meta.yaml
+++ b/tests/output-eve-tftp-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tftp, udp]

--- a/tests/output-multi-eve/meta.yaml
+++ b/tests/output-multi-eve/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, data-text-lines, http, ip, media, q931, sll, tcp, urlencoded-form]

--- a/tests/output-pcap-log-conditional-alert/meta.yaml
+++ b/tests/output-pcap-log-conditional-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/output-pcap-log-conditional-noalert/meta.yaml
+++ b/tests/output-pcap-log-conditional-noalert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/output-pcap-log-conditional-tag-alert/meta.yaml
+++ b/tests/output-pcap-log-conditional-tag-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/output-pcap-log-filter/meta.yaml
+++ b/tests/output-pcap-log-filter/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, dns, eth, http, ip, tcp, udp]

--- a/tests/output-pcap-log/meta.yaml
+++ b/tests/output-pcap-log/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/output-tcp-data/meta.yaml
+++ b/tests/output-tcp-data/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/pcap-file-delete-non-alerts-only-flow-timeout-alert/meta.yaml
+++ b/tests/pcap-file-delete-non-alerts-only-flow-timeout-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/pcap-file-delete-non-alerts-only-no-alerts/meta.yaml
+++ b/tests/pcap-file-delete-non-alerts-only-no-alerts/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/pcap-file-delete-non-alerts-only-pseudo-no-alert/meta.yaml
+++ b/tests/pcap-file-delete-non-alerts-only-pseudo-no-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/pcap-file-delete-non-alerts-only-stream-alerts/meta.yaml
+++ b/tests/pcap-file-delete-non-alerts-only-stream-alerts/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/pcap-file-delete-non-alerts-only-with-alerts/meta.yaml
+++ b/tests/pcap-file-delete-non-alerts-only-with-alerts/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/pcap-file-stdin/meta.yaml
+++ b/tests/pcap-file-stdin/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp]

--- a/tests/pcap-log-lz4-01/meta.yaml
+++ b/tests/pcap-log-lz4-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dns, eth, http, icmp, ip, logotypecertextn, ocsp, pkix1explicit, pkix1implicit, pkixalgs, ssh, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/pcap-log-lz4-02-multi/meta.yaml
+++ b/tests/pcap-log-lz4-02-multi/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dns, eth, http, icmp, ip, logotypecertextn, ocsp, pkix1explicit, pkix1implicit, pkixalgs, ssh, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/pcap-log-lz4-03-multi-ring/meta.yaml
+++ b/tests/pcap-log-lz4-03-multi-ring/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dns, eth, http, icmp, ip, logotypecertextn, ocsp, pkix1explicit, pkix1implicit, pkixalgs, ssh, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/pcap-log-lz4-04-multi-ring-profile/meta.yaml
+++ b/tests/pcap-log-lz4-04-multi-ring-profile/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dns, eth, http, icmp, ip, logotypecertextn, ocsp, pkix1explicit, pkix1implicit, pkixalgs, ssh, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/pcap-log-lz4-05-tunnel/meta.yaml
+++ b/tests/pcap-log-lz4-05-tunnel/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp, vxlan]

--- a/tests/pcap-log-lz4-write/meta.yaml
+++ b/tests/pcap-log-lz4-write/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/pcap-log-uncompressed-01/meta.yaml
+++ b/tests/pcap-log-uncompressed-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dns, eth, http, icmp, ip, logotypecertextn, ocsp, pkix1explicit, pkix1implicit, pkixalgs, ssh, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/pcap-log-uncompressed-02-multi/meta.yaml
+++ b/tests/pcap-log-uncompressed-02-multi/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dns, eth, http, icmp, ip, logotypecertextn, ocsp, pkix1explicit, pkix1implicit, pkixalgs, ssh, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/pcap-log-uncompressed-03-multi-bpf/meta.yaml
+++ b/tests/pcap-log-uncompressed-03-multi-bpf/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dns, eth, http, icmp, ip, logotypecertextn, ocsp, pkix1explicit, pkix1implicit, pkixalgs, ssh, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/pcre-invalid-rule-01/meta.yaml
+++ b/tests/pcre-invalid-rule-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/pgsql-bug-6080-probe-test-01/meta.yaml
+++ b/tests/pgsql-bug-6080-probe-test-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp]

--- a/tests/pgsql/pgsql-5000-query-results/meta.yaml
+++ b/tests/pgsql/pgsql-5000-query-results/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pgsql, tcp]

--- a/tests/pgsql/pgsql-5524/meta.yaml
+++ b/tests/pgsql/pgsql-5524/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pgsql, tcp]

--- a/tests/pgsql/pgsql-7000-ids/meta.yaml
+++ b/tests/pgsql/pgsql-7000-ids/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pgsql, tcp]

--- a/tests/pgsql/pgsql-bug-5579/meta.yaml
+++ b/tests/pgsql/pgsql-bug-5579/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', pgsql, tcp]

--- a/tests/pgsql/pgsql-bug-6092-log-flags-and-metadata-01/meta.yaml
+++ b/tests/pgsql/pgsql-bug-6092-log-flags-and-metadata-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pgsql, tcp]

--- a/tests/pgsql/pgsql-bug-6092-log-flags-and-metadata-02/meta.yaml
+++ b/tests/pgsql/pgsql-bug-6092-log-flags-and-metadata-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pgsql, tcp]

--- a/tests/pgsql/pgsql-bug-6983-ids/meta.yaml
+++ b/tests/pgsql/pgsql-bug-6983-ids/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pgsql, tcp]

--- a/tests/pgsql/pgsql-bug-6983-ips/meta.yaml
+++ b/tests/pgsql/pgsql-bug-6983-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pgsql, tcp]

--- a/tests/pgsql/pgsql-cancel-request/meta.yaml
+++ b/tests/pgsql/pgsql-cancel-request/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, pgsql, raw, tcp]

--- a/tests/pgsql/pgsql-copy-data-in/meta.yaml
+++ b/tests/pgsql/pgsql-copy-data-in/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pgsql, tcp]

--- a/tests/pgsql/pgsql-copy-data-out/meta.yaml
+++ b/tests/pgsql/pgsql-copy-data-out/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pgsql, tcp]

--- a/tests/pgsql/pgsql-events/meta.yaml
+++ b/tests/pgsql/pgsql-events/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, pgsql, raw, tcp]

--- a/tests/pgsql/pgsql-pwd-output-disabled/meta.yaml
+++ b/tests/pgsql/pgsql-pwd-output-disabled/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pgsql, tcp]

--- a/tests/pgsql/pgsql-query-keyword-01/meta.yaml
+++ b/tests/pgsql/pgsql-query-keyword-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pgsql, tcp]

--- a/tests/pgsql/pgsql-query-keyword-02/meta.yaml
+++ b/tests/pgsql/pgsql-query-keyword-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pgsql, tcp]

--- a/tests/pgsql/pgsql-simple-query-rollback/meta.yaml
+++ b/tests/pgsql/pgsql-simple-query-rollback/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pgsql, tcp]

--- a/tests/pgsql/pgsql-ssl-rejected-md5-auth-simple-query/meta.yaml
+++ b/tests/pgsql/pgsql-ssl-rejected-md5-auth-simple-query/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pgsql, tcp]

--- a/tests/pgsql/pgsql-upgrade-tls/meta.yaml
+++ b/tests/pgsql/pgsql-upgrade-tls/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pgsql, tcp, tls, x509, x509ce, x509sat]

--- a/tests/pop3-02-bug-7709/meta.yaml
+++ b/tests/pop3-02-bug-7709/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pop3, smtp, tcp]

--- a/tests/pop3-03-bug-7709/meta.yaml
+++ b/tests/pop3-03-bug-7709/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, eth, ip, pop3, tcp]

--- a/tests/pop3-auth-01/meta.yaml
+++ b/tests/pop3-auth-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pop3, smtp, tcp]

--- a/tests/pop3/meta.yaml
+++ b/tests/pop3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pop3, smtp, tcp]

--- a/tests/pppoe/meta.yaml
+++ b/tests/pppoe/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ccp, eth, ipcp, ipv6cp, lcp, ppp, pppoed, pppoes]

--- a/tests/pre8/lua-match-scrule/meta.yaml
+++ b/tests/pre8/lua-match-scrule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/pre8/lua-scflowvarget/meta.yaml
+++ b/tests/pre8/lua-scflowvarget/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, json, tcp]

--- a/tests/prefilter-multibuf-multipkts/meta.yaml
+++ b/tests/prefilter-multibuf-multipkts/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [http, ip, media, 'null', tcp]

--- a/tests/proto-mismatch-http-ssh/meta.yaml
+++ b/tests/proto-mismatch-http-ssh/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/protocol-change-failed-event/meta.yaml
+++ b/tests/protocol-change-failed-event/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/quic-ack3/meta.yaml
+++ b/tests/quic-ack3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, quic, raw, tls, udp]

--- a/tests/quic-alerts/meta.yaml
+++ b/tests/quic-alerts/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, quic, udp]

--- a/tests/quic-cyu/meta.yaml
+++ b/tests/quic-cyu/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, quic, udp]

--- a/tests/quic-frag-middle-gap/meta.yaml
+++ b/tests/quic-frag-middle-gap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, quic, tls, udp]

--- a/tests/quic-frag-unordered/meta.yaml
+++ b/tests/quic-frag-unordered/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, quic, raw, tls, udp]

--- a/tests/quic-frag-wait/meta.yaml
+++ b/tests/quic-frag-wait/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, quic, tls, udp]

--- a/tests/quic-frag/meta.yaml
+++ b/tests/quic-frag/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, quic, tls, udp]

--- a/tests/quic-ietf-ja3/meta.yaml
+++ b/tests/quic-ietf-ja3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, quic, tls, udp]

--- a/tests/quic-ietf/meta.yaml
+++ b/tests/quic-ietf/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, quic, tls, udp]

--- a/tests/quic-initial-not-first/meta.yaml
+++ b/tests/quic-initial-not-first/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, quic, tls, udp]

--- a/tests/quic-retry-multiple/meta.yaml
+++ b/tests/quic-retry-multiple/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, quic, tls, udp]

--- a/tests/quic-retry/meta.yaml
+++ b/tests/quic-retry/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, quic, tls, udp]

--- a/tests/quic-v2-ja3/meta.yaml
+++ b/tests/quic-v2-ja3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', quic, tls, udp]

--- a/tests/quic-v2/meta.yaml
+++ b/tests/quic-v2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', quic, tls, udp]

--- a/tests/rdp-protocol/meta.yaml
+++ b/tests/rdp-protocol/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [cotp, data, eth, ip, rdp, t124, t125, tcp]

--- a/tests/reference-01/meta.yaml
+++ b/tests/reference-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/reference-02/meta.yaml
+++ b/tests/reference-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/reference-03/meta.yaml
+++ b/tests/reference-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/reference-04/meta.yaml
+++ b/tests/reference-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/reference-config-validate-01/meta.yaml
+++ b/tests/reference-config-validate-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/reference-config-validate-02/meta.yaml
+++ b/tests/reference-config-validate-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/reputation-config/reputation-config-cr-lf/meta.yaml
+++ b/tests/reputation-config/reputation-config-cr-lf/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/reputation-config/reputation-config-cr/meta.yaml
+++ b/tests/reputation-config/reputation-config-cr/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/reputation-config/reputation-config-lf/meta.yaml
+++ b/tests/reputation-config/reputation-config-lf/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/requires-7-unknown/meta.yaml
+++ b/tests/requires-7-unknown/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/requires-fail/meta.yaml
+++ b/tests/requires-fail/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/requires-ok/meta.yaml
+++ b/tests/requires-ok/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/requires-unknown/meta.yaml
+++ b/tests/requires-unknown/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/rfb-frames/meta.yaml
+++ b/tests/rfb-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, rfb, tcp]

--- a/tests/rfb-parser/meta.yaml
+++ b/tests/rfb-parser/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', rfb, tcp]

--- a/tests/rfb-partial-tx/meta.yaml
+++ b/tests/rfb-partial-tx/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, eth, ip, nbdgm, nbns, rfb, smb, tcp, udp]

--- a/tests/rfb-protocol-3.3/meta.yaml
+++ b/tests/rfb-protocol-3.3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, rfb, tcp]

--- a/tests/rfb-protocol-3.7/meta.yaml
+++ b/tests/rfb-protocol-3.7/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, rfb, tcp]

--- a/tests/rfb-protocol-3.8/meta.yaml
+++ b/tests/rfb-protocol-3.8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, rfb, tcp]

--- a/tests/rfb-rules-8/meta.yaml
+++ b/tests/rfb-rules-8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, rfb, tcp]

--- a/tests/rfb-rules/meta.yaml
+++ b/tests/rfb-rules/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, rfb, tcp]

--- a/tests/rule-grouping/rule-grouping-1/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-10/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-10/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-11/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-11/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-12/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-12/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-13/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-13/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-14/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-14/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-15/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-15/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-16/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-16/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-17/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-17/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-18/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-18/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-19/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-19/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-2/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-3/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-4/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-4/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-5/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-5/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-6/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-6/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-7/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-7/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-8/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-grouping/rule-grouping-9/meta.yaml
+++ b/tests/rule-grouping/rule-grouping-9/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rule-hooks/http-body-hook-01/meta.yaml
+++ b/tests/rule-hooks/http-body-hook-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, media, tcp]

--- a/tests/rule-hooks/pkt-hook-flow-start-01/meta.yaml
+++ b/tests/rule-hooks/pkt-hook-flow-start-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ipv6, media, tcp]

--- a/tests/rule-hooks/tls-handshake-01-ips-sni/meta.yaml
+++ b/tests/rule-hooks/tls-handshake-01-ips-sni/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/rule-hooks/tls-handshake-02-ips-sni-drop/meta.yaml
+++ b/tests/rule-hooks/tls-handshake-02-ips-sni-drop/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/rule-types/meta.yaml
+++ b/tests/rule-types/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/absent/meta.yaml
+++ b/tests/rules/absent/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/app-layer-protocol/meta.yaml
+++ b/tests/rules/app-layer-protocol/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/bug-5177/meta.yaml
+++ b/tests/rules/bug-5177/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/content/meta.yaml
+++ b/tests/rules/content/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/dce_stub_data/meta.yaml
+++ b/tests/rules/dce_stub_data/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/detect-bidir-http-rule/meta.yaml
+++ b/tests/rules/detect-bidir-http-rule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/detect-bidir-ja3-rule/meta.yaml
+++ b/tests/rules/detect-bidir-ja3-rule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/dns_query/meta.yaml
+++ b/tests/rules/dns_query/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/dsize-8.0.0/meta.yaml
+++ b/tests/rules/dsize-8.0.0/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/dsize/meta.yaml
+++ b/tests/rules/dsize/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/file_data/meta.yaml
+++ b/tests/rules/file_data/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/filemagic/meta.yaml
+++ b/tests/rules/filemagic/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/flow_age/meta.yaml
+++ b/tests/rules/flow_age/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/flowbit-engine-analysis/meta.yaml
+++ b/tests/rules/flowbit-engine-analysis/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/flowbits/meta.yaml
+++ b/tests/rules/flowbits/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/flowints/meta.yaml
+++ b/tests/rules/flowints/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/frame_transform/meta.yaml
+++ b/tests/rules/frame_transform/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/ftpbounce/meta.yaml
+++ b/tests/rules/ftpbounce/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/http-header/meta.yaml
+++ b/tests/rules/http-header/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/http-request-body/meta.yaml
+++ b/tests/rules/http-request-body/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/http-response-body/meta.yaml
+++ b/tests/rules/http-response-body/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/http_uri/meta.yaml
+++ b/tests/rules/http_uri/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/icmp_code/meta.yaml
+++ b/tests/rules/icmp_code/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/icmp_id/meta.yaml
+++ b/tests/rules/icmp_id/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/ipopts/meta.yaml
+++ b/tests/rules/ipopts/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/pcre-unicode-cluster/meta.yaml
+++ b/tests/rules/pcre-unicode-cluster/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/pgsql-7000/meta.yaml
+++ b/tests/rules/pgsql-7000/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/prefilter/meta.yaml
+++ b/tests/rules/prefilter/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/rule-type-app-layer/meta.yaml
+++ b/tests/rules/rule-type-app-layer/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/rule-type-app-tx/meta.yaml
+++ b/tests/rules/rule-type-app-tx/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/rule-type-de-only/meta.yaml
+++ b/tests/rules/rule-type-de-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/rule-type-ip-only/meta.yaml
+++ b/tests/rules/rule-type-ip-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/rule-type-like-ip-only/meta.yaml
+++ b/tests/rules/rule-type-like-ip-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/rule-type-pd-only/meta.yaml
+++ b/tests/rules/rule-type-pd-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/rule-type-pkt-stream/meta.yaml
+++ b/tests/rules/rule-type-pkt-stream/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/rule-type-pkt/meta.yaml
+++ b/tests/rules/rule-type-pkt/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/rule-type-stream/meta.yaml
+++ b/tests/rules/rule-type-stream/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/stream_size/meta.yaml
+++ b/tests/rules/stream_size/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/tcp-mss/meta.yaml
+++ b/tests/rules/tcp-mss/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/tcp-seq-keyword/meta.yaml
+++ b/tests/rules/tcp-seq-keyword/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/tcp_ack/meta.yaml
+++ b/tests/rules/tcp_ack/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/tcp_window/meta.yaml
+++ b/tests/rules/tcp_window/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/time_to_live/meta.yaml
+++ b/tests/rules/time_to_live/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/uricontent/meta.yaml
+++ b/tests/rules/uricontent/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/rules/xbits/meta.yaml
+++ b/tests/rules/xbits/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/runmode-error-5711/meta.yaml
+++ b/tests/runmode-error-5711/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/sctp-keywords-prefilter/meta.yaml
+++ b/tests/sctp-keywords-prefilter/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, m3ua, sccp, sccpmg, sctp]

--- a/tests/sctp-keywords/meta.yaml
+++ b/tests/sctp-keywords/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, m3ua, sccp, sccpmg, sctp]

--- a/tests/sctp-max-chunks/meta.yaml
+++ b/tests/sctp-max-chunks/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, sctp]

--- a/tests/sctp-pkt-too-small/meta.yaml
+++ b/tests/sctp-pkt-too-small/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sctp]

--- a/tests/security-4710-01/meta.yaml
+++ b/tests/security-4710-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, ip, sll, tcp]

--- a/tests/security-4710-02/meta.yaml
+++ b/tests/security-4710-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, ip, 'null', tcp]

--- a/tests/security-8510/meta.yaml
+++ b/tests/security-8510/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, ipv6, ipv6.fraghdr, ipv6.hopopts, udp]

--- a/tests/security-8550/meta.yaml
+++ b/tests/security-8550/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, gre, ip]

--- a/tests/security-8642-swf/meta.yaml
+++ b/tests/security-8642-swf/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/show-help/meta.yaml
+++ b/tests/show-help/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/sip-body-frames/meta.yaml
+++ b/tests/sip-body-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sdp, sip, udp]

--- a/tests/sip-body-large/meta.yaml
+++ b/tests/sip-body-large/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', sdp, sip, tcp]

--- a/tests/sip-compact-form/meta.yaml
+++ b/tests/sip-compact-form/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sdp, sip, udp]

--- a/tests/sip-content-length/meta.yaml
+++ b/tests/sip-content-length/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, data, dhcp, dns, eth, ftp, ip, nbdgm, nbns, rtcp, rtp, sdp, sip, smb, tcp, udp]

--- a/tests/sip-content-type/meta.yaml
+++ b/tests/sip-content-type/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, data, dhcp, dns, eth, ftp, ip, nbdgm, nbns, rtcp, rtp, sdp, sip, smb, tcp, udp]

--- a/tests/sip-from/meta.yaml
+++ b/tests/sip-from/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, data, dhcp, dns, eth, ftp, ip, nbdgm, nbns, rtcp, rtp, sdp, sip, smb, tcp, udp]

--- a/tests/sip-header-multi-value/meta.yaml
+++ b/tests/sip-header-multi-value/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sdp, sip, udp]

--- a/tests/sip-method/meta.yaml
+++ b/tests/sip-method/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, data, dhcp, dns, eth, ftp, ip, nbdgm, nbns, rtcp, rtp, sdp, sip, smb, tcp, udp]

--- a/tests/sip-options-method/meta.yaml
+++ b/tests/sip-options-method/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sip, udp]

--- a/tests/sip-pattern-matching/meta.yaml
+++ b/tests/sip-pattern-matching/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sip, udp]

--- a/tests/sip-protocol/meta.yaml
+++ b/tests/sip-protocol/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, data, dhcp, dns, eth, ftp, ip, nbdgm, nbns, rtcp, rtp, sdp, sip, smb, tcp, udp]

--- a/tests/sip-request-line/meta.yaml
+++ b/tests/sip-request-line/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, data, dhcp, dns, eth, ftp, ip, nbdgm, nbns, rtcp, rtp, sdp, sip, smb, tcp, udp]

--- a/tests/sip-response-line/meta.yaml
+++ b/tests/sip-response-line/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, data, dhcp, dns, eth, ftp, ip, nbdgm, nbns, rtcp, rtp, sdp, sip, smb, tcp, udp]

--- a/tests/sip-sdp/meta.yaml
+++ b/tests/sip-sdp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sdp, sip, udp]

--- a/tests/sip-ssdp-pm/meta.yaml
+++ b/tests/sip-ssdp-pm/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssdp, udp]

--- a/tests/sip-stat-code/meta.yaml
+++ b/tests/sip-stat-code/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, data, dhcp, dns, eth, ftp, ip, nbdgm, nbns, rtcp, rtp, sdp, sip, smb, tcp, udp]

--- a/tests/sip-stat-msg/meta.yaml
+++ b/tests/sip-stat-msg/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, data, dhcp, dns, eth, ftp, ip, nbdgm, nbns, rtcp, rtp, sdp, sip, smb, tcp, udp]

--- a/tests/sip-tcp-body-frames/meta.yaml
+++ b/tests/sip-tcp-body-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sip, tcp]

--- a/tests/sip-tcp-method/meta.yaml
+++ b/tests/sip-tcp-method/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sip, tcp]

--- a/tests/sip-tcp-pattern-matching/meta.yaml
+++ b/tests/sip-tcp-pattern-matching/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sip, tcp]

--- a/tests/sip-tcp-protocol/meta.yaml
+++ b/tests/sip-tcp-protocol/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sip, tcp]

--- a/tests/sip-tcp-request-line/meta.yaml
+++ b/tests/sip-tcp-request-line/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sip, tcp]

--- a/tests/sip-tcp-response-line/meta.yaml
+++ b/tests/sip-tcp-response-line/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sip, tcp]

--- a/tests/sip-tcp-stat-code/meta.yaml
+++ b/tests/sip-tcp-stat-code/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sip, tcp]

--- a/tests/sip-tcp-stat-msg/meta.yaml
+++ b/tests/sip-tcp-stat-msg/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sip, tcp]

--- a/tests/sip-tcp-uri/meta.yaml
+++ b/tests/sip-tcp-uri/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, sip, tcp]

--- a/tests/sip-to/meta.yaml
+++ b/tests/sip-to/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, data, dhcp, dns, eth, ftp, ip, nbdgm, nbns, rtcp, rtp, sdp, sip, smb, tcp, udp]

--- a/tests/sip-uri/meta.yaml
+++ b/tests/sip-uri/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, data, dhcp, dns, eth, ftp, ip, nbdgm, nbns, rtcp, rtp, sdp, sip, smb, tcp, udp]

--- a/tests/sip-user-agent/meta.yaml
+++ b/tests/sip-user-agent/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, data, dhcp, dns, eth, ftp, ip, nbdgm, nbns, rtcp, rtp, sdp, sip, smb, tcp, udp]

--- a/tests/sip-via/meta.yaml
+++ b/tests/sip-via/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, data, dhcp, dns, eth, ftp, ip, nbdgm, nbns, rtcp, rtp, sdp, sip, smb, tcp, udp]

--- a/tests/smb-dce_iface/meta.yaml
+++ b/tests/smb-dce_iface/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb-dce_opnum/meta.yaml
+++ b/tests/smb-dce_opnum/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb-eicar-andx/meta.yaml
+++ b/tests/smb-eicar-andx/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb-eicar-file-frames/meta.yaml
+++ b/tests/smb-eicar-file-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [gss-api, ip, nbss, ntlmssp, sll, smb, spnego, tcp]

--- a/tests/smb-eicar-file-nbss-more-ffsmb/meta.yaml
+++ b/tests/smb-eicar-file-nbss-more-ffsmb/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb-eicar-file-segmentation-postheader/meta.yaml
+++ b/tests/smb-eicar-file-segmentation-postheader/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb-eicar-file-segmentation-random/meta.yaml
+++ b/tests/smb-eicar-file-segmentation-random/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb-eicar-file/meta.yaml
+++ b/tests/smb-eicar-file/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [gss-api, ip, nbss, ntlmssp, sll, smb, spnego, tcp]

--- a/tests/smb-eicar-overlap/meta.yaml
+++ b/tests/smb-eicar-overlap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [gss-api, ip, nbss, ntlmssp, sll, smb, spnego, tcp]

--- a/tests/smb-eicar-padding/meta.yaml
+++ b/tests/smb-eicar-padding/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [gss-api, ip, nbss, ntlmssp, sll, smb, spnego, tcp]

--- a/tests/smb-filename/meta.yaml
+++ b/tests/smb-filename/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, spnego-krb5, tcp]

--- a/tests/smb-length-5770/meta.yaml
+++ b/tests/smb-length-5770/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [afp, data, dcerpc, gss-api, ip, ipv6, mdns, nbss, ntlmssp, 'null', smb, spnego, spnego-krb5, tcp, udp]

--- a/tests/smb-length-5786/meta.yaml
+++ b/tests/smb-length-5786/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [afp, data, dcerpc, gss-api, ip, nbss, 'null', smb, spnego, spnego-krb5, tcp]

--- a/tests/smb-log-conf-01/meta.yaml
+++ b/tests/smb-log-conf-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, eth, gss-api, icmpv6, ip, ipv6, ipv6.hopopts, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb-log-conf-02/meta.yaml
+++ b/tests/smb-log-conf-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, eth, gss-api, icmpv6, ip, ipv6, ipv6.hopopts, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb-named-pipe-ascii-frames/meta.yaml
+++ b/tests/smb-named-pipe-ascii-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [gss-api, ip, nbss, ntlmssp, sll, smb, spnego, tcp]

--- a/tests/smb-named-pipe-ascii/meta.yaml
+++ b/tests/smb-named-pipe-ascii/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [gss-api, ip, nbss, ntlmssp, sll, smb, spnego, tcp]

--- a/tests/smb-named-pipe-unicode/meta.yaml
+++ b/tests/smb-named-pipe-unicode/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, gss-api, ip, nbss, ntlmssp, sll, smb, spnego, tcp]

--- a/tests/smb-version-keyword-invalid/meta.yaml
+++ b/tests/smb-version-keyword-invalid/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb-version-keyword/meta.yaml
+++ b/tests/smb-version-keyword/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb1-01/meta.yaml
+++ b/tests/smb1-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, nbss, smb, tcp]

--- a/tests/smb1-02/meta.yaml
+++ b/tests/smb1-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb1-03-midstream/meta.yaml
+++ b/tests/smb1-03-midstream/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb2-01/meta.yaml
+++ b/tests/smb2-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, eth, gss-api, icmpv6, ip, ipv6, ipv6.hopopts, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb2-02/meta.yaml
+++ b/tests/smb2-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb2-03-rule/meta.yaml
+++ b/tests/smb2-03-rule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb2-04/meta.yaml
+++ b/tests/smb2-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, ip, nbss, smb, tcp]

--- a/tests/smb2-05/meta.yaml
+++ b/tests/smb2-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, gss-api, ip, nbss, smb, spnego, spnego-krb5, tcp]

--- a/tests/smb2-06/meta.yaml
+++ b/tests/smb2-06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dcerpc, eth, gss-api, ip, nbss, smb, spnego, spnego-krb5, tcp]

--- a/tests/smb2-07-frames/meta.yaml
+++ b/tests/smb2-07-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, data, dcerpc, dhcp, dhcpv6, dns, eth, gss-api, icmp, ip, ipv6, llmnr, nbdgm, nbns, nbss, smb, spnego, spnego-krb5, tcp, udp]

--- a/tests/smb2-07/meta.yaml
+++ b/tests/smb2-07/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, data, dcerpc, dhcp, dhcpv6, dns, eth, gss-api, icmp, ip, ipv6, llmnr, nbdgm, nbns, nbss, smb, spnego, spnego-krb5, tcp, udp]

--- a/tests/smb2-08-rule/meta.yaml
+++ b/tests/smb2-08-rule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb2-09-trunc-file-logging/meta.yaml
+++ b/tests/smb2-09-trunc-file-logging/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, gss-api, ip, nbss, smb, spnego, spnego-krb5, tcp]

--- a/tests/smb2-async-read/meta.yaml
+++ b/tests/smb2-async-read/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb2-async/meta.yaml
+++ b/tests/smb2-async/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, nbss, smb, tcp]

--- a/tests/smb2-delete/meta.yaml
+++ b/tests/smb2-delete/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb2-frames-gap-payload-logging-02/meta.yaml
+++ b/tests/smb2-frames-gap-payload-logging-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, eth, gss-api, icmpv6, ip, ipv6, ipv6.hopopts, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb2-frames-gap-payload-logging/meta.yaml
+++ b/tests/smb2-frames-gap-payload-logging/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, eth, gss-api, icmpv6, ip, ipv6, ipv6.hopopts, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb2-named-pipe-unicode/meta.yaml
+++ b/tests/smb2-named-pipe-unicode/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb2-ntlmssp-negotiateflags/meta.yaml
+++ b/tests/smb2-ntlmssp-negotiateflags/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, browser, data, dcerpc, dhcp, dhcpv6, dns, eth, gss-api, icmp, icmpv6, igmp, ip, ipv6, ipv6.hopopts, llmnr, nbdgm, nbns, nbss, ntlmssp, smb, spnego, ssdp, tcp, udp]

--- a/tests/smb2-ntlmssp-order/meta.yaml
+++ b/tests/smb2-ntlmssp-order/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb3-01/meta.yaml
+++ b/tests/smb3-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/smb3-02-midstream/meta.yaml
+++ b/tests/smb3-02-midstream/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, nbss, smb, tcp]

--- a/tests/smb3-03-midstream/meta.yaml
+++ b/tests/smb3-03-midstream/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, nbss, smb, tcp]

--- a/tests/smtp-attachment-md5/meta.yaml
+++ b/tests/smtp-attachment-md5/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, igmp, ip, smtp, tcp]

--- a/tests/smtp-bug-5981/meta.yaml
+++ b/tests/smtp-bug-5981/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, ip, smtp, tcp]

--- a/tests/smtp-bug-5989/meta.yaml
+++ b/tests/smtp-bug-5989/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, ip, smtp, tcp]

--- a/tests/smtp-bug-6053/meta.yaml
+++ b/tests/smtp-bug-6053/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, smtp, tcp]

--- a/tests/smtp-data-rejected/meta.yaml
+++ b/tests/smtp-data-rejected/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ip, smtp, tcp]

--- a/tests/smtp-errors/meta.yaml
+++ b/tests/smtp-errors/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, ip, smtp, tcp, tls]

--- a/tests/smtp-eve/meta.yaml
+++ b/tests/smtp-eve/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data-text-lines, dns, eth, icmp, ip, nbdgm, smb, smtp, tcp, udp]

--- a/tests/smtp-extract-url-schemes/meta.yaml
+++ b/tests/smtp-extract-url-schemes/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, smtp, tcp]

--- a/tests/smtp-file-data-01/meta.yaml
+++ b/tests/smtp-file-data-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, smtp, tcp]

--- a/tests/smtp-file-data-02/meta.yaml
+++ b/tests/smtp-file-data-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data-text-lines, dns, eth, icmp, ip, nbdgm, smb, smtp, tcp, udp]

--- a/tests/smtp-keywords/meta.yaml
+++ b/tests/smtp-keywords/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data-text-lines, dns, eth, icmp, ip, nbdgm, smb, smtp, tcp, udp]

--- a/tests/smtp-long-DATA-line-02-frames/meta.yaml
+++ b/tests/smtp-long-DATA-line-02-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, ip, smtp, tcp]

--- a/tests/smtp-long-DATA-line-03-frames-ips/meta.yaml
+++ b/tests/smtp-long-DATA-line-03-frames-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, ip, smtp, tcp]

--- a/tests/smtp-long-DATA-line/meta.yaml
+++ b/tests/smtp-long-DATA-line/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, ip, smtp, tcp]

--- a/tests/smtp-long-command/meta.yaml
+++ b/tests/smtp-long-command/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, smtp, tcp]

--- a/tests/smtp-md5/meta.yaml
+++ b/tests/smtp-md5/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data-text-lines, dns, eth, icmp, ip, nbdgm, smb, smtp, tcp, udp]

--- a/tests/smtp-pipelining/meta.yaml
+++ b/tests/smtp-pipelining/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/smtp-quit/meta.yaml
+++ b/tests/smtp-quit/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, smtp, tcp]

--- a/tests/smtp-raw-extraction/meta.yaml
+++ b/tests/smtp-raw-extraction/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ip, smtp, tcp]

--- a/tests/smtp-rfc2231/meta.yaml
+++ b/tests/smtp-rfc2231/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ip, smtp, tcp]

--- a/tests/smtp-rset-starttls/meta.yaml
+++ b/tests/smtp-rset-starttls/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/smtp-rset/meta.yaml
+++ b/tests/smtp-rset/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', smtp, tcp]

--- a/tests/smtp-startssl/meta.yaml
+++ b/tests/smtp-startssl/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, smtp, tcp, tls]

--- a/tests/smtp-tls-protodetect/meta.yaml
+++ b/tests/smtp-tls-protodetect/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, tls]

--- a/tests/smtp-to-comma/meta.yaml
+++ b/tests/smtp-to-comma/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, ip, smtp, tcp]

--- a/tests/smtp-url-base64/meta.yaml
+++ b/tests/smtp-url-base64/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/smtp-url-schemes-bug-5174/meta.yaml
+++ b/tests/smtp-url-schemes-bug-5174/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, smtp, tcp]

--- a/tests/smtp/meta.yaml
+++ b/tests/smtp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data-text-lines, dns, eth, icmp, ip, nbdgm, smb, smtp, tcp, udp]

--- a/tests/snmp-community/meta.yaml
+++ b/tests/snmp-community/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, snmp, udp]

--- a/tests/snmp-detection-only/meta.yaml
+++ b/tests/snmp-detection-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, snmp, udp]

--- a/tests/snmp-disabled/meta.yaml
+++ b/tests/snmp-disabled/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, snmp, udp]

--- a/tests/snmp-pdu-type/meta.yaml
+++ b/tests/snmp-pdu-type/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, snmp, udp]

--- a/tests/snmp-v2c-get/meta.yaml
+++ b/tests/snmp-v2c-get/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, snmp, udp]

--- a/tests/snmp-v3-encrypted/meta.yaml
+++ b/tests/snmp-v3-encrypted/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, snmp, udp]

--- a/tests/snmp-v3-unauth/meta.yaml
+++ b/tests/snmp-v3-unauth/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, snmp, udp]

--- a/tests/ssh-banner-only/meta.yaml
+++ b/tests/ssh-banner-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, dns, eth, ip, ssh, tcp, udp]

--- a/tests/ssh-frames/meta.yaml
+++ b/tests/ssh-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/ssh-hassh-disabled/meta.yaml
+++ b/tests/ssh-hassh-disabled/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, dns, eth, ip, ssh, tcp, udp]

--- a/tests/ssh-hassh-incomplete/meta.yaml
+++ b/tests/ssh-hassh-incomplete/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/ssh-hassh-only/meta.yaml
+++ b/tests/ssh-hassh-only/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, eth, ip, ssh, tcp, udp]

--- a/tests/ssh-hassh-reassembled/meta.yaml
+++ b/tests/ssh-hassh-reassembled/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/ssh-hassh/meta.yaml
+++ b/tests/ssh-hassh/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, dns, eth, ip, ssh, tcp, udp]

--- a/tests/ssh-lua-hassh/meta.yaml
+++ b/tests/ssh-lua-hassh/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, dns, eth, ip, ssh, tcp, udp]

--- a/tests/ssh-lua-output/meta.yaml
+++ b/tests/ssh-lua-output/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, dns, eth, ip, ssh, tcp, udp]

--- a/tests/ssh-lua-rules/meta.yaml
+++ b/tests/ssh-lua-rules/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, dns, eth, ip, ssh, tcp, udp]

--- a/tests/ssh-newkeys/meta.yaml
+++ b/tests/ssh-newkeys/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, ssh, tcp]

--- a/tests/ssl_version_negated/meta.yaml
+++ b/tests/ssl_version_negated/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509sat]

--- a/tests/sslv2-tls-upgrade-01/meta.yaml
+++ b/tests/sslv2-tls-upgrade-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509sat]

--- a/tests/stream-async/http/stream-async-6063-cli-01/meta.yaml
+++ b/tests/stream-async/http/stream-async-6063-cli-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/stream-async/http/stream-async-6063-cli-02/meta.yaml
+++ b/tests/stream-async/http/stream-async-6063-cli-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/stream-async/http/stream-async-6063-cli-03/meta.yaml
+++ b/tests/stream-async/http/stream-async-6063-cli-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/stream-async/http/stream-async-6063-srv-01/meta.yaml
+++ b/tests/stream-async/http/stream-async-6063-srv-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/stream-async/http/stream-async-6063-srv-02/meta.yaml
+++ b/tests/stream-async/http/stream-async-6063-srv-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/stream-async/http/stream-async-6063-srv-03/meta.yaml
+++ b/tests/stream-async/http/stream-async-6063-srv-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/stream-depth-reached-event/meta.yaml
+++ b/tests/stream-depth-reached-event/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dcerpc, eth, gss-api, ip, nbss, ntlmssp, smb, spnego, tcp]

--- a/tests/streamsize-keyword-02-prefilter/meta.yaml
+++ b/tests/streamsize-keyword-02-prefilter/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [gss-api, ip, nbss, ntlmssp, sll, smb, spnego, tcp]

--- a/tests/streamsize-keyword-03-prefilter-pseudo/meta.yaml
+++ b/tests/streamsize-keyword-03-prefilter-pseudo/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/streamsize-keyword/meta.yaml
+++ b/tests/streamsize-keyword/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [gss-api, ip, nbss, ntlmssp, sll, smb, spnego, tcp]

--- a/tests/subslice/subslice-01/meta.yaml
+++ b/tests/subslice/subslice-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, http2, ip, 'null', tcp]

--- a/tests/subslice/subslice-02/meta.yaml
+++ b/tests/subslice/subslice-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, http2, ip, 'null', tcp]

--- a/tests/subslice/subslice-03/meta.yaml
+++ b/tests/subslice/subslice-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, http2, ip, 'null', tcp]

--- a/tests/subslice/subslice-04/meta.yaml
+++ b/tests/subslice/subslice-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, http2, ip, 'null', tcp]

--- a/tests/subslice/subslice-05/meta.yaml
+++ b/tests/subslice/subslice-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, http2, ip, 'null', tcp]

--- a/tests/tcp-5379/meta.yaml
+++ b/tests/tcp-5379/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/tcp-async-01/meta.yaml
+++ b/tests/tcp-async-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, imap, ip, smtp, tcp]

--- a/tests/tcp-empty-sack/meta.yaml
+++ b/tests/tcp-empty-sack/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, pkix1explicit, pkix1implicit, raw, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tcp-fastopen-01/meta.yaml
+++ b/tests/tcp-fastopen-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/tcp-fastopen-02/meta.yaml
+++ b/tests/tcp-fastopen-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/tcp-fastopen-03/meta.yaml
+++ b/tests/tcp-fastopen-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/tcp-fastopen-04/meta.yaml
+++ b/tests/tcp-fastopen-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, sll, tcp]

--- a/tests/tcp-fastopen-05/meta.yaml
+++ b/tests/tcp-fastopen-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, sll, tcp]

--- a/tests/tcp-fastopen-06/meta.yaml
+++ b/tests/tcp-fastopen-06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/tcp-fastopen-07/meta.yaml
+++ b/tests/tcp-fastopen-07/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/tcp-fastopen-08/meta.yaml
+++ b/tests/tcp-fastopen-08/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/tcp-fastopen-09/meta.yaml
+++ b/tests/tcp-fastopen-09/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/tcp-fastopen-10-syn-data-ignore/meta.yaml
+++ b/tests/tcp-fastopen-10-syn-data-ignore/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp, tls]

--- a/tests/tcp-fastopen-11-reject-syn-data/meta.yaml
+++ b/tests/tcp-fastopen-11-reject-syn-data/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp, tls]

--- a/tests/tcp-fastopen-12/meta.yaml
+++ b/tests/tcp-fastopen-12/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, sll, tcp]

--- a/tests/tcp-fastopen-13/meta.yaml
+++ b/tests/tcp-fastopen-13/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/tcp-hdr-keyword/meta.yaml
+++ b/tests/tcp-hdr-keyword/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/tcp-mss-keyword/meta.yaml
+++ b/tests/tcp-mss-keyword/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/tcp-protodetect-bailout/meta.yaml
+++ b/tests/tcp-protodetect-bailout/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, ip, 'null', tcp]

--- a/tests/tcp-rst-unacked-stream-01-raw/meta.yaml
+++ b/tests/tcp-rst-unacked-stream-01-raw/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/tcp-rst-unacked-stream-02-raw-ips/meta.yaml
+++ b/tests/tcp-rst-unacked-stream-02-raw-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/tcp-rst-unacked-stream-03-gap/meta.yaml
+++ b/tests/tcp-rst-unacked-stream-03-gap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/tcp-rst-unacked-stream-04-gap-ips/meta.yaml
+++ b/tests/tcp-rst-unacked-stream-04-gap-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, vlan]

--- a/tests/tcp-rst-unacked-stream-05-http-nogap/meta.yaml
+++ b/tests/tcp-rst-unacked-stream-05-http-nogap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp, vlan]

--- a/tests/tcp-rst-unacked-stream-06-http-nogap-ips/meta.yaml
+++ b/tests/tcp-rst-unacked-stream-06-http-nogap-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp, vlan]

--- a/tests/tcp-rst-unacked-stream-07-http/meta.yaml
+++ b/tests/tcp-rst-unacked-stream-07-http/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp, vlan]

--- a/tests/tcp-rst-unacked-stream-08-http-ips/meta.yaml
+++ b/tests/tcp-rst-unacked-stream-08-http-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp, vlan]

--- a/tests/tcp-rst-unacked-stream-09/meta.yaml
+++ b/tests/tcp-rst-unacked-stream-09/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/tcp-rst-unacked-stream-10/meta.yaml
+++ b/tests/tcp-rst-unacked-stream-10/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/tcp-rst-unacked-stream-11/meta.yaml
+++ b/tests/tcp-rst-unacked-stream-11/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/tcp-rst-unacked-stream-12/meta.yaml
+++ b/tests/tcp-rst-unacked-stream-12/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, http, ip, tcp]

--- a/tests/tcp-split-handshake-01-4whs/meta.yaml
+++ b/tests/tcp-split-handshake-01-4whs/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, q931, tcp]

--- a/tests/tcp-split-handshake-02-5whs/meta.yaml
+++ b/tests/tcp-split-handshake-02-5whs/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, q931, tcp]

--- a/tests/tcp-stream-after-swap/meta.yaml
+++ b/tests/tcp-stream-after-swap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp]

--- a/tests/tcp-urgp-01-oob/meta.yaml
+++ b/tests/tcp-urgp-01-oob/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/tcp-urgp-02-drop-ips/meta.yaml
+++ b/tests/tcp-urgp-02-drop-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/tcp-urgp-03-inline/meta.yaml
+++ b/tests/tcp-urgp-03-inline/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/tcp-urgp-04-2byte-XY/meta.yaml
+++ b/tests/tcp-urgp-04-2byte-XY/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/tcp-urgp-06-oob-within-limit/meta.yaml
+++ b/tests/tcp-urgp-06-oob-within-limit/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/tcp-urgp-07-oob-exceed-limit/meta.yaml
+++ b/tests/tcp-urgp-07-oob-exceed-limit/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/tcp-urgp-08-oob-exceed-limit-gap/meta.yaml
+++ b/tests/tcp-urgp-08-oob-exceed-limit-gap/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/tcp-urgp-09-oob-exceed-limit-inline/meta.yaml
+++ b/tests/tcp-urgp-09-oob-exceed-limit-inline/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, data-text-lines, eth, http, ip, tcp]

--- a/tests/telnet/telnet-01/meta.yaml
+++ b/tests/telnet/telnet-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, telnet]

--- a/tests/test-bad-byte-extract-rule-1/meta.yaml
+++ b/tests/test-bad-byte-extract-rule-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-byte-extract-rule-2/meta.yaml
+++ b/tests/test-bad-byte-extract-rule-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-content-dsize-rule-2/meta.yaml
+++ b/tests/test-bad-content-dsize-rule-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-content-dsize-rule-3/meta.yaml
+++ b/tests/test-bad-content-dsize-rule-3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-content-quotes-rule-1/meta.yaml
+++ b/tests/test-bad-content-quotes-rule-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-depth-depth-rule-1/meta.yaml
+++ b/tests/test-bad-depth-depth-rule-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-depth-distance-rule-1/meta.yaml
+++ b/tests/test-bad-depth-distance-rule-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-depth-distance-rule-2/meta.yaml
+++ b/tests/test-bad-depth-distance-rule-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-depth-rule-1/meta.yaml
+++ b/tests/test-bad-depth-rule-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-depth-within-rule-1/meta.yaml
+++ b/tests/test-bad-depth-within-rule-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-depth-within-rule-2/meta.yaml
+++ b/tests/test-bad-depth-within-rule-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-dsize-offset-rule-2/meta.yaml
+++ b/tests/test-bad-dsize-offset-rule-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-dsize-range-offset-rule-2/meta.yaml
+++ b/tests/test-bad-dsize-range-offset-rule-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-dsize-range-rule-2/meta.yaml
+++ b/tests/test-bad-dsize-range-rule-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-hex-rule-1/meta.yaml
+++ b/tests/test-bad-hex-rule-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-hex-rule-2/meta.yaml
+++ b/tests/test-bad-hex-rule-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-hex-rule-3/meta.yaml
+++ b/tests/test-bad-hex-rule-3/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-http-host-rule-1/meta.yaml
+++ b/tests/test-bad-http-host-rule-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-http-host-rule-2/meta.yaml
+++ b/tests/test-bad-http-host-rule-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-negate-fast-pattern-rule-1/meta.yaml
+++ b/tests/test-bad-negate-fast-pattern-rule-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-offset-distance-rule-1/meta.yaml
+++ b/tests/test-bad-offset-distance-rule-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-offset-offset-rule-1/meta.yaml
+++ b/tests/test-bad-offset-offset-rule-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-offset-within-rule-1/meta.yaml
+++ b/tests/test-bad-offset-within-rule-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-quotation-marks-rule-1/meta.yaml
+++ b/tests/test-bad-quotation-marks-rule-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-relative-keyword-fast-pattern-rule-1/meta.yaml
+++ b/tests/test-bad-relative-keyword-fast-pattern-rule-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-semicolon-rule-1/meta.yaml
+++ b/tests/test-bad-semicolon-rule-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-semicolon-rule-2/meta.yaml
+++ b/tests/test-bad-semicolon-rule-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bad-within-within-rule-1/meta.yaml
+++ b/tests/test-bad-within-within-rule-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-bsize-values-1/meta.yaml
+++ b/tests/test-bsize-values-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/test-bsize-values-2/meta.yaml
+++ b/tests/test-bsize-values-2/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/test-config-empty-rule-file/meta.yaml
+++ b/tests/test-config-empty-rule-file/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-content-limits-1/meta.yaml
+++ b/tests/test-content-limits-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-dsize-values/meta.yaml
+++ b/tests/test-dsize-values/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp]

--- a/tests/test-ruleparse-etopen-01/meta.yaml
+++ b/tests/test-ruleparse-etopen-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/test-unreachable-distance-1/meta.yaml
+++ b/tests/test-unreachable-distance-1/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp]

--- a/tests/test-valid-json/meta.yaml
+++ b/tests/test-valid-json/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/tftp-tx-handling-rrq/meta.yaml
+++ b/tests/tftp-tx-handling-rrq/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tftp, udp]

--- a/tests/tftp-tx-handling-wrq/meta.yaml
+++ b/tests/tftp-tx-handling-wrq/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tftp, udp]

--- a/tests/threshold-config-byrule/meta.yaml
+++ b/tests/threshold-config-byrule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold-config-validate-01/meta.yaml
+++ b/tests/threshold-config-validate-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/threshold-config-validate-02/meta.yaml
+++ b/tests/threshold-config-validate-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, media, tcp]

--- a/tests/threshold/detection_filter-rule-flow/meta.yaml
+++ b/tests/threshold/detection_filter-rule-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/threshold/detection_filter-rule-hostsrc/meta.yaml
+++ b/tests/threshold/detection_filter-rule-hostsrc/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/threshold/threshold-config-rate-filter-alert-flow/meta.yaml
+++ b/tests/threshold/threshold-config-rate-filter-alert-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-rate-filter-alert-hostdst/meta.yaml
+++ b/tests/threshold/threshold-config-rate-filter-alert-hostdst/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-rate-filter-alert-hostsrc/meta.yaml
+++ b/tests/threshold/threshold-config-rate-filter-alert-hostsrc/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-rate-filter-alert-pair/meta.yaml
+++ b/tests/threshold/threshold-config-rate-filter-alert-pair/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-rate-filter-alert-rule/meta.yaml
+++ b/tests/threshold/threshold-config-rate-filter-alert-rule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-rate-filter-drop-hostdst/meta.yaml
+++ b/tests/threshold/threshold-config-rate-filter-drop-hostdst/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-rate-filter-drop-hostsrc/meta.yaml
+++ b/tests/threshold/threshold-config-rate-filter-drop-hostsrc/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-rate-filter-drop-ippair/meta.yaml
+++ b/tests/threshold/threshold-config-rate-filter-drop-ippair/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-rate-filter-drop-rule/meta.yaml
+++ b/tests/threshold/threshold-config-rate-filter-drop-rule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-rate-filter-pass-hostdst/meta.yaml
+++ b/tests/threshold/threshold-config-rate-filter-pass-hostdst/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-rate-filter-pass-hostsrc/meta.yaml
+++ b/tests/threshold/threshold-config-rate-filter-pass-hostsrc/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-rate-filter-pass-pair/meta.yaml
+++ b/tests/threshold/threshold-config-rate-filter-pass-pair/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-rate-filter-pass-rule/meta.yaml
+++ b/tests/threshold/threshold-config-rate-filter-pass-rule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-rate-filter-reject-hostdst/meta.yaml
+++ b/tests/threshold/threshold-config-rate-filter-reject-hostdst/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-rate-filter-reject-hostsrc/meta.yaml
+++ b/tests/threshold/threshold-config-rate-filter-reject-hostsrc/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-rate-filter-reject-pair/meta.yaml
+++ b/tests/threshold/threshold-config-rate-filter-reject-pair/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-rate-filter-reject-rule/meta.yaml
+++ b/tests/threshold/threshold-config-rate-filter-reject-rule/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-suppress-bydst-ip/meta.yaml
+++ b/tests/threshold/threshold-config-suppress-bydst-ip/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-suppress-bydst-ipsubnet/meta.yaml
+++ b/tests/threshold/threshold-config-suppress-bydst-ipsubnet/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-suppress-bydst-ipvar/meta.yaml
+++ b/tests/threshold/threshold-config-suppress-bydst-ipvar/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-suppress-byeither-ip/meta.yaml
+++ b/tests/threshold/threshold-config-suppress-byeither-ip/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-suppress-byeither-ipsubnet/meta.yaml
+++ b/tests/threshold/threshold-config-suppress-byeither-ipsubnet/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-suppress-byeither-ipvar/meta.yaml
+++ b/tests/threshold/threshold-config-suppress-byeither-ipvar/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-suppress-bysrc-ip/meta.yaml
+++ b/tests/threshold/threshold-config-suppress-bysrc-ip/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-suppress-bysrc-ipsubnet/meta.yaml
+++ b/tests/threshold/threshold-config-suppress-bysrc-ipsubnet/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-suppress-bysrc-ipvar/meta.yaml
+++ b/tests/threshold/threshold-config-suppress-bysrc-ipvar/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-threshold-both-flow/meta.yaml
+++ b/tests/threshold/threshold-config-threshold-both-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-threshold-limit-flow/meta.yaml
+++ b/tests/threshold/threshold-config-threshold-limit-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-config-threshold-threshold-flow/meta.yaml
+++ b/tests/threshold/threshold-config-threshold-threshold-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, xml]

--- a/tests/threshold/threshold-rule-flow-backoff-single-flow/meta.yaml
+++ b/tests/threshold/threshold-rule-flow-backoff-single-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dcerpc, eth, ip, nbss, ntlmssp, smb, tcp, vlan]

--- a/tests/threshold/threshold-rule-flow-backoff/meta.yaml
+++ b/tests/threshold/threshold-rule-flow-backoff/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dns, eth, http, icmp, ip, logotypecertextn, ocsp, pkix1explicit, pkix1implicit, pkixalgs, ssh, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/threshold/threshold-rule-flow/meta.yaml
+++ b/tests/threshold/threshold-rule-flow/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip]

--- a/tests/tls-alpn-client-log-01/meta.yaml
+++ b/tests/tls-alpn-client-log-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, quic, tcp, tls, udp]

--- a/tests/tls-alpn-log-detect-02/meta.yaml
+++ b/tests/tls-alpn-log-detect-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, ocsp, pkix1explicit, pkix1implicit, pkixalgs, raw, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls-duplicate-hello/meta.yaml
+++ b/tests/tls-duplicate-hello/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', tcp, tls]

--- a/tests/tls-extra-alert-engine-analysis/meta.yaml
+++ b/tests/tls-extra-alert-engine-analysis/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/tls-extra-alert/meta.yaml
+++ b/tests/tls-extra-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, icmp, ip, tcp, tls]

--- a/tests/tls/bug-7286-tls-metadata-01/meta.yaml
+++ b/tests/tls/bug-7286-tls-metadata-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/bug-7286-tls-metadata-02/meta.yaml
+++ b/tests/tls/bug-7286-tls-metadata-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-altname-zero/meta.yaml
+++ b/tests/tls/tls-altname-zero/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-bypass-missing-event/meta.yaml
+++ b/tests/tls/tls-bypass-missing-event/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, q931, tcp, tls]

--- a/tests/tls/tls-cert-chain-len/meta.yaml
+++ b/tests/tls/tls-cert-chain-len/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-cert-issuer/meta.yaml
+++ b/tests/tls/tls-cert-issuer/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, eth, ip, ipv6, mdns, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/tls/tls-cert-noissuer/meta.yaml
+++ b/tests/tls/tls-cert-noissuer/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-cert-validity/meta.yaml
+++ b/tests/tls/tls-cert-validity/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, eth, ip, ipv6, mdns, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/tls/tls-certs-alert/meta.yaml
+++ b/tests/tls/tls-certs-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-client-cert-01/meta.yaml
+++ b/tests/tls/tls-client-cert-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ipv6, 'null', tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-client-hello-frag-01/meta.yaml
+++ b/tests/tls/tls-client-hello-frag-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, pkixalgs, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-eve-custom-fields/meta.yaml
+++ b/tests/tls/tls-eve-custom-fields/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ipv6, 'null', tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-fin-close-data-01/meta.yaml
+++ b/tests/tls/tls-fin-close-data-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls]

--- a/tests/tls/tls-fingerprint-alert/meta.yaml
+++ b/tests/tls/tls-fingerprint-alert/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, tls]

--- a/tests/tls/tls-glupteba-mb/meta.yaml
+++ b/tests/tls/tls-glupteba-mb/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-glupteba/meta.yaml
+++ b/tests/tls/tls-glupteba/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-issuer-zero-pre8/meta.yaml
+++ b/tests/tls/tls-issuer-zero-pre8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', ocsp, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-issuer-zero/meta.yaml
+++ b/tests/tls/tls-issuer-zero/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', ocsp, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-issuerdn/meta.yaml
+++ b/tests/tls/tls-issuerdn/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, eth, ip, ipv6, mdns, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/tls/tls-ja3s-pre8/meta.yaml
+++ b/tests/tls/tls-ja3s-pre8/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-ja3s-requires-off/meta.yaml
+++ b/tests/tls/tls-ja3s-requires-off/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-ja3s-requires/meta.yaml
+++ b/tests/tls/tls-ja3s-requires/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-ja3s/meta.yaml
+++ b/tests/tls/tls-ja3s/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-json-output-ids/meta.yaml
+++ b/tests/tls/tls-json-output-ids/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, tls]

--- a/tests/tls/tls-json-output-ips/meta.yaml
+++ b/tests/tls/tls-json-output-ips/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, tls]

--- a/tests/tls/tls-pre-1970/meta.yaml
+++ b/tests/tls/tls-pre-1970/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, raw, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-random-6989/meta.yaml
+++ b/tests/tls/tls-random-6989/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-random/meta.yaml
+++ b/tests/tls/tls-random/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-store-01/meta.yaml
+++ b/tests/tls/tls-store-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, eth, ip, ipv6, mdns, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/tls/tls-store-02/meta.yaml
+++ b/tests/tls/tls-store-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ipv6, 'null', tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-store-03/meta.yaml
+++ b/tests/tls/tls-store-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, eth, ip, ipv6, mdns, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/tls/tls-subject-zero/meta.yaml
+++ b/tests/tls/tls-subject-zero/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [ip, 'null', ocsp, pkix1explicit, pkix1implicit, tcp, tls, x509, x509ce, x509sat]

--- a/tests/tls/tls-subject/meta.yaml
+++ b/tests/tls/tls-subject/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, eth, ip, ipv6, mdns, tcp, tls, udp, x509, x509ce, x509sat]

--- a/tests/tls/tls-subjectaltname/meta.yaml
+++ b/tests/tls/tls-subjectaltname/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [browser, data, data-text-lines, dns, eth, http, icmpv6, image-jfif, ip, ipv6, ipv6.hopopts, llc, llmnr, media, nbdgm, nbns, ocsp, pkix1explicit, pkix1implicit, pkixalgs, png, smb, stp, tcp, tls, udp, x509, x509af, x509ce, x509sat]

--- a/tests/tls/tls13-draft14/meta.yaml
+++ b/tests/tls/tls13-draft14/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls]

--- a/tests/tls/tls13-draft18/meta.yaml
+++ b/tests/tls/tls13-draft18/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, dns, eth, ip, tcp, tls, udp]

--- a/tests/tls/tls13-draft19/meta.yaml
+++ b/tests/tls/tls13-draft19/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls]

--- a/tests/tls/tls13-draft22/meta.yaml
+++ b/tests/tls/tls13-draft22/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls]

--- a/tests/tls/tls13-draft23/meta.yaml
+++ b/tests/tls/tls13-draft23/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp, tls]

--- a/tests/tls/tls13-draft28-frames/meta.yaml
+++ b/tests/tls/tls13-draft28-frames/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, tcp, tls]

--- a/tests/tls/tls13-draft28/meta.yaml
+++ b/tests/tls/tls13-draft28/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ipv6, tcp, tls]

--- a/tests/transform-base64-7296/meta.yaml
+++ b/tests/transform-base64-7296/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, http, http2, ip, 'null', tcp]

--- a/tests/transform-dotprefix-uaf-8537/meta.yaml
+++ b/tests/transform-dotprefix-uaf-8537/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/transform-gunzip-uaf-8536/meta.yaml
+++ b/tests/transform-gunzip-uaf-8536/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp]

--- a/tests/transform-gunzip/meta.yaml
+++ b/tests/transform-gunzip/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, http, ip, 'null', tcp]

--- a/tests/transform-header-lowercase/meta.yaml
+++ b/tests/transform-header-lowercase/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, http2, ip, 'null', tcp]

--- a/tests/transform-strip-pseudo-headers/meta.yaml
+++ b/tests/transform-strip-pseudo-headers/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, http2, ip, 'null', tcp]

--- a/tests/transform-zlib-deflate/meta.yaml
+++ b/tests/transform-zlib-deflate/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, http, ip, 'null', tcp]

--- a/tests/truncate-applayer-test-01/meta.yaml
+++ b/tests/truncate-applayer-test-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dcerpc, eth, ip, q931, tcp, vlan]

--- a/tests/truncate-applayer-test-02/meta.yaml
+++ b/tests/truncate-applayer-test-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, dcerpc, eth, ip, q931, tcp, vlan]

--- a/tests/udp-5379/udp-hlen-invalid-non-strict/meta.yaml
+++ b/tests/udp-5379/udp-hlen-invalid-non-strict/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, udp]

--- a/tests/udp-5379/udp-hlen-invalid-strict/meta.yaml
+++ b/tests/udp-5379/udp-hlen-invalid-strict/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, udp]

--- a/tests/udp-5379/udp-len-invalid/meta.yaml
+++ b/tests/udp-5379/udp-len-invalid/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, udp]

--- a/tests/udp-5379/udp-trailing-data/meta.yaml
+++ b/tests/udp-5379/udp-trailing-data/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, udp]

--- a/tests/udp-hdr-keyword/meta.yaml
+++ b/tests/udp-hdr-keyword/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, udp, vlan]

--- a/tests/unix-socket/hostbit-add-ip6/meta.yaml
+++ b/tests/unix-socket/hostbit-add-ip6/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/uricontent/detect-uricontent-01/meta.yaml
+++ b/tests/uricontent/detect-uricontent-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp, vlan]

--- a/tests/uricontent/detect-uricontent-02/meta.yaml
+++ b/tests/uricontent/detect-uricontent-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp, vlan]

--- a/tests/uricontent/detect-uricontent-03/meta.yaml
+++ b/tests/uricontent/detect-uricontent-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, http, ip, tcp, vlan]

--- a/tests/uricontent/detect-uricontent-04/meta.yaml
+++ b/tests/uricontent/detect-uricontent-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/uricontent/detect-uricontent-05/meta.yaml
+++ b/tests/uricontent/detect-uricontent-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/uricontent/detect-uricontent-06/meta.yaml
+++ b/tests/uricontent/detect-uricontent-06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/uricontent/detect-uricontent-07/meta.yaml
+++ b/tests/uricontent/detect-uricontent-07/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [eth, ip, tcp]

--- a/tests/ut-complete/meta.yaml
+++ b/tests/ut-complete/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/ut-leakcheck/meta.yaml
+++ b/tests/ut-leakcheck/meta.yaml
@@ -1,0 +1,1 @@
+protocols: []

--- a/tests/util-action-tests/util-action-01/meta.yaml
+++ b/tests/util-action-tests/util-action-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, vlan]

--- a/tests/util-action-tests/util-action-02/meta.yaml
+++ b/tests/util-action-tests/util-action-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, vlan]

--- a/tests/util-action-tests/util-action-03/meta.yaml
+++ b/tests/util-action-tests/util-action-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, vlan]

--- a/tests/util-action-tests/util-action-04/meta.yaml
+++ b/tests/util-action-tests/util-action-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, vlan]

--- a/tests/util-action-tests/util-action-05/meta.yaml
+++ b/tests/util-action-tests/util-action-05/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, vlan]

--- a/tests/util-action-tests/util-action-06/meta.yaml
+++ b/tests/util-action-tests/util-action-06/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, vlan]

--- a/tests/util-action-tests/util-action-07/meta.yaml
+++ b/tests/util-action-tests/util-action-07/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, vlan]

--- a/tests/util-action-tests/util-action-08/meta.yaml
+++ b/tests/util-action-tests/util-action-08/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, vlan]

--- a/tests/util-action-tests/util-action-09/meta.yaml
+++ b/tests/util-action-tests/util-action-09/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, vlan]

--- a/tests/util-action-tests/util-action-10/meta.yaml
+++ b/tests/util-action-tests/util-action-10/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, vlan]

--- a/tests/util-action-tests/util-action-11/meta.yaml
+++ b/tests/util-action-tests/util-action-11/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, vlan]

--- a/tests/util-action-tests/util-action-12/meta.yaml
+++ b/tests/util-action-tests/util-action-12/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, vlan]

--- a/tests/util-action-tests/util-action-13/meta.yaml
+++ b/tests/util-action-tests/util-action-13/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, vlan]

--- a/tests/util-action-tests/util-action-14/meta.yaml
+++ b/tests/util-action-tests/util-action-14/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, vlan]

--- a/tests/util-action-tests/util-action-15/meta.yaml
+++ b/tests/util-action-tests/util-action-15/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, vlan]

--- a/tests/util-action-tests/util-action-16/meta.yaml
+++ b/tests/util-action-tests/util-action-16/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data, eth, ip, tcp, vlan]

--- a/tests/vxlan-decoder-01/meta.yaml
+++ b/tests/vxlan-decoder-01/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, udp, vxlan]

--- a/tests/vxlan-decoder-02/meta.yaml
+++ b/tests/vxlan-decoder-02/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, eth, icmp, ip, udp, vxlan]

--- a/tests/vxlan-decoder-03/meta.yaml
+++ b/tests/vxlan-decoder-03/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [dns, eth, ip, ntp, ssh, tcp, udp, vxlan]

--- a/tests/vxlan-decoder-04/meta.yaml
+++ b/tests/vxlan-decoder-04/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, eth, icmp, ip, udp, vxlan]

--- a/tests/vxlan-decoder-07-arp/meta.yaml
+++ b/tests/vxlan-decoder-07-arp/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [arp, data, eth, icmp, ip, udp, vxlan]

--- a/tests/vxlan-non-zero-reserved-fields/meta.yaml
+++ b/tests/vxlan-non-zero-reserved-fields/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, udp, vxlan]

--- a/tests/websocket-compressed/meta.yaml
+++ b/tests/websocket-compressed/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, websocket]

--- a/tests/websocket-control-frag/meta.yaml
+++ b/tests/websocket-control-frag/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, websocket]

--- a/tests/websocket-ping/meta.yaml
+++ b/tests/websocket-ping/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, http, ip, sll, tcp, websocket]

--- a/tests/websocket/meta.yaml
+++ b/tests/websocket/meta.yaml
@@ -1,0 +1,1 @@
+protocols: [data-text-lines, eth, http, ip, tcp, websocket]

--- a/util/update-meta-protocols.py
+++ b/util/update-meta-protocols.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Generate per-test meta.yaml protocol lists from pcaps.
+
+The protocol list is derived from tshark's per-frame dissector stack and then
+mapped to Suricata-style app-layer protocol names where the names differ.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# tshark dissector names that should be normalized or expanded for metadata.
+# Values can be either a string or a list of strings. Protocols not listed here
+# are emitted as tshark reports them, unless they are in IGNORED_PROTOCOLS.
+PROTOCOL_RENAMES = {
+    "bittorrent_dht": "bittorrent-dht",
+    "bootp": "dhcp",
+    "btdht": "bittorrent-dht",
+    "cip": "enip",
+    "cldap": "ldap",
+    "dcerpc.cn": "dcerpc",
+    "dcerpc.dg": "dcerpc",
+    "dhcpv6": ["dhcp", "dhcpv6"],
+    "ftp_data": "ftp-data",
+    "gquic": "quic",
+    "ikev2": "ike",
+    "imf": "smtp",
+    "isakmp": "ike",
+    "kerberos": "krb5",
+    "mbtcp": "modbus",
+    "pop": "pop3",
+    "postgresql": "pgsql",
+    "smb2": "smb",
+    "ssl": "tls",
+    "vnc": "rfb",
+    "xmpp": ["xmpp", "jabber"],
+    "x509ce": ["x509", "x509ce"],
+    "x509sat": ["x509", "x509sat"],
+}
+
+# Keep this minimal: the metadata is intentionally a liberal list of protocols
+# tshark reports for the pcap, with only PROTOCOL_RENAMES applied. "ethertype"
+# is just Wireshark's Ethernet dispatch field and adds noise.
+IGNORED_PROTOCOLS = {"ethertype"}
+
+PCAP_REF_RE = re.compile(
+    r"(?P<path>(?:\$\{TEST_DIR\}|\$TEST_DIR|[^\s\"'`])+?\.pcap(?:ng)?)"
+)
+
+
+class FlowStyleList(list):
+    pass
+
+
+class MetaDumper(yaml.SafeDumper):
+    pass
+
+
+def represent_flow_style_list(dumper: yaml.SafeDumper, data: FlowStyleList):
+    return dumper.represent_sequence(
+        "tag:yaml.org,2002:seq", list(data), flow_style=True
+    )
+
+
+MetaDumper.add_representer(FlowStyleList, represent_flow_style_list)
+
+
+def load_yaml(path: Path) -> dict:
+    with path.open("rb") as fp:
+        data = yaml.safe_load(fp) or {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def resolve_command_ref(test_dir: Path, ref: str) -> Path:
+    ref = ref.replace("${TEST_DIR}", str(test_dir))
+    ref = ref.replace("$TEST_DIR", str(test_dir))
+    path = Path(ref)
+    if not path.is_absolute():
+        path = test_dir / path
+    return path.resolve()
+
+
+def unique_paths(paths: Iterable[Path]) -> list[Path]:
+    seen = set()
+    unique = []
+    for path in paths:
+        if path not in seen:
+            unique.append(path)
+            seen.add(path)
+    return unique
+
+
+def relative_to_repo(path: Path) -> Path:
+    try:
+        return path.relative_to(REPO_ROOT)
+    except ValueError:
+        return path
+
+
+def find_pcaps(test_yaml: Path) -> tuple[list[Path], list[str]]:
+    config = load_yaml(test_yaml)
+    test_dir = test_yaml.parent
+    warnings = []
+    pcaps = []
+
+    if config.get("pcap") is False:
+        return [], warnings
+
+    pcap_value = config.get("pcap")
+    if isinstance(pcap_value, str):
+        pcaps.append((test_dir / pcap_value).resolve())
+    elif pcap_value is not None:
+        warnings.append(f"{test_yaml}: unsupported pcap value: {pcap_value!r}")
+    else:
+        command = config.get("command")
+        if command:
+            for match in PCAP_REF_RE.finditer(str(command)):
+                pcaps.append(resolve_command_ref(test_dir, match.group("path")))
+        if not pcaps:
+            pcaps.extend(sorted(path.resolve() for path in test_dir.glob("*.pcap")))
+            pcaps.extend(sorted(path.resolve() for path in test_dir.glob("*.pcapng")))
+
+    existing = []
+    for pcap in unique_paths(pcaps):
+        if pcap.exists():
+            existing.append(pcap)
+        else:
+            warnings.append(f"{test_yaml}: pcap not found: {pcap}")
+    return existing, warnings
+
+
+def sort_protocols(protocols: Iterable[str]) -> list[str]:
+    return sorted(set(protocols))
+
+
+def protocols_from_tshark_output(output: str) -> list[str]:
+    protocols = set()
+    for line in output.splitlines():
+        stack = [proto.lower() for proto in line.strip().split(":") if proto]
+        if not stack:
+            continue
+
+        for proto in stack:
+            if proto in IGNORED_PROTOCOLS:
+                continue
+            replacement = PROTOCOL_RENAMES.get(proto, proto)
+            if isinstance(replacement, list):
+                protocols.update(replacement)
+            else:
+                protocols.add(replacement)
+
+    return sort_protocols(protocols)
+
+
+def extract_pcap_protocols(pcap: Path) -> tuple[Path, list[str], str | None]:
+    result = subprocess.run(
+        ["tshark", "-n", "-r", str(pcap), "-T", "fields", "-e", "frame.protocols"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    protocols = protocols_from_tshark_output(result.stdout)
+    if result.returncode != 0 and not result.stdout:
+        error = result.stderr.strip() or f"tshark exited with {result.returncode}"
+        return pcap, protocols, error
+    return pcap, protocols, None
+
+
+def render_meta(path: Path, protocols: list[str]) -> str:
+    meta = {}
+    if path.exists():
+        meta = load_yaml(path)
+    meta["protocols"] = FlowStyleList(protocols)
+    return yaml.dump(meta, Dumper=MetaDumper, sort_keys=False, width=4096)
+
+
+def write_meta(path: Path, content: str, *, dry_run: bool, check: bool) -> bool:
+    old = path.read_text() if path.exists() else None
+    if old == content:
+        return False
+    if check or dry_run:
+        return True
+    path.write_text(content)
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate meta.yaml protocols from test pcaps."
+    )
+    parser.add_argument(
+        "test_dir",
+        nargs="?",
+        type=Path,
+        help="optional single test directory containing test.yaml to update",
+    )
+    parser.add_argument(
+        "--tests-root",
+        type=Path,
+        default=REPO_ROOT / "tests",
+        help="root directory to scan for test.yaml files",
+    )
+    parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=min(8, os.cpu_count() or 1),
+        help="number of concurrent tshark processes",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="show what would change without writing files",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit non-zero if any meta.yaml would change",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="print each changed meta.yaml path",
+    )
+    args = parser.parse_args()
+
+    if args.test_dir:
+        test_dir = args.test_dir.resolve()
+        test_yaml = test_dir / "test.yaml"
+        if not test_yaml.exists():
+            parser.error(f"{args.test_dir} does not contain test.yaml")
+        test_yamls = [test_yaml]
+    else:
+        tests_root = args.tests_root.resolve()
+        test_yamls = sorted(tests_root.rglob("test.yaml"))
+
+    test_pcaps = {}
+    pcap_tests = {}
+    warnings = []
+    printed_tests = set()
+
+    def print_test_progress(test_yaml: Path) -> None:
+        if test_yaml in printed_tests:
+            return
+        print(relative_to_repo(test_yaml.parent), file=sys.stderr, flush=True)
+        printed_tests.add(test_yaml)
+
+    for test_yaml in test_yamls:
+        pcaps, pcap_warnings = find_pcaps(test_yaml)
+        test_pcaps[test_yaml] = pcaps
+        if pcaps:
+            for pcap in pcaps:
+                pcap_tests.setdefault(pcap, []).append(test_yaml)
+        else:
+            print_test_progress(test_yaml)
+        warnings.extend(pcap_warnings)
+
+    unique_pcaps = sorted({pcap for pcaps in test_pcaps.values() for pcap in pcaps})
+    pcap_protocols = {}
+    tshark_errors = []
+
+    if unique_pcaps:
+        jobs = max(1, args.jobs)
+        with ThreadPoolExecutor(max_workers=jobs) as executor:
+            futures = {
+                executor.submit(extract_pcap_protocols, pcap): pcap
+                for pcap in unique_pcaps
+            }
+            for future in as_completed(futures):
+                pcap, protocols, error = future.result()
+                pcap_protocols[pcap] = protocols
+                for test_yaml in pcap_tests.get(pcap, []):
+                    print_test_progress(test_yaml)
+                if error:
+                    tshark_errors.append(f"{pcap}: {error}")
+
+    changed = 0
+    empty = 0
+    for test_yaml in test_yamls:
+        print_test_progress(test_yaml)
+        protocols = sort_protocols(
+            proto
+            for pcap in test_pcaps[test_yaml]
+            for proto in pcap_protocols.get(pcap, [])
+        )
+        if not protocols:
+            empty += 1
+        meta_yaml = test_yaml.parent / "meta.yaml"
+        content = render_meta(meta_yaml, protocols)
+        if write_meta(meta_yaml, content, dry_run=args.dry_run, check=args.check):
+            changed += 1
+            if args.verbose or args.dry_run or args.check:
+                print(meta_yaml.relative_to(REPO_ROOT))
+
+    for warning in warnings:
+        print(f"warning: {warning}", file=sys.stderr)
+    for error in tshark_errors:
+        print(f"warning: {error}", file=sys.stderr)
+
+    print(
+        "tests={} tests_with_pcaps={} unique_pcaps={} changed={} empty={}".format(
+            len(test_yamls),
+            sum(1 for pcaps in test_pcaps.values() if pcaps),
+            len(unique_pcaps),
+            changed,
+            empty,
+        )
+    )
+
+    if args.check and changed:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Adds a meta.yaml to each test that has a "protocols" array
- Adds a utility to update this meta.yaml for every test using tshark
- Update run.py to tag a --meta-protocols command option

To run tests that have been identified by tshark to have smtp:

  .../run.py --meta-protocols smtp

or that have smtp or imap:

  .../run.py --meta-protocols smtp,imap

To update the metadata:

  ./util/update-meta-protocols.py

This was AI assisted then tuned up some.  Protocol renames/mappings might need some refining.