### PR TITLE
Backport/8.0.x: firewall: test the default policy v1

### DIFF
--- a/tests/detect-email-date/test.yaml
+++ b/tests/detect-email-date/test.yaml
@@ -15,17 +15,17 @@ checks:
       alert.signature_id: 1
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 1
     match:
       event_type: smtp
       email.date: Fri, 21 Apr 2023 05:10:36 +0000
       pcap_cnt: 14
-# Pre-9 does not defer tx completion to the server response, so the
-# SMTP event lands one packet earlier. Remove when backported to 8.
+# Pre-8.0.7 does not defer tx completion to the server response, so the
+# SMTP event lands one packet earlier. Backported to 8.0.7.
 - filter:
     requires:
-      lt-version: 9
+      lt-version: 8.0.7
     count: 1
     match:
       event_type: smtp

--- a/tests/detect-email-msg-id/test.yaml
+++ b/tests/detect-email-msg-id/test.yaml
@@ -15,17 +15,17 @@ checks:
       alert.signature_id: 1
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 1
     match:
       event_type: smtp
       email.message_id: <alpine.DEB.2.00.1311261630120.9535@sd-26634.dedibox.fr>
       pcap_cnt: 14
-# Pre-9 does not defer tx completion to the server response, so the
-# SMTP event lands one packet earlier. Remove when backported to 8.
+# Pre-8.0.7 does not defer tx completion to the server response, so the
+# SMTP event lands one packet earlier. Backported to 8.0.7.
 - filter:
     requires:
-      lt-version: 9
+      lt-version: 8.0.7
     count: 1
     match:
       event_type: smtp

--- a/tests/detect-email-subject/test.yaml
+++ b/tests/detect-email-subject/test.yaml
@@ -15,17 +15,17 @@ checks:
       alert.signature_id: 1
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 1
     match:
       event_type: smtp
       pcap_cnt: 14
       email.subject: This is a test email
-# Pre-9 does not defer tx completion to the server response, so the
-# SMTP event lands one packet earlier. Remove when backported to 8.
+# Pre-8.0.7 does not defer tx completion to the server response, so the
+# SMTP event lands one packet earlier. Backported to 8.0.7.
 - filter:
     requires:
-      lt-version: 9
+      lt-version: 8.0.7
     count: 1
     match:
       event_type: smtp

--- a/tests/firewall/ruletype-firewall-103-default-app-policy-drop-alert/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-103-default-app-policy-drop-alert/suricata.yaml
@@ -20,13 +20,14 @@ outputs:
 
 firewall:
   policies:
-    dns:
-      # Allow DNS requests to start.
-      request-started: ["accept:hook"]
+    app:
+      dns:
+        # Allow DNS requests to start.
+        request-started: ["accept:hook"]
 
-      # Drop and alert on all DNS requests that are not allowed in
-      # firewall.rules.
-      request-complete: ["drop:flow", "alert"]
+        # Drop and alert on all DNS requests that are not allowed in
+        # firewall.rules.
+        request-complete: ["drop:flow", "alert"]
 
-      # Accept all responses.
-      response-started: ["accept:flow"]
+        # Accept all responses.
+        response-started: ["accept:flow"]

--- a/tests/firewall/ruletype-firewall-104-default-app-policy-missed-rule-alert/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-104-default-app-policy-missed-rule-alert/suricata.yaml
@@ -21,6 +21,7 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started: ["accept:hook"]
-      request-line: ["drop:flow", "alert"]
+    app:
+      http1:
+        request-started: ["accept:hook"]
+        request-line: ["drop:flow", "alert"]

--- a/tests/firewall/ruletype-firewall-105-default-packet-policy-alert-app-rule/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-105-default-packet-policy-alert-app-rule/suricata.yaml
@@ -21,17 +21,19 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: ["accept:hook", "alert"]
-    http:
-      request-started: ["accept:hook"]
-      request-line: ["accept:hook"]
-      request-headers: ["accept:hook"]
-      request-body: ["accept:hook"]
-      request-trailer: ["accept:hook"]
-      request-complete: ["accept:hook"]
-      response-started: ["accept:hook"]
-      response-line: ["accept:hook"]
-      response-headers: ["accept:hook"]
-      response-body: ["accept:hook"]
-      response-trailer: ["accept:hook"]
-      response-complete: ["accept:hook"]
+    packet:
+      filter: ["accept:hook", "alert"]
+    app:
+      http1:
+        request-started: ["accept:hook"]
+        request-line: ["accept:hook"]
+        request-headers: ["accept:hook"]
+        request-body: ["accept:hook"]
+        request-trailer: ["accept:hook"]
+        request-complete: ["accept:hook"]
+        response-started: ["accept:hook"]
+        response-line: ["accept:hook"]
+        response-headers: ["accept:hook"]
+        response-body: ["accept:hook"]
+        response-trailer: ["accept:hook"]
+        response-complete: ["accept:hook"]

--- a/tests/firewall/ruletype-firewall-106-default-app-policy-accept-flow-alert/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-106-default-app-policy-accept-flow-alert/suricata.yaml
@@ -21,6 +21,8 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: ["accept:hook"]
-    http:
-      request-started: ["accept:flow", "alert"]
+    packet:
+      filter: ["accept:hook"]
+    app:
+      http1:
+        request-started: ["accept:flow", "alert"]

--- a/tests/firewall/ruletype-firewall-107-default-app-policy-missed-rule-accept-tx-alert/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-107-default-app-policy-missed-rule-accept-tx-alert/suricata.yaml
@@ -21,8 +21,9 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started: ["accept:hook"]
-      request-line:
-        - "accept:tx"
-        - "alert"
+    app:
+      http1:
+        request-started: ["accept:hook"]
+        request-line:
+          - "accept:tx"
+          - "alert"

--- a/tests/firewall/ruletype-firewall-108-default-app-policy-missed-rule-accept-tx-alert/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-108-default-app-policy-missed-rule-accept-tx-alert/suricata.yaml
@@ -21,8 +21,9 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started: ["accept:hook"]
-      request-line:
-        - "accept:tx"
-        - "alert"
+    app:
+      http1:
+        request-started: ["accept:hook"]
+        request-line:
+          - "accept:tx"
+          - "alert"

--- a/tests/firewall/ruletype-firewall-115-ftp-download-active-user/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-115-ftp-download-active-user/suricata.yaml
@@ -21,8 +21,7 @@ outputs:
 
 firewall:
   policies:
-    ftp-data:
-      request-started:
-        - "accept:flow"
-      response-started:
-        - "accept:flow"
+    app:
+      ftp-data:
+        request-started: ["accept:flow"]
+        response-started: ["accept:flow"]

--- a/tests/firewall/ruletype-firewall-119-ftp-non-anonymous-default-allow/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-119-ftp-non-anonymous-default-allow/suricata.yaml
@@ -22,21 +22,23 @@ outputs:
 
 firewall:
   policies:
-    packet-filter:
-      - "accept:hook"
-
-    ftp:
-      request-started:
-        - "accept:hook"
-      request-complete:
-        - "accept:hook"
-      response-started:
-        - "accept:hook"
-      response-complete:
+    packet:
+      filter:
         - "accept:hook"
 
-    ftp-data:
-      request-started:
-        - "accept:flow"
-      response-started:
-        - "accept:flow"
+    app:
+      ftp:
+        request-started:
+          - "accept:hook"
+        request-complete:
+          - "accept:hook"
+        response-started:
+          - "accept:hook"
+        response-complete:
+          - "accept:hook"
+
+      ftp-data:
+        request-started:
+          - "accept:flow"
+        response-started:
+          - "accept:flow"

--- a/tests/firewall/ruletype-firewall-120-ftp-drop-by-dynamic-port/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-120-ftp-drop-by-dynamic-port/suricata.yaml
@@ -22,21 +22,23 @@ outputs:
 
 firewall:
   policies:
-    packet-filter:
-      - "accept:hook"
-
-    ftp:
-      request-started:
-        - "accept:hook"
-      request-complete:
-        - "accept:hook"
-      response-started:
-        - "accept:hook"
-      response-complete:
+    packet:
+      filter:
         - "accept:hook"
 
-    ftp-data:
-      request-started:
-        - "accept:flow"
-      response-started:
-        - "accept:flow"
+    app:
+      ftp:
+        request-started:
+          - "accept:hook"
+        request-complete:
+          - "accept:hook"
+        response-started:
+          - "accept:hook"
+        response-complete:
+          - "accept:hook"
+
+      ftp-data:
+        request-started:
+          - "accept:flow"
+        response-started:
+          - "accept:flow"

--- a/tests/firewall/ruletype-firewall-121-ftp-bounce/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-121-ftp-bounce/suricata.yaml
@@ -22,21 +22,23 @@ outputs:
 
 firewall:
   policies:
-    packet-filter:
-      - "accept:hook"
-
-    ftp:
-      request-started:
-        - "accept:hook"
-      request-complete:
-        - "accept:hook"
-      response-started:
-        - "accept:hook"
-      response-complete:
+    packet:
+      filter:
         - "accept:hook"
 
-    ftp-data:
-      request-started:
-        - "accept:flow"
-      response-started:
-        - "accept:flow"
+    app:
+      ftp:
+        request-started:
+          - "accept:hook"
+        request-complete:
+          - "accept:hook"
+        response-started:
+          - "accept:hook"
+        response-complete:
+          - "accept:hook"
+
+      ftp-data:
+        request-started:
+          - "accept:flow"
+        response-started:
+          - "accept:flow"

--- a/tests/firewall/ruletype-firewall-122-http2-substate/test.yaml
+++ b/tests/firewall/ruletype-firewall-122-http2-substate/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../http2-userinfo-authority/http2_userinfo_in_authority_1.pcap
 

--- a/tests/firewall/ruletype-firewall-122-smtp/test.yaml
+++ b/tests/firewall/ruletype-firewall-122-smtp/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: smtp-simple-session.pcap
 

--- a/tests/firewall/ruletype-firewall-123-http2-substate/test.yaml
+++ b/tests/firewall/ruletype-firewall-123-http2-substate/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: false
 

--- a/tests/firewall/ruletype-firewall-123-smtp-blocked-sender/test.yaml
+++ b/tests/firewall/ruletype-firewall-123-smtp-blocked-sender/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../ruletype-firewall-122-smtp/smtp-simple-session.pcap
 

--- a/tests/firewall/ruletype-firewall-124-http2-substate-default-policy/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-124-http2-substate-default-policy/suricata.yaml
@@ -64,34 +64,35 @@ outputs:
 
 firewall:
   policies:
-    http2:
-      stream:
-        request-started:
-          - "accept:hook"
-        request-headers:
-          - "accept:hook"
-        request-data:
-          - "accept:hook"
-        request-closed:
-          - "accept:hook"
-        request-complete:
-          - "accept:hook"
-        response-started:
-          - "accept:hook"
-        response-headers:
-          - "accept:hook"
-        response-data:
-          - "accept:hook"
-        response-closed:
-          - "accept:hook"
-        response-complete:
-          - "accept:tx"
-      global:
-        request-started:
-          - "accept:hook"
-        request-complete:
-          - "accept:tx"
-        response-started:
-          - "accept:hook"
-        response-complete:
-          - "accept:tx"
+    app:
+      http2:
+        stream:
+          request-started:
+            - "accept:hook"
+          request-headers:
+            - "accept:hook"
+          request-data:
+            - "accept:hook"
+          request-closed:
+            - "accept:hook"
+          request-complete:
+            - "accept:hook"
+          response-started:
+            - "accept:hook"
+          response-headers:
+            - "accept:hook"
+          response-data:
+            - "accept:hook"
+          response-closed:
+            - "accept:hook"
+          response-complete:
+            - "accept:tx"
+        global:
+          request-started:
+            - "accept:hook"
+          request-complete:
+            - "accept:tx"
+          response-started:
+            - "accept:hook"
+          response-complete:
+            - "accept:tx"

