### PR TITLE
tests: add firewall bypass test

### DIFF
--- a/tests/firewall/ruletype-firewall-141-ban-bypass-keyword-firewall-rule/README.md
+++ b/tests/firewall/ruletype-firewall-141-ban-bypass-keyword-firewall-rule/README.md
@@ -1,0 +1,16 @@
+# Test
+
+Ensure that the engine rejects the `bypass` keyword in a firewall rule.
+
+The rejected firewall rule would match the decoded HTTP host
+`www.testmyids.com`, then accept and bypass the flow at the
+`http1:request_headers` hook. The retained event checks document the behavior
+expected if bypass support is enabled in the future.
+
+This ticket also contains valid checks for if the bypass were to be allowed in
+firewall mode.
+
+## Ticket
+
+Related to
+https://redmine.openinfosecfoundation.org/issues/8459.

--- a/tests/firewall/ruletype-firewall-141-ban-bypass-keyword-firewall-rule/firewall.rules
+++ b/tests/firewall/ruletype-firewall-141-ban-bypass-keyword-firewall-rule/firewall.rules
@@ -1,0 +1,4 @@
+accept:hook tcp:all any any <> any 80 (sid:2000002;)
+accept:hook http1:request_started any any -> any 80 (sid:2000003;)
+accept:hook http1:request_line any any -> any 80 (sid:2000004;)
+accept:flow,alert http1:request_headers any any -> any 80 (msg:"Bypass HTTP host from firewall rule"; http.host; content:"www.testmyids.com"; bypass; sid:2000001;)

--- a/tests/firewall/ruletype-firewall-141-ban-bypass-keyword-firewall-rule/td.rules
+++ b/tests/firewall/ruletype-firewall-141-ban-bypass-keyword-firewall-rule/td.rules
@@ -1,0 +1,2 @@
+# Would alert on the HTTP response body if the firewall rule did not bypass the flow.
+alert http any any -> any any (msg:"Response body inspected after firewall bypass"; flow:to_client,established; http.response_body; content:"uid=0|28|root|29|"; sid:100001;)

--- a/tests/firewall/ruletype-firewall-141-ban-bypass-keyword-firewall-rule/test.yaml
+++ b/tests/firewall/ruletype-firewall-141-ban-bypass-keyword-firewall-rule/test.yaml
@@ -1,0 +1,40 @@
+requires:
+  min-version: 9
+
+pcap: ../../flowbit-oring/input.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+exit-code: 1
+
+checks:
+  - filter:
+      # Would be 1 if bypass were enabled in firewall rules.
+      count: 0
+      match:
+        event_type: alert
+        alert.signature_id: 2000001
+        http.hostname: www.testmyids.com
+  - filter:
+      # Would remain 0 if bypass were enabled and suppressed TD inspection.
+      count: 0
+      match:
+        event_type: alert
+        alert.signature_id: 100001
+  - filter:
+      # Would be 1 if bypass were enabled in firewall rules.
+      count: 0
+      match:
+        event_type: flow
+        flow.state: bypassed
+        flow.bypass: local
+  - filter:
+      # Would be 1 if bypass were enabled in firewall rules.
+      count: 0
+      match:
+        event_type: stats
+        stats.flow_bypassed.local_pkts: 6
+  - shell:
+      args: grep "keyword 'bypass' is not allowed in firewall mode" stderr | wc -l
+      expect: 1


### PR DESCRIPTION
This tests that a "bypass" in a firewall rule fails out and Suricata
exits with exit code 0.

It also contains the checks for if bypass in firewall mode were to be
allowed. Based on a simple revert of commit
a78300740818dfa634d4e19a50d7051544ee655a in Suricata.

Ticket: #8459