--- a/tests/firewall/ruletype-firewall-124-http2-substate-default-policy/test.yaml
+++ b/tests/firewall/ruletype-firewall-124-http2-substate-default-policy/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../http2-userinfo-authority/http2_userinfo_in_authority_1.pcap
 

--- a/tests/firewall/ruletype-firewall-124-smtp-blocked-rcpt-to/test.yaml
+++ b/tests/firewall/ruletype-firewall-124-smtp-blocked-rcpt-to/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../ruletype-firewall-122-smtp/smtp-simple-session.pcap
 

--- a/tests/firewall/ruletype-firewall-125-http2-substate/test.yaml
+++ b/tests/firewall/ruletype-firewall-125-http2-substate/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../http2-userinfo-authority/http2_userinfo_in_authority_1.pcap
 

--- a/tests/firewall/ruletype-firewall-125-smtp-all-rcpts-required-drop/test.yaml
+++ b/tests/firewall/ruletype-firewall-125-smtp-all-rcpts-required-drop/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: two-rcpt.pcap
 

--- a/tests/firewall/ruletype-firewall-126-http2-substate-lte/test.yaml
+++ b/tests/firewall/ruletype-firewall-126-http2-substate-lte/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../http2-userinfo-authority/http2_userinfo_in_authority_1.pcap
 

--- a/tests/firewall/ruletype-firewall-126-smtp-any-rcpt-allowed-accept/test.yaml
+++ b/tests/firewall/ruletype-firewall-126-smtp-any-rcpt-allowed-accept/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../ruletype-firewall-125-smtp-all-rcpts-required-drop/two-rcpt.pcap
 

--- a/tests/firewall/ruletype-firewall-127-http2-no-substate/test.yaml
+++ b/tests/firewall/ruletype-firewall-127-http2-no-substate/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: false
 

--- a/tests/firewall/ruletype-firewall-127-smtp-interactive-commands/test.yaml
+++ b/tests/firewall/ruletype-firewall-127-smtp-interactive-commands/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: smtp-interactive.pcap
 

--- a/tests/firewall/ruletype-firewall-128-doh2/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-128-doh2/suricata.yaml
@@ -56,93 +56,94 @@ outputs:
 
 firewall:
   policies:
-    http2:
-      stream:
-        request-started:
-          - "accept:hook"
-          - "alert"
-        request-headers:
-          - "accept:hook"
-          - "alert"
-        request-data:
-          - "accept:hook"
-          - "alert"
-        request-closed:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:hook"
-          - "alert"
-        response-started:
-          - "accept:hook"
-          - "alert"
-        response-headers:
-          - "accept:hook"
-          - "alert"
-        response-data:
-          - "accept:hook"
-          - "alert"
-        response-closed:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-      global:
-        request-started:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:tx"
-          - "alert"
-        response-started:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-    doh2:
-      stream:
-        request-started:
-          - "accept:hook"
-          - "alert"
-        request-headers:
-          - "accept:hook"
-          - "alert"
-        request-data:
-          - "accept:hook"
-          - "alert"
-        request-closed:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:hook"
-          - "alert"
-        response-started:
-          - "accept:hook"
-          - "alert"
-        response-headers:
-          - "accept:hook"
-          - "alert"
-        response-data:
-          - "accept:hook"
-          - "alert"
-        response-closed:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-      global:
-        request-started:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:tx"
-          - "alert"
-        response-started:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
+    app:
+      http2:
+        stream:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-headers:
+            - "accept:hook"
+            - "alert"
+          request-data:
+            - "accept:hook"
+            - "alert"
+          request-closed:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:hook"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-headers:
+            - "accept:hook"
+            - "alert"
+          response-data:
+            - "accept:hook"
+            - "alert"
+          response-closed:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+        global:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:tx"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+      doh2:
+        stream:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-headers:
+            - "accept:hook"
+            - "alert"
+          request-data:
+            - "accept:hook"
+            - "alert"
+          request-closed:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:hook"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-headers:
+            - "accept:hook"
+            - "alert"
+          response-data:
+            - "accept:hook"
+            - "alert"
+          response-closed:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+        global:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:tx"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"

--- a/tests/firewall/ruletype-firewall-128-doh2/test.yaml
+++ b/tests/firewall/ruletype-firewall-128-doh2/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../dns-over-http2/dns_over_https.pcap
 

--- a/tests/firewall/ruletype-firewall-128-smtp-rset-next-tx-delivered/test.yaml
+++ b/tests/firewall/ruletype-firewall-128-smtp-rset-next-tx-delivered/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: smtp-rset-change-sender.pcap
 

--- a/tests/firewall/ruletype-firewall-129-doh2-crash/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-129-doh2-crash/suricata.yaml
@@ -53,93 +53,94 @@ outputs:
 
 firewall:
   policies:
-    http2:
-      stream:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-headers:
-          - "accept:hook"
-          - "alert"
-        request-data:
-          - "accept:hook"
-          - "alert"
-        request-closed:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:hook"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-headers:
-          - "accept:hook"
-          - "alert"
-        response-data:
-          - "accept:hook"
-          - "alert"
-        response-closed:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-      global:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:tx"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-    doh2:
-      stream:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-headers:
-          - "accept:hook"
-          - "alert"
-        request-data:
-          - "accept:hook"
-          - "alert"
-        request-closed:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:hook"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-headers:
-          - "accept:hook"
-          - "alert"
-        response-data:
-          - "accept:hook"
-          - "alert"
-        response-closed:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-      global:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:tx"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
+    app:
+      http2:
+        stream:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-headers:
+            - "accept:hook"
+            - "alert"
+          request-data:
+            - "accept:hook"
+            - "alert"
+          request-closed:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:hook"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-headers:
+            - "accept:hook"
+            - "alert"
+          response-data:
+            - "accept:hook"
+            - "alert"
+          response-closed:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+        global:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:tx"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+      doh2:
+        stream:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-headers:
+            - "accept:hook"
+            - "alert"
+          request-data:
+            - "accept:hook"
+            - "alert"
+          request-closed:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:hook"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-headers:
+            - "accept:hook"
+            - "alert"
+          response-data:
+            - "accept:hook"
+            - "alert"
+          response-closed:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+        global:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:tx"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"

--- a/tests/firewall/ruletype-firewall-129-doh2-crash/test.yaml
+++ b/tests/firewall/ruletype-firewall-129-doh2-crash/test.yaml
@@ -1,4 +1,4 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../dns-over-http2/dns_over_https.pcap

--- a/tests/firewall/ruletype-firewall-129-smtp-rset-next-tx-blocked-sender/test.yaml
+++ b/tests/firewall/ruletype-firewall-129-smtp-rset-next-tx-blocked-sender/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../ruletype-firewall-128-smtp-rset-next-tx-delivered/smtp-rset-change-sender.pcap
 

--- a/tests/firewall/ruletype-firewall-130-doh2-disabled/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-130-doh2-disabled/suricata.yaml
@@ -58,93 +58,94 @@ app-layer:
 
 firewall:
   policies:
-    http2:
-      stream:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-headers:
-          - "accept:hook"
-          - "alert"
-        request-data:
-          - "accept:hook"
-          - "alert"
-        request-closed:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:hook"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-headers:
-          - "accept:hook"
-          - "alert"
-        response-data:
-          - "accept:hook"
-          - "alert"
-        response-closed:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-      global:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:tx"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-    doh2:
-      stream:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-headers:
-          - "accept:hook"
-          - "alert"
-        request-data:
-          - "accept:hook"
-          - "alert"
-        request-closed:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:hook"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-headers:
-          - "accept:hook"
-          - "alert"
-        response-data:
-          - "accept:hook"
-          - "alert"
-        response-closed:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-      global:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:tx"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
+    app:
+      http2:
+        stream:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-headers:
+            - "accept:hook"
+            - "alert"
+          request-data:
+            - "accept:hook"
+            - "alert"
+          request-closed:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:hook"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-headers:
+            - "accept:hook"
+            - "alert"
+          response-data:
+            - "accept:hook"
+            - "alert"
+          response-closed:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+        global:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:tx"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+      doh2:
+        stream:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-headers:
+            - "accept:hook"
+            - "alert"
+          request-data:
+            - "accept:hook"
+            - "alert"
+          request-closed:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:hook"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-headers:
+            - "accept:hook"
+            - "alert"
+          response-data:
+            - "accept:hook"
+            - "alert"
+          response-closed:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+        global:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:tx"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"

--- a/tests/firewall/ruletype-firewall-130-smtp-rset-after-rcpt/test.yaml
+++ b/tests/firewall/ruletype-firewall-130-smtp-rset-after-rcpt/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: smtp-rset-after-rcpt.pcap
 

--- a/tests/firewall/ruletype-firewall-131-http2-mixed-rule/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-131-http2-mixed-rule/suricata.yaml
@@ -60,96 +60,97 @@ app-layer:
 
 firewall:
   policies:
-    http2:
-      stream:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-headers:
-          - "accept:hook"
-          - "alert"
-        request-data:
-          - "accept:hook"
-          - "alert"
-        request-closed:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:hook"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-headers:
-          - "accept:hook"
-          - "alert"
-        response-data:
-          - "accept:hook"
-          - "alert"
-        response-closed:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-      global:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:tx"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-    doh2:
-      stream:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-headers:
-          - "accept:hook"
-          - "alert"
-        request-data:
-          - "accept:hook"
-          - "alert"
-        request-closed:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:hook"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-headers:
-          - "accept:hook"
-          - "alert"
-        response-data:
-          - "accept:hook"
-          - "alert"
-        response-closed:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-      global:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:tx"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
+    app:
+      http2:
+        stream:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-headers:
+            - "accept:hook"
+            - "alert"
+          request-data:
+            - "accept:hook"
+            - "alert"
+          request-closed:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:hook"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-headers:
+            - "accept:hook"
+            - "alert"
+          response-data:
+            - "accept:hook"
+            - "alert"
+          response-closed:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+        global:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:tx"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+      doh2:
+        stream:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-headers:
+            - "accept:hook"
+            - "alert"
+          request-data:
+            - "accept:hook"
+            - "alert"
+          request-closed:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:hook"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-headers:
+            - "accept:hook"
+            - "alert"
+          response-data:
+            - "accept:hook"
+            - "alert"
+          response-closed:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+        global:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:tx"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
 
 engine-analysis:
   rules-fast-pattern: yes

--- a/tests/firewall/ruletype-firewall-131-http2-mixed-rule/test.yaml
+++ b/tests/firewall/ruletype-firewall-131-http2-mixed-rule/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../dns-over-http2/dns_over_https.pcap
 

--- a/tests/firewall/ruletype-firewall-131-smtp-quit-after-mail-from/test.yaml
+++ b/tests/firewall/ruletype-firewall-131-smtp-quit-after-mail-from/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: smtp-quit-after-mail.pcap
 

--- a/tests/firewall/ruletype-firewall-132-smtp-nested-mail-from/test.yaml
+++ b/tests/firewall/ruletype-firewall-132-smtp-nested-mail-from/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: smtp-nested-mail.pcap
 

--- a/tests/firewall/ruletype-firewall-133-smtp-out-of-order-commands/test.yaml
+++ b/tests/firewall/ruletype-firewall-133-smtp-out-of-order-commands/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: smtp-out-of-order.pcap
 

--- a/tests/firewall/ruletype-firewall-134-smtp-rset-then-quit/test.yaml
+++ b/tests/firewall/ruletype-firewall-134-smtp-rset-then-quit/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: smtp-rset-then-quit.pcap
 

--- a/tests/firewall/ruletype-firewall-135-smtp-multi-mail-accept/test.yaml
+++ b/tests/firewall/ruletype-firewall-135-smtp-multi-mail-accept/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: smtp-multi-mail.pcap
 

--- a/tests/firewall/ruletype-firewall-136-smtp-multi-mail-blocked-sender/test.yaml
+++ b/tests/firewall/ruletype-firewall-136-smtp-multi-mail-blocked-sender/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../ruletype-firewall-135-smtp-multi-mail-accept/smtp-multi-mail.pcap
 

--- a/tests/firewall/ruletype-firewall-139-smtp-pipelined-post-data-mail-from/test.yaml
+++ b/tests/firewall/ruletype-firewall-139-smtp-pipelined-post-data-mail-from/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: smtp-pipelined-post-data-mail-from.pcap
 

--- a/tests/firewall/ruletype-firewall-140-smtp-pipelined-post-data-rset-sequence/test.yaml
+++ b/tests/firewall/ruletype-firewall-140-smtp-pipelined-post-data-rset-sequence/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: smtp-pipelined-post-data-rset-sequence.pcap
 

--- a/tests/firewall/ruletype-firewall-141-default-policy-packet-hooks/README.md
+++ b/tests/firewall/ruletype-firewall-141-default-policy-packet-hooks/README.md
@@ -1,0 +1,9 @@
+Test that packet.default-policy applies to every packet hook, not just filter.
+
+pre-stream is where this is observable as its built-in policy is accept:hook, so
+inheriting drop:packet changes the outcome. pre-flow and filter are given
+accept:hook of their own, leaving pre-stream as the only hook able to drop.
+
+The flow event shows the packets got past pre-flow, so the drops happened at
+pre-stream. The two rules in firewall.rules exist only to install the pre-flow
+and pre-stream hooks, which are skipped entirely when no rule targets them.

--- a/tests/firewall/ruletype-firewall-141-default-policy-packet-hooks/firewall.rules
+++ b/tests/firewall/ruletype-firewall-141-default-policy-packet-hooks/firewall.rules
@@ -1,0 +1,5 @@
+# The pre-flow and pre-stream hooks are only installed when a rule targets
+# them, so these two rules exist purely to make the hooks run. Port 1 is not
+# in the pcap, so neither ever matches and both hooks fall to their policy.
+accept:packet tcp:pre_flow any any -> any 1 (sid:1;)
+accept:packet tcp:pre_stream any any -> any 1 (sid:2;)

--- a/tests/firewall/ruletype-firewall-141-default-policy-packet-hooks/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-141-default-policy-packet-hooks/suricata.yaml
@@ -1,0 +1,28 @@
+%YAML 1.1
+---
+
+stats:
+  enabled: yes
+  interval: 8
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - stats
+        - flow
+        - alert
+        - drop:
+            alerts: yes
+            flows: all
+
+firewall:
+  policies:
+    packet:
+      # pre-flow and filter have their own setting, so this default is only
+      # visible at pre-stream, whose built-in policy is accept:hook.
+      default-policy: [ "drop:packet" ]
+      pre-flow: [ "accept:hook" ]
+      filter: [ "accept:hook" ]

--- a/tests/firewall/ruletype-firewall-141-default-policy-packet-hooks/test.yaml
+++ b/tests/firewall/ruletype-firewall-141-default-policy-packet-hooks/test.yaml
@@ -1,0 +1,41 @@
+requires:
+  min-version: 8.0.7
+
+pcap: ../../tls/tls-random/input.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+# pre-flow accepted, so the flow was set up and the packets reached pre-stream.
+- filter:
+    count: 1
+    match:
+      event_type: flow
+      flow.pkts_toserver: 7
+      flow.pkts_toclient: 6
+# Neither hook rule matches, so nothing alerts.
+- filter:
+    count: 0
+    match:
+      event_type: alert
+# Every packet dies at pre-stream, on the policy it inherited from
+# packet.default-policy.
+- filter:
+    count: 13
+    match:
+      event_type: drop
+      drop.reason: "firewall default packet policy"
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.flow.total: 1
+      stats.firewall.accepted: 0
+      stats.firewall.blocked: 13
+      stats.firewall.rejected: 0
+      stats.firewall.drop_reason.default_packet_policy: 13
+      stats.firewall.drop_reason.rules: 0
+      stats.firewall.drop_reason.pre_flow_hook: 0
+      stats.firewall.drop_reason.pre_stream_hook: 0

--- a/tests/firewall/ruletype-firewall-142-default-policy-packet-precedence/README.md
+++ b/tests/firewall/ruletype-firewall-142-default-policy-packet-precedence/README.md
@@ -1,0 +1,12 @@
+Test that packet.default-policy takes precedence over the global default-policy
+at a packet filter hook.
+
+Packet filter hook has no setting of its own, so it inherits reject:packet from
+packet.default-policy. That action distinguishes the winning tier from the
+alternatives: the global default is accept:hook and the built-in filter policy
+is drop:packet, so 13 rejected packets rule out both. reject is the only action
+that tells the three apart here, which is why the test requires LIBNET1.1.
+
+pre-flow and pre-stream carry accept:hook so the packets survive to reach
+filter. The two rules in firewall.rules exist only to install those hooks and
+never match.

--- a/tests/firewall/ruletype-firewall-142-default-policy-packet-precedence/firewall.rules
+++ b/tests/firewall/ruletype-firewall-142-default-policy-packet-precedence/firewall.rules
@@ -1,0 +1,5 @@
+# The pre-flow and pre-stream hooks are only installed when a rule targets
+# them. Port 1 is not in the pcap, so neither rule ever matches and both hooks
+# fall to their configured policy.
+accept:packet tcp:pre_flow any any -> any 1 (sid:1;)
+accept:packet tcp:pre_stream any any -> any 1 (sid:2;)

--- a/tests/firewall/ruletype-firewall-142-default-policy-packet-precedence/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-142-default-policy-packet-precedence/suricata.yaml
@@ -1,0 +1,30 @@
+%YAML 1.1
+---
+
+stats:
+  enabled: yes
+  interval: 8
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - stats
+        - flow
+        - alert
+        - drop:
+            alerts: yes
+            flows: all
+
+firewall:
+  policies:
+    # Would apply to every hook, packet and app, if nothing more specific did.
+    default-policy: [ "accept:hook" ]
+    packet:
+      # Beats the global default at the packet hooks. Only filter is left
+      # without a setting of its own, so only filter inherits it.
+      default-policy: [ "reject:packet" ]
+      pre-flow: [ "accept:hook" ]
+      pre-stream: [ "accept:hook" ]

--- a/tests/firewall/ruletype-firewall-142-default-policy-packet-precedence/test.yaml
+++ b/tests/firewall/ruletype-firewall-142-default-policy-packet-precedence/test.yaml
@@ -1,0 +1,42 @@
+requires:
+  min-version: 8.0.7
+  features:
+    - LIBNET1.1
+
+pcap: ../../tls/tls-random/input.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+# pre-flow and pre-stream specify accept:hook, so the packets reach filter
+- filter:
+    count: 1
+    match:
+      event_type: flow
+      flow.pkts_toserver: 7
+      flow.pkts_toclient: 6
+- filter:
+    count: 0
+    match:
+      event_type: alert
+- filter:
+    count: 13
+    match:
+      event_type: drop
+      drop.reason: "firewall default packet policy"
+# reject is neither the built-in filter policy (drop:packet) nor the global
+# default (accept:hook), so it can only have come from packet.default-policy.
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.flow.total: 1
+      stats.firewall.accepted: 0
+      stats.firewall.blocked: 0
+      stats.firewall.rejected: 13
+      stats.firewall.drop_reason.default_packet_policy: 13
+      stats.firewall.drop_reason.rules: 0
+      stats.firewall.drop_reason.pre_flow_hook: 0
+      stats.firewall.drop_reason.pre_stream_hook: 0

--- a/tests/firewall/ruletype-firewall-143-default-policy-app-layer/README.md
+++ b/tests/firewall/ruletype-firewall-143-default-policy-app-layer/README.md
@@ -1,0 +1,2 @@
+Test that app.default-policy supplies the policy for the app-layer hooks of
+every protocol.

--- a/tests/firewall/ruletype-firewall-143-default-policy-app-layer/firewall.rules
+++ b/tests/firewall/ruletype-firewall-143-default-policy-app-layer/firewall.rules
@@ -1,0 +1,2 @@
+# No app rules at all: the app hooks are decided entirely by
+# app.default-policy.

--- a/tests/firewall/ruletype-firewall-143-default-policy-app-layer/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-143-default-policy-app-layer/suricata.yaml
@@ -1,0 +1,29 @@
+%YAML 1.1
+---
+
+stats:
+  enabled: yes
+  interval: 8
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - stats
+        - flow
+        - alert
+        - dns
+        - drop:
+            alerts: yes
+            flows: all
+
+firewall:
+  policies:
+    packet:
+      filter: [ "accept:hook" ]
+    app:
+      # No per-protocol or per-hook setting anywhere, so every app hook of
+      # every protocol resolves through this one.
+      default-policy: [ "accept:hook" ]

--- a/tests/firewall/ruletype-firewall-143-default-policy-app-layer/test.yaml
+++ b/tests/firewall/ruletype-firewall-143-default-policy-app-layer/test.yaml
@@ -1,0 +1,42 @@
+requires:
+  min-version: 8.0.7
+
+pcap: ../../dns/dns-eve/input.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+# Both directions get through: the app tier covers response hooks too.
+- filter:
+    count: 4
+    match:
+      event_type: dns
+      dns.type: request
+- filter:
+    count: 4
+    match:
+      event_type: dns
+      dns.type: response
+- filter:
+    count: 0
+    match:
+      event_type: drop
+- filter:
+    count: 4
+    match:
+      event_type: flow
+      flow.alerted: false
+      not-has-key: flow.action
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.flow.total: 4
+      stats.firewall.accepted: 8
+      stats.firewall.blocked: 0
+      stats.firewall.rejected: 0
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.default_packet_policy: 0
+      stats.firewall.drop_reason.flow_drop: 0

--- a/tests/firewall/ruletype-firewall-144-default-policy-substate/README.md
+++ b/tests/firewall/ruletype-firewall-144-default-policy-substate/README.md
@@ -1,0 +1,11 @@
+Test that a sub state's default-policy takes precedence over the per-protocol
+default-policy.
+
+HTTP/2 hooks live under the stream and global sub states, which gives the
+resolution chain an extra tier:
+
+    firewall.policies.app.http2.stream.<hook>
+    firewall.policies.app.http2.stream.default-policy
+    firewall.policies.app.http2.default-policy
+    firewall.policies.app.default-policy
+    firewall.policies.default-policy

--- a/tests/firewall/ruletype-firewall-144-default-policy-substate/firewall.rules
+++ b/tests/firewall/ruletype-firewall-144-default-policy-substate/firewall.rules
@@ -1,0 +1,3 @@
+# No app rules: the http2 hooks are decided entirely by the configured
+# default policies.
+accept:hook tcp:all any any -> any any (sid:1;)

--- a/tests/firewall/ruletype-firewall-144-default-policy-substate/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-144-default-policy-substate/suricata.yaml
@@ -1,0 +1,28 @@
+%YAML 1.1
+---
+
+stats:
+  enabled: yes
+  interval: 8
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - stats
+        - flow
+        - alert
+        - http2
+        - drop:
+            alerts: yes
+            flows: all
+
+firewall:
+  policies:
+    app:
+      http2:
+        default-policy: [ "accept:hook" ]
+        stream:
+          default-policy: [ "drop:flow", "alert" ]

--- a/tests/firewall/ruletype-firewall-144-default-policy-substate/test.yaml
+++ b/tests/firewall/ruletype-firewall-144-default-policy-substate/test.yaml
@@ -1,0 +1,64 @@
+requires:
+  min-version: 8.0.7
+
+pcap: ../../http2-userinfo-authority/http2_userinfo_in_authority_1.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+# The connection-level "global" sub state hooks run first and inherit the
+# per-protocol accept:hook, so nothing drops while they are in charge.
+- filter:
+    count: 0
+    match:
+      event_type: drop
+      pcap_cnt: 4
+- filter:
+    count: 0
+    match:
+      event_type: drop
+      pcap_cnt: 5
+- filter:
+    count: 0
+    match:
+      event_type: drop
+      pcap_cnt: 6
+# The first "stream" sub state hook uses the sub state's own default, not the
+# per-protocol one, so the flow is dropped here and the policy signature fires.
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      alert.signature_id: 2201001
+      app_proto: http2
+      pcap_cnt: 7
+- filter:
+    count: 1
+    match:
+      event_type: drop
+      drop.reason: "firewall default app policy"
+      pcap_cnt: 7
+- filter:
+    count: 2
+    match:
+      event_type: drop
+      drop.reason: "firewall flow drop"
+- filter:
+    count: 1
+    match:
+      event_type: flow
+      app_proto: http2
+      flow.action: drop
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.app_layer.flow.http2: 1
+      stats.firewall.accepted: 6
+      stats.firewall.blocked: 3
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.flow_drop: 2
+      stats.firewall.drop_reason.rules: 0
+      stats.firewall.drop_reason.default_packet_policy: 0

--- a/tests/firewall/ruletype-firewall-145-default-policy-substate-fallthrough/README.md
+++ b/tests/firewall/ruletype-firewall-145-default-policy-substate-fallthrough/README.md
@@ -1,0 +1,9 @@
+Test that a sub state with no default-policy of its own falls through to the
+per-protocol default-policy.
+
+
+app.http2.default-policy is drop:flow and app.http2.stream.default-policy is
+accept:hook. Only stream has a default of its own but the connection-level
+global sub state does not, so its hooks fall through one tier and drop the flow
+at packet 4, before any stream hook gets a turn and before the http2 parser
+registers the flow. The alert shows that it picked up the protocol default.

--- a/tests/firewall/ruletype-firewall-145-default-policy-substate-fallthrough/firewall.rules
+++ b/tests/firewall/ruletype-firewall-145-default-policy-substate-fallthrough/firewall.rules
@@ -1,0 +1,3 @@
+# No app rules: the http2 hooks are decided entirely by the configured
+# default policies.
+accept:hook tcp:all any any -> any any (sid:1;)

--- a/tests/firewall/ruletype-firewall-145-default-policy-substate-fallthrough/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-145-default-policy-substate-fallthrough/suricata.yaml
@@ -1,0 +1,28 @@
+%YAML 1.1
+---
+
+stats:
+  enabled: yes
+  interval: 8
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - stats
+        - flow
+        - alert
+        - http2
+        - drop:
+            alerts: yes
+            flows: all
+
+firewall:
+  policies:
+    app:
+      http2:
+        default-policy: [ "drop:flow", "alert" ]
+        stream:
+          default-policy: [ "accept:hook" ]

--- a/tests/firewall/ruletype-firewall-145-default-policy-substate-fallthrough/test.yaml
+++ b/tests/firewall/ruletype-firewall-145-default-policy-substate-fallthrough/test.yaml
@@ -1,0 +1,48 @@
+requires:
+  min-version: 8.0.7
+
+pcap: ../../http2-userinfo-authority/http2_userinfo_in_authority_1.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+# The "global" sub state has no default-policy of its own, so its first hook
+# falls through to app.http2.default-policy and drops the flow immediately.
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      alert.signature_id: 2201001
+      app_proto: http2
+      pcap_cnt: 4
+- filter:
+    count: 1
+    match:
+      event_type: drop
+      drop.reason: "firewall default app policy"
+      pcap_cnt: 4
+- filter:
+    count: 5
+    match:
+      event_type: drop
+      drop.reason: "firewall flow drop"
+- filter:
+    count: 1
+    match:
+      event_type: flow
+      app_proto: http2
+      flow.action: drop
+# The flow is dropped before the http2 parser registers it.
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.app_layer.flow.http2: 0
+      stats.firewall.accepted: 3
+      stats.firewall.blocked: 6
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.flow_drop: 5
+      stats.firewall.drop_reason.rules: 0
+      stats.firewall.drop_reason.default_packet_policy: 0

--- a/tests/firewall/ruletype-firewall-146-default-policy-tls-request-complete/README.md
+++ b/tests/firewall/ruletype-firewall-146-default-policy-tls-request-complete/README.md
@@ -1,0 +1,2 @@
+Test that the generic request-complete hook alias resolves to a protocol's own
+final state.

--- a/tests/firewall/ruletype-firewall-146-default-policy-tls-request-complete/firewall.rules
+++ b/tests/firewall/ruletype-firewall-146-default-policy-tls-request-complete/firewall.rules
@@ -1,0 +1,2 @@
+# No app rules: the tls hooks are decided entirely by the configured default
+# policies.

--- a/tests/firewall/ruletype-firewall-146-default-policy-tls-request-complete/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-146-default-policy-tls-request-complete/suricata.yaml
@@ -1,0 +1,32 @@
+%YAML 1.1
+---
+
+stats:
+  enabled: yes
+  interval: 8
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - stats
+        - flow
+        - alert
+        - tls:
+            extended: yes
+        - drop:
+            alerts: yes
+            flows: all
+
+firewall:
+  policies:
+    packet:
+      filter: [ "accept:hook" ]
+    app:
+      tls:
+        default-policy: [ "accept:hook" ]
+        # TLS calls its to_server completion state "client_finished". The
+        # generic completion alias has to resolve to that same hook.
+        request-complete: [ "drop:flow", "alert" ]

--- a/tests/firewall/ruletype-firewall-146-default-policy-tls-request-complete/test.yaml
+++ b/tests/firewall/ruletype-firewall-146-default-policy-tls-request-complete/test.yaml
@@ -1,0 +1,43 @@
+requires:
+  min-version: 8.0.7
+
+pcap: ../../tls/tls-random/input.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+# Exactly one drop + alert, on the packet where to_server reaches client_finished.
+- filter:
+    count: 1
+    match:
+      event_type: drop
+      drop.reason: "firewall default app policy"
+      pcap_cnt: 13
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      alert.signature_id: 2201001
+      app_proto: tls
+      pcap_cnt: 13
+- filter:
+    count: 1
+    match:
+      event_type: flow
+      app_proto: tls
+      flow.action: drop
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.flow.total: 1
+      stats.app_layer.flow.tls: 1
+      stats.firewall.accepted: 12
+      stats.firewall.blocked: 1
+      stats.firewall.rejected: 0
+      stats.firewall.drop_reason.default_app_policy: 1
+      stats.firewall.drop_reason.default_packet_policy: 0
+      stats.firewall.drop_reason.rules: 0
+      stats.firewall.drop_reason.flow_drop: 0

--- a/tests/firewall/ruletype-firewall-147-default-policy-scope-packet-hook/README.md
+++ b/tests/firewall/ruletype-firewall-147-default-policy-scope-packet-hook/README.md
@@ -1,0 +1,2 @@
+Test that a global default-policy carrying an app-only action scope is rejected
+at startup when it reaches a packet hook.

--- a/tests/firewall/ruletype-firewall-147-default-policy-scope-packet-hook/firewall.rules
+++ b/tests/firewall/ruletype-firewall-147-default-policy-scope-packet-hook/firewall.rules
@@ -1,0 +1,1 @@
+# A rule file has to exist so the run is in firewall-mode

--- a/tests/firewall/ruletype-firewall-147-default-policy-scope-packet-hook/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-147-default-policy-scope-packet-hook/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: no
+
+firewall:
+  policies:
+    default-policy: [ "accept:tx" ]

--- a/tests/firewall/ruletype-firewall-147-default-policy-scope-packet-hook/test.yaml
+++ b/tests/firewall/ruletype-firewall-147-default-policy-scope-packet-hook/test.yaml
@@ -1,0 +1,15 @@
+requires:
+  min-version: 8.0.7
+  pcap: false
+
+args:
+  - --simulate-ips
+  - -T
+
+exit-code: 1
+
+checks:
+  - shell:
+      args: |-
+        grep -qF 'firewall.policies.default-policy: action scope ("tx") is not valid.  Valid scopes: packet/hook/flow' stderr && echo found
+      expect: found

--- a/tests/firewall/ruletype-firewall-148-default-policy-scope-app-hook/README.md
+++ b/tests/firewall/ruletype-firewall-148-default-policy-scope-app-hook/README.md
@@ -1,0 +1,2 @@
+Test that a global default-policy carrying a packet-only action scope is
+rejected at startup when it reaches an app-layer hook.

--- a/tests/firewall/ruletype-firewall-148-default-policy-scope-app-hook/firewall.rules
+++ b/tests/firewall/ruletype-firewall-148-default-policy-scope-app-hook/firewall.rules
@@ -1,0 +1,1 @@
+# A rule file has to exist so the run is in firewall-mode

--- a/tests/firewall/ruletype-firewall-148-default-policy-scope-app-hook/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-148-default-policy-scope-app-hook/suricata.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: no
+
+firewall:
+  policies:
+    default-policy: [ "drop:packet" ]

--- a/tests/firewall/ruletype-firewall-148-default-policy-scope-app-hook/test.yaml
+++ b/tests/firewall/ruletype-firewall-148-default-policy-scope-app-hook/test.yaml
@@ -1,0 +1,15 @@
+requires:
+  min-version: 8.0.7
+  pcap: false
+
+args:
+  - --simulate-ips
+  - -T
+
+exit-code: 1
+
+checks:
+  - shell:
+      args: |-
+        grep -qF 'firewall.policies.default-policy: action scope ("packet") is not valid.  Valid scopes: flow/tx/hook' stderr && echo found
+      expect: found

--- a/tests/firewall/ruletype-firewall-149-default-policy-scope-substate/README.md
+++ b/tests/firewall/ruletype-firewall-149-default-policy-scope-substate/README.md
@@ -1,0 +1,7 @@
+Test that action scope validation covers default policies nested under a sub
+state.
+
+The rejected setting is app.http2.stream.default-policy rather than one at the
+top of firewall.policies. The error quotes the full nested path, so the check
+confirms both that the sub state tier is validated like any other and that the
+message points at where the bad setting actually lives.

--- a/tests/firewall/ruletype-firewall-149-default-policy-scope-substate/firewall.rules
+++ b/tests/firewall/ruletype-firewall-149-default-policy-scope-substate/firewall.rules
@@ -1,0 +1,1 @@
+# A rule file has to exist so the run is in firewall-mode

--- a/tests/firewall/ruletype-firewall-149-default-policy-scope-substate/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-149-default-policy-scope-substate/suricata.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: no
+
+firewall:
+  policies:
+    app:
+      http2:
+        stream:
+          default-policy: [ "drop:packet" ]

--- a/tests/firewall/ruletype-firewall-149-default-policy-scope-substate/test.yaml
+++ b/tests/firewall/ruletype-firewall-149-default-policy-scope-substate/test.yaml
@@ -1,0 +1,15 @@
+requires:
+  min-version: 8.0.7
+  pcap: false
+
+args:
+  - --simulate-ips
+  - -T
+
+exit-code: 1
+
+checks:
+  - shell:
+      args: |-
+        grep -qF 'firewall.policies.app.http2.stream.default-policy: action scope ("packet") is not valid.  Valid scopes: flow/tx/hook' stderr && echo found
+      expect: found

--- a/tests/firewall/ruletype-firewall-150-default-policy-global/README.md
+++ b/tests/firewall/ruletype-firewall-150-default-policy-global/README.md
@@ -1,0 +1,8 @@
+Test that the global default-policy supplies the policy for every hook, packet
+and app-layer alike.
+
+It is the last tier consulted, so with no rules and nothing more specific
+configured it decides all of them. The built-ins it displaces would otherwise
+drop: drop:packet at the filter hook and drop:flow at the app hooks. Instead the
+TLS session runs to completion with all 62 packets accepted, no drop events, and
+no action recorded on the flow.

--- a/tests/firewall/ruletype-firewall-150-default-policy-global/firewall.rules
+++ b/tests/firewall/ruletype-firewall-150-default-policy-global/firewall.rules
@@ -1,0 +1,2 @@
+# No rules: every hook, packet and app, is decided by the global
+# default-policy.

--- a/tests/firewall/ruletype-firewall-150-default-policy-global/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-150-default-policy-global/suricata.yaml
@@ -1,0 +1,57 @@
+%YAML 1.1
+---
+
+vars:
+  address-groups:
+    HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
+    EXTERNAL_NET: "!$HOME_NET"
+    HTTP_SERVERS: "$HOME_NET"
+    SMTP_SERVERS: "$HOME_NET"
+    SQL_SERVERS: "$HOME_NET"
+    DNS_SERVERS: "$HOME_NET"
+    TELNET_SERVERS: "$HOME_NET"
+    AIM_SERVERS: "$EXTERNAL_NET"
+    DC_SERVERS: "$HOME_NET"
+    DNP3_SERVER: "$HOME_NET"
+    DNP3_CLIENT: "$HOME_NET"
+    MODBUS_CLIENT: "$HOME_NET"
+    MODBUS_SERVER: "$HOME_NET"
+    ENIP_CLIENT: "$HOME_NET"
+    ENIP_SERVER: "$HOME_NET"
+
+  port-groups:
+    HTTP_PORTS: "80"
+    SHELLCODE_PORTS: "!80"
+    ORACLE_PORTS: 1521
+    SSH_PORTS: 22
+    DNP3_PORTS: 20000
+    MODBUS_PORTS: 502
+    FILE_DATA_PORTS: "[$HTTP_PORTS,110,143]"
+    FTP_PORTS: 21
+    GENEVE_PORTS: 6081
+    VXLAN_PORTS: 4789
+    TEREDO_PORTS: 3544
+    SIP_PORTS: "[5060, 5061]"
+
+stats:
+  enabled: yes
+  interval: 8
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - stats
+        - flow
+        - alert
+        - tls:
+            extended: yes
+        - drop:
+            alerts: yes
+            flows: all
+
+firewall:
+  policies:
+    default-policy: [ "accept:hook" ]

--- a/tests/firewall/ruletype-firewall-150-default-policy-global/test.yaml
+++ b/tests/firewall/ruletype-firewall-150-default-policy-global/test.yaml
@@ -1,0 +1,37 @@
+requires:
+  min-version: 8.0.7
+
+pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+- filter:
+    count: 0
+    match:
+      event_type: drop
+- filter:
+    count: 1
+    match:
+      event_type: flow
+      flow.pkts_toserver: 32
+      flow.pkts_toclient: 30
+      flow.state: "closed"
+      flow.alerted: false
+      not-has-key: flow.action
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 62
+      stats.ips.blocked: 0
+      stats.ips.rejected: 0
+      stats.ips.drop_reason.flow_drop: 0
+      stats.firewall.accepted: 62
+      stats.firewall.blocked: 0
+      stats.firewall.rejected: 0
+      stats.firewall.drop_reason.default_packet_policy: 0
+      stats.firewall.drop_reason.default_app_policy: 0
+      stats.firewall.drop_reason.flow_drop: 0

--- a/tests/firewall/ruletype-firewall-151-default-policy-per-proto/README.md
+++ b/tests/firewall/ruletype-firewall-151-default-policy-per-proto/README.md
@@ -1,0 +1,10 @@
+Test that a per-protocol default-policy covers a protocol's app-layer hooks
+while a specific hook setting carves one of them out.
+
+packet.default-policy opens the packet hooks. app.dns.default-policy is
+drop:flow, and dns.request-started is set to accept:hook, so DNS requests are
+allowed to start while every later hook falls back to the per-protocol default.
+
+The four requests are parsed and logged, then dropped before any response
+arrives. Each of the four flows accounts for two drops: one attributed to the
+default app policy, and one to the flow drop that follows from it.

--- a/tests/firewall/ruletype-firewall-151-default-policy-per-proto/firewall.rules
+++ b/tests/firewall/ruletype-firewall-151-default-policy-per-proto/firewall.rules
@@ -1,0 +1,3 @@
+# The hooks are decided entirely by the configured default policies.
+# packet.default-policy opens the packet hooks, request-started is carved out
+# for DNS, and everything else falls back to app.dns.default-policy.

--- a/tests/firewall/ruletype-firewall-151-default-policy-per-proto/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-151-default-policy-per-proto/suricata.yaml
@@ -1,0 +1,61 @@
+%YAML 1.1
+---
+
+vars:
+  address-groups:
+    HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
+    EXTERNAL_NET: "!$HOME_NET"
+    HTTP_SERVERS: "$HOME_NET"
+    SMTP_SERVERS: "$HOME_NET"
+    SQL_SERVERS: "$HOME_NET"
+    DNS_SERVERS: "$HOME_NET"
+    TELNET_SERVERS: "$HOME_NET"
+    AIM_SERVERS: "$EXTERNAL_NET"
+    DC_SERVERS: "$HOME_NET"
+    DNP3_SERVER: "$HOME_NET"
+    DNP3_CLIENT: "$HOME_NET"
+    MODBUS_CLIENT: "$HOME_NET"
+    MODBUS_SERVER: "$HOME_NET"
+    ENIP_CLIENT: "$HOME_NET"
+    ENIP_SERVER: "$HOME_NET"
+
+  port-groups:
+    HTTP_PORTS: "80"
+    SHELLCODE_PORTS: "!80"
+    ORACLE_PORTS: 1521
+    SSH_PORTS: 22
+    DNP3_PORTS: 20000
+    MODBUS_PORTS: 502
+    FILE_DATA_PORTS: "[$HTTP_PORTS,110,143]"
+    FTP_PORTS: 21
+    GENEVE_PORTS: 6081
+    VXLAN_PORTS: 4789
+    TEREDO_PORTS: 3544
+    SIP_PORTS: "[5060, 5061]"
+
+stats:
+  enabled: yes
+  interval: 8
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - stats
+        - flow
+        - alert
+        - dns
+        - drop:
+            alerts: yes
+            flows: all
+
+firewall:
+  policies:
+    packet:
+      default-policy: [ "accept:hook" ]
+    app:
+      dns:
+        default-policy: [ "drop:flow" ]
+        request-started: [ "accept:hook" ]

--- a/tests/firewall/ruletype-firewall-151-default-policy-per-proto/test.yaml
+++ b/tests/firewall/ruletype-firewall-151-default-policy-per-proto/test.yaml
@@ -1,0 +1,51 @@
+requires:
+  min-version: 8.0.7
+
+pcap: ../../dns/dns-eve/input.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+- filter:
+    count: 4
+    match:
+      event_type: dns
+      dns.type: request
+- filter:
+    count: 0
+    match:
+      event_type: dns
+      dns.type: response
+- filter:
+    count: 8
+    match:
+      event_type: drop
+- filter:
+    count: 4
+    match:
+      event_type: drop
+      drop.reason: "firewall default app policy"
+- filter:
+    count: 4
+    match:
+      event_type: drop
+      drop.reason: "firewall flow drop"
+- filter:
+    count: 4
+    match:
+      event_type: flow
+      flow.action: drop
+      flow.alerted: false
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.ips.accepted: 0
+      stats.ips.blocked: 0
+      stats.firewall.accepted: 0
+      stats.firewall.blocked: 8
+      stats.firewall.drop_reason.default_packet_policy: 0
+      stats.firewall.drop_reason.default_app_policy: 4
+      stats.firewall.drop_reason.flow_drop: 4

--- a/tests/firewall/ruletype-firewall-68-config-default-policy-tls/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-68-config-default-policy-tls/suricata.yaml
@@ -33,14 +33,15 @@ outputs:
 
 firewall:
   policies:
-    tls:
-      client-in-progress:
-        - "accept:hook"
-      client-hello-done:
-        - "drop:flow"
-      client-cert-done:
-        - "accept:hook"
-      client-handshake-done:
-        - "accept:hook"
-      client-finished:
-        - "accept:hook"
+    app:
+      tls:
+        client-in-progress:
+          - "accept:hook"
+        client-hello-done:
+          - "drop:flow"
+        client-cert-done:
+          - "accept:hook"
+        client-handshake-done:
+          - "accept:hook"
+        client-finished:
+          - "accept:hook"

--- a/tests/firewall/ruletype-firewall-69-config-default-policy-tls-accept/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-69-config-default-policy-tls-accept/suricata.yaml
@@ -33,14 +33,15 @@ outputs:
 
 firewall:
   policies:
-    tls:
-      client-in-progress:
-        - "accept:hook"
-      client-hello-done:
-        - "accept:hook"
-      client-cert-done:
-        - "accept:hook"
-      client-handshake-done:
-        - "accept:hook"
-      client-finished:
-        - "accept:hook"
+    app:
+      tls:
+        client-in-progress:
+          - "accept:hook"
+        client-hello-done:
+          - "accept:hook"
+        client-cert-done:
+          - "accept:hook"
+        client-handshake-done:
+          - "accept:hook"
+        client-finished:
+          - "accept:hook"

--- a/tests/firewall/ruletype-firewall-70-config-default-policy-http/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-70-config-default-policy-http/suricata.yaml
@@ -64,10 +64,9 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-line:
-        - "accept:hook"
-      request-body:
-        - "accept:hook"
-      request-trailers:
-        - "accept:hook"
+    app:
+      http1:
+        request-line:
+          - "accept:hook"
+        request-body:
+          - "accept:hook"

--- a/tests/firewall/ruletype-firewall-71-reject-app-default-policy/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-71-reject-app-default-policy/suricata.yaml
@@ -66,6 +66,7 @@ outputs:
 
 firewall:
   policies:
-    tls:
-      client-hello-done:
-        - "reject:flow"
+    app:
+      tls:
+        client-hello-done:
+          - "reject:flow"

--- a/tests/firewall/ruletype-firewall-72-config-default-policy-http/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-72-config-default-policy-http/suricata.yaml
@@ -64,10 +64,11 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started:
-        - "accept:hook"
-      request-trailer:
-        - "accept:hook"
-      request-complete:
-        - "accept:hook"
+    app:
+      http1:
+        request-started:
+          - "accept:hook"
+        request-trailer:
+          - "accept:hook"
+        request-complete:
+          - "accept:hook"

--- a/tests/firewall/ruletype-firewall-73-config-default-policy-http/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-73-config-default-policy-http/suricata.yaml
@@ -64,14 +64,15 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started:
-        - "accept:hook"
-      request-line:
-        - "accept:hook"
-      request-headers:
-        - "accept:hook"
-      request-body:
-        - "accept:hook"
-      request-trailer:
-        - "accept:hook"
+    app:
+      http1:
+        request-started:
+          - "accept:hook"
+        request-line:
+          - "accept:hook"
+        request-headers:
+          - "accept:hook"
+        request-body:
+          - "accept:hook"
+        request-trailer:
+          - "accept:hook"

--- a/tests/firewall/ruletype-firewall-74-config-default-policy-dns/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-74-config-default-policy-dns/suricata.yaml
@@ -64,12 +64,9 @@ outputs:
 
 firewall:
   policies:
-    dns:
-      request-started:
-        - "accept:hook"
-      request-complete:
-        - "drop:flow"
-      response-started:
-        - "accept:hook"
-      response-complete:
-        - "drop:flow"
+    app:
+      dns:
+        request-started: ["accept:hook"]
+        request-complete: ["drop:flow"]
+        response-started: ["accept:hook"]
+        response-complete: ["drop:flow"]

--- a/tests/firewall/ruletype-firewall-75-config-default-policy-http-accept-tx/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-75-config-default-policy-http-accept-tx/suricata.yaml
@@ -64,6 +64,6 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started:
-        - "accept:tx"
+    app:
+      http1:
+        request-started: ["accept:tx"]

--- a/tests/firewall/ruletype-firewall-76-config-default-policy-http-accept-tx-td/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-76-config-default-policy-http-accept-tx-td/suricata.yaml
@@ -64,6 +64,6 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started:
-        - "accept:tx"
+    app:
+      http1:
+        request-started: ["accept:tx"]

--- a/tests/firewall/ruletype-firewall-77-ruleset-default-packet-policy/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-77-ruleset-default-packet-policy/suricata.yaml
@@ -65,4 +65,5 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "reject:packet" ]
+    packet:
+      filter: ["reject:packet"]

--- a/tests/firewall/ruletype-firewall-78-ruleset-default-packet-policy-accept/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-78-ruleset-default-packet-policy-accept/suricata.yaml
@@ -65,4 +65,5 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "accept:packet" ]
+    packet:
+      filter: ["accept:packet"]

--- a/tests/firewall/ruletype-firewall-79-ruleset-default-packet-policy-accept-hook/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-79-ruleset-default-packet-policy-accept-hook/suricata.yaml
@@ -65,4 +65,5 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "accept:hook" ]
+    packet:
+      filter: ["accept:hook"]

--- a/tests/firewall/ruletype-firewall-80-ruleset-default-packet-policy-accept-hook-no-rules/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-80-ruleset-default-packet-policy-accept-hook-no-rules/suricata.yaml
@@ -65,4 +65,5 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "accept:hook" ]
+    packet:
+      filter: ["accept:hook"]

--- a/tests/firewall/ruletype-firewall-81-ruleset-default-packet-policy-accept-hook-all/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-81-ruleset-default-packet-policy-accept-hook-all/suricata.yaml
@@ -65,16 +65,18 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "accept:hook" ]
-    tls:
-      client-in-progress: [ "accept:hook" ]
-      client-hello-done: [ "accept:hook" ]
-      client-cert-done: [ "accept:hook" ]
-      client-handshake-done: [ "accept:hook" ]
-      client-finished: [ "accept:hook" ]
-      server-in-progress: [ "accept:hook" ]
-      server-hello: [ "accept:hook" ]
-      server-hello-done: [ "accept:hook" ]
-      server-cert-done: [ "accept:hook" ]
-      server-handshake-done: [ "accept:hook" ]
-      server-finished: [ "accept:hook" ]
+    packet:
+      filter: ["accept:hook"]
+    app:
+      tls:
+        client-in-progress: ["accept:hook"]
+        client-hello-done: ["accept:hook"]
+        client-cert-done: ["accept:hook"]
+        client-handshake-done: ["accept:hook"]
+        client-finished: ["accept:hook"]
+        server-in-progress: ["accept:hook"]
+        server-hello: ["accept:hook"]
+        server-hello-done: ["accept:hook"]
+        server-cert-done: ["accept:hook"]
+        server-handshake-done: ["accept:hook"]
+        server-finished: ["accept:hook"]

--- a/tests/firewall/ruletype-firewall-82-ruleset-default-app-policy-accept-flow/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-82-ruleset-default-app-policy-accept-flow/suricata.yaml
@@ -65,6 +65,8 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "accept:hook" ]
-    tls:
-      client-in-progress: [ "accept:flow" ]
+    packet:
+      filter: ["accept:hook"]
+    app:
+      tls:
+        client-in-progress: ["accept:flow"]

--- a/tests/firewall/ruletype-firewall-83-ruleset-default-packet-policy-accept-flow/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-83-ruleset-default-packet-policy-accept-flow/suricata.yaml
@@ -65,4 +65,5 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "accept:flow" ]
+    packet:
+      filter: ["accept:flow"]

--- a/tests/firewall/ruletype-firewall-84-ruleset-default-app-policy-tls-request-started/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-84-ruleset-default-app-policy-tls-request-started/suricata.yaml
@@ -65,6 +65,8 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "accept:hook" ]
-    tls:
-      request-started: [ "accept:flow" ]
+    packet:
+      filter: ["accept:hook"]
+    app:
+      tls:
+        request-started: ["accept:flow"]

--- a/tests/firewall/ruletype-firewall-86-packet-filter-accept-flow-pass-with-td/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-86-packet-filter-accept-flow-pass-with-td/suricata.yaml
@@ -19,6 +19,6 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started: [ "accept:flow" ]
-      #request-started: [ "accept:flow", "pass:flow" ]
+    app:
+      http1:
+        request-started: ["accept:flow"]

--- a/tests/firewall/ruletype-firewall-87-broken-default-policy/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-87-broken-default-policy/suricata.yaml
@@ -19,5 +19,6 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started: [ "accept:foo" ]
+    app:
+      http1:
+        request-started: [ "accept:foo" ]

--- a/tests/firewall/ruletype-firewall-88-default-accept-tx-pipeline/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-88-default-accept-tx-pipeline/suricata.yaml
@@ -19,17 +19,19 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: ["accept:hook"]
-    http:
-      request-started: ["accept:hook"]
-      request-line: ["accept:hook"]
-      request-headers: ["accept:hook"]
-      request-body: ["accept:hook"]
-      request-trailer: ["accept:hook"]
-      request-complete: ["accept:tx"]
-      response-started: ["accept:hook"]
-      response-line: ["accept:hook"]
-      response-headers: ["accept:hook"]
-      response-body: ["accept:hook"]
-      response-trailer: ["accept:hook"]
-      response-complete: ["accept:hook"]
+    packet:
+      filter: ["accept:hook"]
+    app:
+      http1:
+        request-started: ["accept:hook"]
+        request-line: ["accept:hook"]
+        request-headers: ["accept:hook"]
+        request-body: ["accept:hook"]
+        request-trailer: ["accept:hook"]
+        request-complete: ["accept:tx"]
+        response-started: ["accept:hook"]
+        response-line: ["accept:hook"]
+        response-headers: ["accept:hook"]
+        response-body: ["accept:hook"]
+        response-trailer: ["accept:hook"]
+        response-complete: ["accept:hook"]

--- a/tests/firewall/ruletype-firewall-89-defaults-over-drop/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-89-defaults-over-drop/suricata.yaml
@@ -19,17 +19,19 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: ["accept:hook"]
-    http:
-      request-started: ["accept:hook"]
-      request-line: ["accept:hook"]
-      request-headers: ["accept:hook"]
-      request-body: ["accept:hook"]
-      request-trailer: ["accept:hook"]
-      request-complete: ["accept:hook"]
-      response-started: ["accept:hook"]
-      response-line: ["accept:hook"]
-      response-headers: ["accept:hook"]
-      response-body: ["accept:hook"]
-      response-trailer: ["accept:hook"]
-      response-complete: ["accept:hook"]
+    packet:
+      filter: ["accept:hook"]
+    app:
+      http1:
+        request-started: ["accept:hook"]
+        request-line: ["accept:hook"]
+        request-headers: ["accept:hook"]
+        request-body: ["accept:hook"]
+        request-trailer: ["accept:hook"]
+        request-complete: ["accept:hook"]
+        response-started: ["accept:hook"]
+        response-line: ["accept:hook"]
+        response-headers: ["accept:hook"]
+        response-body: ["accept:hook"]
+        response-trailer: ["accept:hook"]
+        response-complete: ["accept:hook"]

--- a/tests/firewall/ruletype-firewall-92-lt-ua-mix/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-92-lt-ua-mix/suricata.yaml
@@ -65,5 +65,6 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started: [ "accept:hook" ]
+    app:
+      http1:
+        request-started: ["accept:hook"]

--- a/tests/firewall/ruletype-firewall-93-lt-ua-mix-accept-hook/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-93-lt-ua-mix-accept-hook/suricata.yaml
@@ -65,9 +65,9 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started: [ "accept:hook" ]
-
-      request-body: [ "accept:hook" ]
-      request-trailer: [ "accept:hook" ]
-      request-complete: [ "accept:tx" ]
+    app:
+      http1:
+        request-started: ["accept:hook"]
+        request-body: ["accept:hook"]
+        request-trailer: ["accept:hook"]
+        request-complete: ["accept:tx"]

--- a/tests/firewall/ruletype-firewall-94-config-default-policy-http/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-94-config-default-policy-http/suricata.yaml
@@ -64,19 +64,10 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started:
-        - "accept:hook"
-        - "alert"
-      request-line:
-        - "accept:hook"
-        - "alert"
-      request-headers:
-        - "accept:hook"
-        - "alert"
-      request-body:
-        - "accept:hook"
-        - "alert"
-      request-trailer:
-        - "accept:hook"
-        - "alert"
+    app:
+      http1:
+        request-started: ["accept:hook", "alert"]
+        request-line: ["accept:hook", "alert"]
+        request-headers: ["accept:hook", "alert"]
+        request-body: ["accept:hook", "alert"]
+        request-trailer: ["accept:hook", "alert"]

--- a/tests/firewall/ruletype-firewall-95-ruleset-default-packet-policy-accept-hook-alert/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-95-ruleset-default-packet-policy-accept-hook-alert/suricata.yaml
@@ -65,52 +65,30 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "accept:hook", "alert" ]
-    http:
-      request-started:
-        - "accept:hook"
-      request-line:
-        - "accept:hook"
-      request-headers:
-        - "accept:hook"
-      request-body:
-        - "accept:hook"
-      request-trailer:
-        - "accept:hook"
-      request-complete:
-        - "accept:hook"
-      request-started:
-        - "accept:hook"
-      response-line:
-        - "accept:hook"
-      response-headers:
-        - "accept:hook"
-      response-body:
-        - "accept:hook"
-      response-trailer:
-        - "accept:hook"
-      response-complete:
-        - "accept:hook"
-    tls:
-      client-in-progress:
-        - "accept:hook"
-      client-hello-done:
-        - "accept:hook"
-      client-cert-done:
-        - "accept:hook"
-      client-handshake-done:
-        - "accept:hook"
-      client-finished:
-        - "accept:hook"
-      server-in-progress:
-        - "accept:hook"
-      server-hello:
-        - "accept:hook"
-      server-hello-done:
-        - "accept:hook"
-      server-cert-done:
-        - "accept:hook"
-      server-handshake-done:
-        - "accept:hook"
-      server-finished:
-        - "accept:hook"
+    packet:
+      filter: ["accept:hook", "alert"]
+    app:
+      http1:
+        request-started: ["accept:hook"]
+        request-line: ["accept:hook"]
+        request-headers: ["accept:hook"]
+        request-body: ["accept:hook"]
+        request-trailer: ["accept:hook"]
+        request-complete: ["accept:hook"]
+        response-line: ["accept:hook"]
+        response-headers: ["accept:hook"]
+        response-body: ["accept:hook"]
+        response-trailer: ["accept:hook"]
+        response-complete: ["accept:hook"]
+      tls:
+        client-in-progress: ["accept:hook"]
+        client-hello-done: ["accept:hook"]
+        client-cert-done: ["accept:hook"]
+        client-handshake-done: ["accept:hook"]
+        client-finished: ["accept:hook"]
+        server-in-progress: ["accept:hook"]
+        server-hello: ["accept:hook"]
+        server-hello-done: ["accept:hook"]
+        server-cert-done: ["accept:hook"]
+        server-handshake-done: ["accept:hook"]
+        server-finished: ["accept:hook"]

--- a/tests/http2-keywords2/test.yaml
+++ b/tests/http2-keywords2/test.yaml
@@ -57,14 +57,14 @@ checks:
         alert.signature_id: 34
   - filter:
       requires:
-        lt-version: 9
+        lt-version: 8.0.7
       count: 12
       match:
         event_type: alert
         alert.signature_id: 35
   - filter:
       requires:
-        min-version: 9
+        min-version: 8.0.7
       # In 9, we match only once for global tx instead of for each direction
       # TODO currently matching only on stream type
       count: 4
@@ -83,7 +83,7 @@ checks:
         alert.signature_id: 37
   - filter:
       requires:
-        lt-version: 9
+        lt-version: 8.0.7
       count: 6
       match:
         event_type: alert
@@ -91,14 +91,14 @@ checks:
   - filter:
       # TODO currently matching only on stream type
       requires:
-        min-version: 9
+        min-version: 8.0.7
       count: 2
       match:
         event_type: alert
         alert.signature_id: 38
   - filter:
       requires:
-        lt-version: 9
+        lt-version: 8.0.7
       count: 6
       match:
         event_type: alert
@@ -106,7 +106,7 @@ checks:
   - filter:
       # TODO currently matching only on stream type
       requires:
-        min-version: 9
+        min-version: 8.0.7
       count: 2
       match:
         event_type: alert

--- a/tests/mime/mime-dec-parse-full-msg-test01/test.yaml
+++ b/tests/mime/mime-dec-parse-full-msg-test01/test.yaml
@@ -4,7 +4,7 @@ args:
 checks:
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -21,11 +21,11 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 does not defer tx completion to the server response, so the
-# SMTP event lands one packet earlier. Remove when backported to 8.
+# Pre-8.0.7 does not defer tx completion to the server response, so the
+# SMTP event lands one packet earlier. Backported to 8.0.7.
 - filter:
     requires:
-      lt-version: 9
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -42,10 +42,10 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 creates/logs a trailing QUIT transaction with inherited HELO.
+# Pre-8.0.7 creates/logs a trailing QUIT transaction with inherited HELO.
 - filter:
     requires:
-      lt-version: 9.0
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -58,7 +58,7 @@ checks:
       tx_id: 1
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 0
     match:
       dest_ip: 127.0.0.1

--- a/tests/mime/mime-dec-parse-full-msg-test02/test.yaml
+++ b/tests/mime/mime-dec-parse-full-msg-test02/test.yaml
@@ -4,7 +4,7 @@ args:
 checks:
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -21,11 +21,11 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 does not defer tx completion to the server response, so the
-# SMTP event lands one packet earlier. Remove when backported to 8.
+# Pre-8.0.7 does not defer tx completion to the server response, so the
+# SMTP event lands one packet earlier. Backported to 8.0.7.
 - filter:
     requires:
-      lt-version: 9
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -42,10 +42,10 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 creates/logs a trailing QUIT transaction with inherited HELO.
+# Pre-8.0.7 creates/logs a trailing QUIT transaction with inherited HELO.
 - filter:
     requires:
-      lt-version: 9.0
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -58,7 +58,7 @@ checks:
       tx_id: 1
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 0
     match:
       dest_ip: 127.0.0.1

--- a/tests/mime/mime-dec-parse-line-test01/test.yaml
+++ b/tests/mime/mime-dec-parse-line-test01/test.yaml
@@ -4,7 +4,7 @@ args:
 checks:
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -21,11 +21,11 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 does not defer tx completion to the server response, so the
-# SMTP event lands one packet earlier. Remove when backported to 8.
+# Pre-8.0.7 does not defer tx completion to the server response, so the
+# SMTP event lands one packet earlier. Backported to 8.0.7.
 - filter:
     requires:
-      lt-version: 9
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -42,10 +42,10 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 creates/logs a trailing QUIT transaction with inherited HELO.
+# Pre-8.0.7 creates/logs a trailing QUIT transaction with inherited HELO.
 - filter:
     requires:
-      lt-version: 9.0
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -58,7 +58,7 @@ checks:
       tx_id: 1
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 0
     match:
       dest_ip: 127.0.0.1

--- a/tests/mime/mime-dec-parse-line-test02/test.yaml
+++ b/tests/mime/mime-dec-parse-line-test02/test.yaml
@@ -4,7 +4,7 @@ args:
 checks:
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -22,11 +22,11 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 does not defer tx completion to the server response, so the
-# SMTP event lands one packet earlier. Remove when backported to 8.
+# Pre-8.0.7 does not defer tx completion to the server response, so the
+# SMTP event lands one packet earlier. Backported to 8.0.7.
 - filter:
     requires:
-      lt-version: 9
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -44,10 +44,10 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 creates/logs a trailing QUIT transaction with inherited HELO.
+# Pre-8.0.7 creates/logs a trailing QUIT transaction with inherited HELO.
 - filter:
     requires:
-      lt-version: 9.0
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -60,7 +60,7 @@ checks:
       tx_id: 1
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 0
     match:
       dest_ip: 127.0.0.1

--- a/tests/mime/mime-dec-parse-long-filename01/test.yaml
+++ b/tests/mime/mime-dec-parse-long-filename01/test.yaml
@@ -19,7 +19,7 @@ checks:
       tx_id: 0
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -37,11 +37,11 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 does not defer tx completion to the server response, so the
-# SMTP event lands one packet earlier. Remove when backported to 8.
+# Pre-8.0.7 does not defer tx completion to the server response, so the
+# SMTP event lands one packet earlier. Backported to 8.0.7.
 - filter:
     requires:
-      lt-version: 9
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -83,10 +83,10 @@ checks:
       smtp.rcpt_to[0]: <172.16.92.2@linuxbox>
       src_ip: 127.0.0.1
       src_port: 39202
-# Pre-9 creates/logs a trailing QUIT transaction with inherited HELO.
+# Pre-8.0.7 creates/logs a trailing QUIT transaction with inherited HELO.
 - filter:
     requires:
-      lt-version: 9.0
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -99,7 +99,7 @@ checks:
       tx_id: 1
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 0
     match:
       dest_ip: 127.0.0.1

--- a/tests/mime/mime-dec-parse-long-filename02/test.yaml
+++ b/tests/mime/mime-dec-parse-long-filename02/test.yaml
@@ -4,7 +4,7 @@ args:
 checks:
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -22,11 +22,11 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 does not defer tx completion to the server response, so the
-# SMTP event lands one packet earlier. Remove when backported to 8.
+# Pre-8.0.7 does not defer tx completion to the server response, so the
+# SMTP event lands one packet earlier. Backported to 8.0.7.
 - filter:
     requires:
-      lt-version: 9
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -68,10 +68,10 @@ checks:
       smtp.rcpt_to[0]: <172.16.92.2@linuxbox>
       src_ip: 127.0.0.1
       src_port: 39202
-# Pre-9 creates/logs a trailing QUIT transaction with inherited HELO.
+# Pre-8.0.7 creates/logs a trailing QUIT transaction with inherited HELO.
 - filter:
     requires:
-      lt-version: 9.0
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -84,7 +84,7 @@ checks:
       tx_id: 1
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 0
     match:
       dest_ip: 127.0.0.1

--- a/tests/mime/mime-dec-parse-odd-len/test.yaml
+++ b/tests/mime/mime-dec-parse-odd-len/test.yaml
@@ -4,7 +4,7 @@ args:
 checks:
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -21,11 +21,11 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 does not defer tx completion to the server response, so the
-# SMTP event lands one packet earlier. Remove when backported to 8.
+# Pre-8.0.7 does not defer tx completion to the server response, so the
+# SMTP event lands one packet earlier. Backported to 8.0.7.
 - filter:
     requires:
-      lt-version: 9
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -42,10 +42,10 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 creates/logs a trailing QUIT transaction with inherited HELO.
+# Pre-8.0.7 creates/logs a trailing QUIT transaction with inherited HELO.
 - filter:
     requires:
-      lt-version: 9.0
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -58,7 +58,7 @@ checks:
       tx_id: 1
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 0
     match:
       dest_ip: 127.0.0.1

--- a/tests/mime/mime-dec-parse-rem-sp/test.yaml
+++ b/tests/mime/mime-dec-parse-rem-sp/test.yaml
@@ -4,7 +4,7 @@ args:
 checks:
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -21,11 +21,11 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 does not defer tx completion to the server response, so the
-# SMTP event lands one packet earlier. Remove when backported to 8.
+# Pre-8.0.7 does not defer tx completion to the server response, so the
+# SMTP event lands one packet earlier. Backported to 8.0.7.
 - filter:
     requires:
-      lt-version: 9
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -42,10 +42,10 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 creates/logs a trailing QUIT transaction with inherited HELO.
+# Pre-8.0.7 creates/logs a trailing QUIT transaction with inherited HELO.
 - filter:
     requires:
-      lt-version: 9.0
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -58,7 +58,7 @@ checks:
       tx_id: 1
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 0
     match:
       dest_ip: 127.0.0.1

--- a/tests/mime/mime-dec-parse-small-rem-inp/test.yaml
+++ b/tests/mime/mime-dec-parse-small-rem-inp/test.yaml
@@ -4,7 +4,7 @@ args:
 checks:
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -21,11 +21,11 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 does not defer tx completion to the server response, so the
-# SMTP event lands one packet earlier. Remove when backported to 8.
+# Pre-8.0.7 does not defer tx completion to the server response, so the
+# SMTP event lands one packet earlier. Backported to 8.0.7.
 - filter:
     requires:
-      lt-version: 9
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -42,10 +42,10 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 creates/logs a trailing QUIT transaction with inherited HELO.
+# Pre-8.0.7 creates/logs a trailing QUIT transaction with inherited HELO.
 - filter:
     requires:
-      lt-version: 9.0
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -58,7 +58,7 @@ checks:
       tx_id: 1
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 0
     match:
       dest_ip: 127.0.0.1

--- a/tests/mime/mime-dec-very-small-inp/test.yaml
+++ b/tests/mime/mime-dec-very-small-inp/test.yaml
@@ -4,7 +4,7 @@ args:
 checks:
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -21,11 +21,11 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 does not defer tx completion to the server response, so the
-# SMTP event lands one packet earlier. Remove when backported to 8.
+# Pre-8.0.7 does not defer tx completion to the server response, so the
+# SMTP event lands one packet earlier. Backported to 8.0.7.
 - filter:
     requires:
-      lt-version: 9
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -42,10 +42,10 @@ checks:
       src_ip: 127.0.0.1
       src_port: 39202
       tx_id: 0
-# Pre-9 creates/logs a trailing QUIT transaction with inherited HELO.
+# Pre-8.0.7 creates/logs a trailing QUIT transaction with inherited HELO.
 - filter:
     requires:
-      lt-version: 9.0
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 127.0.0.1
@@ -58,7 +58,7 @@ checks:
       tx_id: 1
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 0
     match:
       dest_ip: 127.0.0.1

--- a/tests/rules/http-request-body/test.yaml
+++ b/tests/rules/http-request-body/test.yaml
@@ -26,7 +26,7 @@ checks:
 - filter:
     # in 9, http2 comes first with a lower progress
     requires:
-      min-version: 9
+      min-version: 8.0.7
     filename: rules.json
     count: 1
     match:
@@ -43,7 +43,7 @@ checks:
       engines.__len: 2
 - filter:
     requires:
-      lt-version: 9
+      lt-version: 8.0.7
     filename: rules.json
     count: 1
     match:

--- a/tests/rules/http-response-body/test.yaml
+++ b/tests/rules/http-response-body/test.yaml
@@ -25,7 +25,7 @@ checks:
       engines.__len: 2
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     filename: rules.json
     count: 1
     match:
@@ -42,7 +42,7 @@ checks:
       engines.__len: 2
 - filter:
     requires:
-      lt-version: 9
+      lt-version: 8.0.7
     filename: rules.json
     count: 1
     match:

--- a/tests/rules/substate-hook-02/test.yaml
+++ b/tests/rules/substate-hook-02/test.yaml
@@ -1,5 +1,5 @@
 requires:
-    min-version: 9
+    min-version: 8.0.7
     pcap: false
 
 args:

--- a/tests/rules/substate-hook-03/test.yaml
+++ b/tests/rules/substate-hook-03/test.yaml
@@ -1,5 +1,5 @@
 requires:
-    min-version: 9
+    min-version: 8.0.7
     pcap: false
 
 args:

--- a/tests/rules/substate-hook/test.yaml
+++ b/tests/rules/substate-hook/test.yaml
@@ -1,5 +1,5 @@
 requires:
-    min-version: 9
+    min-version: 8.0.7
     pcap: false
 
 args:

--- a/tests/smtp-bug-5981/test.yaml
+++ b/tests/smtp-bug-5981/test.yaml
@@ -45,10 +45,10 @@ checks:
       email.from: '"Xxxxxx xxxx" <xxxxxx@xxxxx.co.uk>'
       email.to[0]: <xxxxxx@xxxxx.co.uk>
 
-# Pre-9 creates/logs a trailing QUIT transaction with inherited HELO.
+# Pre-8.0.7 creates/logs a trailing QUIT transaction with inherited HELO.
 - filter:
     requires:
-      lt-version: 9.0
+      lt-version: 8.0.7
     count: 1
     match:
       event_type: smtp
@@ -62,7 +62,7 @@ checks:
       smtp.helo: Percival
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 0
     match:
       event_type: smtp

--- a/tests/smtp-errors/test.yaml
+++ b/tests/smtp-errors/test.yaml
@@ -22,7 +22,7 @@ checks:
         src_port: 49274
   - filter:
       requires:
-        min-version: 9
+        min-version: 8.0.7
       count: 1
       match:
         event_type: anomaly
@@ -30,11 +30,11 @@ checks:
         # no anomaly for 4.7.0 [IPTS04] Messages from 173.166.146.112 temporarily deferred due to user complaints because tx got closed before
         src_port: 49448
 
-  # Versions less than 9 will get 3 anomaly events
-  # Remove when per direction state tracking backported to 8.
+  # Versions less than 8.0.7 will get 3 anomaly events
+  # Backported to 8.0.7.
   - filter:
       requires:
-        lt-version: 9
+        lt-version: 8.0.7
       count: 3
       match:
         event_type: anomaly 

--- a/tests/smtp-file-data-01/test.yaml
+++ b/tests/smtp-file-data-01/test.yaml
@@ -7,7 +7,7 @@ args:
 checks:
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 1
     match:
       dest_ip: 1.2.190.250
@@ -25,11 +25,11 @@ checks:
       src_ip: 1.1.205.22
       src_port: 4053
       tx_id: 0
-# Pre-9 does not defer tx completion to the server response, so the
-# SMTP event lands two packets earlier. Remove when backported to 8.
+# Pre-8.0.7 does not defer tx completion to the server response, so the
+# SMTP event lands two packets earlier. Backported to 8.0.7.
 - filter:
     requires:
-      lt-version: 9
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 1.2.190.250
@@ -83,10 +83,10 @@ checks:
       src_ip: 1.1.205.22
       src_port: 4053
       tx_id: 0
-# Pre-9 creates/logs a trailing QUIT transaction with inherited HELO.
+# Pre-8.0.7 creates/logs a trailing QUIT transaction with inherited HELO.
 - filter:
     requires:
-      lt-version: 9.0
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 1.2.190.250
@@ -100,7 +100,7 @@ checks:
       tx_id: 1
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 0
     match:
       dest_ip: 1.2.190.250

--- a/tests/smtp-file-data-02/test.yaml
+++ b/tests/smtp-file-data-02/test.yaml
@@ -9,7 +9,7 @@ args:
 checks:
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 1
     match:
       dest_ip: 74.53.140.153
@@ -27,11 +27,11 @@ checks:
       src_ip: 10.10.1.4
       src_port: 1470
       tx_id: 0
-# Pre-9 does not defer tx completion to the server response, so the
-# SMTP event lands two packets earlier. Remove when backported to 8.
+# Pre-8.0.7 does not defer tx completion to the server response, so the
+# SMTP event lands two packets earlier. Backported to 8.0.7.
 - filter:
     requires:
-      lt-version: 9
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 74.53.140.153
@@ -85,10 +85,10 @@ checks:
       src_ip: 10.10.1.4
       src_port: 1470
       tx_id: 0
-# Pre-9 creates/logs a trailing QUIT transaction with inherited HELO.
+# Pre-8.0.7 creates/logs a trailing QUIT transaction with inherited HELO.
 - filter:
     requires:
-      lt-version: 9.0
+      lt-version: 8.0.7
     count: 1
     match:
       dest_ip: 74.53.140.153
@@ -102,7 +102,7 @@ checks:
       tx_id: 1
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 0
     match:
       dest_ip: 74.53.140.153

--- a/tests/smtp-keywords/test.yaml
+++ b/tests/smtp-keywords/test.yaml
@@ -4,11 +4,11 @@ requires:
   min-version: 8.0.0
 
 checks:
-# Pre-9 creates/logs a trailing QUIT transaction with inherited HELO,
+# Pre-8.0.7 creates/logs a trailing QUIT transaction with inherited HELO,
 # causing a second HELO alert.
 - filter:
     requires:
-      lt-version: 9.0
+      lt-version: 8.0.7
     count: 2
     match:
       event_type: alert
@@ -16,7 +16,7 @@ checks:
       alert.signature_id: 1
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 1
     match:
       event_type: alert

--- a/tests/smtp-long-DATA-line/test.yaml
+++ b/tests/smtp-long-DATA-line/test.yaml
@@ -44,10 +44,10 @@ checks:
       smtp.helo: Percival
       smtp.mail_from: <xxxxxx@xxxxx.co.uk>
       smtp.rcpt_to[0]: <xxxxxx@xxxxx.co.uk>
-# Pre-9 creates/logs a trailing QUIT transaction with inherited HELO.
+# Pre-8.0.7 creates/logs a trailing QUIT transaction with inherited HELO.
 - filter:
     requires:
-      lt-version: 9.0
+      lt-version: 8.0.7
     count: 1
     match:
       event_type: smtp
@@ -55,7 +55,7 @@ checks:
       tx_id: 1
 - filter:
     requires:
-      min-version: 9
+      min-version: 8.0.7
     count: 0
     match:
       event_type: smtp

--- a/tests/smtp-no-helo-quit/test.yaml
+++ b/tests/smtp-no-helo-quit/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: input.pcap
 

--- a/tests/smtp-no-helo-rset-helo-mail/test.yaml
+++ b/tests/smtp-no-helo-rset-helo-mail/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: input.pcap
 

--- a/tests/smtp-no-helo-rset/test.yaml
+++ b/tests/smtp-no-helo-rset/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: input.pcap
 

--- a/tests/smtp-pipelined-post-data-rset-sequence/test.yaml
+++ b/tests/smtp-pipelined-post-data-rset-sequence/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: input.pcap
 

--- a/tests/smtp-pipelined-rset-after-complete/test.yaml
+++ b/tests/smtp-pipelined-rset-after-complete/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: input.pcap
 

--- a/tests/smtp-quit/test.yaml
+++ b/tests/smtp-quit/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 args:
   - -k none


### PR DESCRIPTION
Redmine ticket: https://redmine.openinfosecfoundation.org/issues/8770

Patchset covers new commits from #3252 but is rebased onto #3229, and enables 8.0.7 for the new tests.