### PR TITLE
dcerpc: check for service and procedure name

### DIFF
--- a/tests/dcerpc-smb-fail/test.yaml
+++ b/tests/dcerpc-smb-fail/test.yaml
@@ -47,3 +47,67 @@ checks:
     count: 1
     match:
       event_type: stats
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: dcerpc
+      dcerpc.interfaces[0].service: "netlogon"
+      dcerpc.interfaces[0].procedure: "NetrServerPasswordSet2"
+- filter:
+    requires:
+      min-version: 9
+    count: 719
+    match:
+      event_type: dcerpc
+      dcerpc.interfaces[0].service: "netlogon"
+      dcerpc.interfaces[0].procedure: "NetrServerAuthenticate2"
+- filter:
+    requires:
+      min-version: 9
+    count: 719
+    match:
+      event_type: dcerpc
+      dcerpc.interfaces[0].service: "netlogon"
+      dcerpc.interfaces[0].procedure: "NetrServerReqChallenge"
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: dcerpc
+      dcerpc.interfaces[0].service: "drsuapi"
+      dcerpc.interfaces[0].procedure: "DRSDomainControllerInfo"
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: dcerpc
+      dcerpc.interfaces[0].service: "drsuapi"
+      dcerpc.interfaces[0].procedure: "DRSGetNCChanges"
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: dcerpc
+      dcerpc.interfaces[0].service: "drsuapi"
+      dcerpc.interfaces[0].procedure: "DRSCrackNames"
+- filter:
+    requires:
+      min-version: 9
+    count: 2
+    match:
+      event_type: dcerpc
+      dcerpc.interfaces[0].service: "drsuapi"
+      dcerpc.interfaces[0].procedure: "DRSBind"
+- filter:
+    requires:
+      min-version: 9
+    count: 2
+    match:
+      event_type: dcerpc
+      dcerpc.interfaces[0].service: "epmapper"
+      dcerpc.interfaces[0].procedure: "ept_map"

--- a/tests/dcerpc/dcerpc-ctxids/test.yaml
+++ b/tests/dcerpc/dcerpc-ctxids/test.yaml
@@ -19,3 +19,28 @@ checks:
       alert.signature_id: 1
       dcerpc.interfaces[0].uuid: 00020400-0000-0000-c000-000000000046
       dcerpc.req.opnum: 6
+- filter:
+    requires:
+      min-version: 9
+    count: 8
+    match:
+      event_type: dcerpc
+      dcerpc.interfaces[0].service: "IRemUnknown2"
+      dcerpc.interfaces[0].procedure: "RemRelease"
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: dcerpc
+      dcerpc.interfaces[0].service: "IRemoteSCMActivator"
+      dcerpc.interfaces[0].procedure: "RemoteGetClassObject"
+- filter:
+    requires:
+      min-version: 9
+    count: 26
+    match:
+      event_type: dcerpc
+      dcerpc.interfaces[0].service: "IRemUnknown2"
+      dcerpc.interfaces[0].procedure: "RemQueryInterface"
+

--- a/tests/dcerpc/dcerpc-dce-iface-01/test.yaml
+++ b/tests/dcerpc/dcerpc-dce-iface-01/test.yaml
@@ -18,3 +18,69 @@ checks:
         dcerpc.request: REQUEST
         dcerpc.interfaces[0].uuid: "367abb81-9844-35f1-ad32-98f038001003"
         dcerpc.call_id: 20
+
+  - filter:
+      requires:
+        min-version: 9
+      count: 6
+      match:
+        event_type: dcerpc
+        dcerpc.interfaces[0].service: "svcctl"
+        dcerpc.interfaces[0].procedure: "CloseServiceHandle"
+  - filter:
+      requires:
+        min-version: 9
+      count: 3
+      match:
+        event_type: dcerpc
+        dcerpc.interfaces[0].service: "svcctl"
+        dcerpc.interfaces[0].procedure: "OpenServiceW"
+  - filter:
+      requires:
+        min-version: 9
+      count: 2
+      match:
+        event_type: dcerpc
+        dcerpc.interfaces[0].service: "svcctl"
+        dcerpc.interfaces[0].procedure: "OpenSCManagerW"
+  - filter:
+      requires:
+        min-version: 9
+      count: 1
+      match:
+        event_type: dcerpc
+        dcerpc.interfaces[0].service: "svcctl"
+        dcerpc.interfaces[0].procedure: "ControlService"
+  - filter:
+      requires:
+        min-version: 9
+      count: 1
+      match:
+        event_type: dcerpc
+        dcerpc.interfaces[0].service: "svcctl"
+        dcerpc.interfaces[0].procedure: "DeleteService"
+  - filter:
+      requires:
+        min-version: 9
+      count: 1
+      match:
+        event_type: dcerpc
+        dcerpc.interfaces[0].service: "svcctl"
+        dcerpc.interfaces[0].procedure: "CreateServiceWOW64W"
+  - filter:
+      requires:
+        min-version: 9
+      count: 4
+      match:
+        event_type: dcerpc
+        dcerpc.interfaces[0].service: "svcctl"
+        dcerpc.interfaces[0].procedure: "QueryServiceStatus"
+  - filter:
+      requires:
+        min-version: 9
+      count: 1
+      match:
+        event_type: dcerpc
+        dcerpc.interfaces[0].service: "svcctl"
+        dcerpc.interfaces[0].procedure: "StartServiceW"
+

--- a/tests/dcerpc/dcerpc-dce-opnum/test.yaml
+++ b/tests/dcerpc/dcerpc-dce-opnum/test.yaml
@@ -29,3 +29,11 @@ checks:
       match:
         event_type: alert
         alert.signature_id: 3
+  - filter:
+      requires:
+        min-version: 9
+      count: 1
+      match:
+        event_type: dcerpc
+        dcerpc.interfaces[0].service: "mgmt"
+        dcerpc.interfaces[0].procedure: "inq_princ_name"

--- a/tests/dcerpc/dcerpc-dce-stub-data-02/test.yaml
+++ b/tests/dcerpc/dcerpc-dce-stub-data-02/test.yaml
@@ -13,3 +13,11 @@ checks:
       event_type: alert
       alert.signature_id: 1
       pcap_cnt: 8
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: dcerpc
+      dcerpc.interfaces[0].service: "dssetup"
+      dcerpc.interfaces[0].procedure: "DsRolerUpgradeDownlevelServer"

--- a/tests/dcerpc/dcerpc-dce-stub-data-04/test.yaml
+++ b/tests/dcerpc/dcerpc-dce-stub-data-04/test.yaml
@@ -35,3 +35,28 @@ checks:
       event_type: alert
       alert.signature_id: 3
       pcap_cnt: 16
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: dcerpc
+      dcerpc.interfaces[0].service: "winreg"
+      dcerpc.interfaces[0].procedure: "OpenLocalMachine"
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: dcerpc
+      dcerpc.interfaces[0].service: "winreg"
+      dcerpc.interfaces[0].procedure: "BaseRegOpenKey"
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: dcerpc
+      dcerpc.interfaces[0].service: "winreg"
+      dcerpc.interfaces[0].procedure: "BaseRegSetValue"
+

--- a/tests/dcerpc/dcerpc-smb-ctxid/test.yaml
+++ b/tests/dcerpc/dcerpc-smb-ctxid/test.yaml
@@ -19,3 +19,20 @@ checks:
       alert.signature_id: 1
       smb.dcerpc.interfaces[0].uuid: 1ff70682-0a51-30e8-076d-740be8cee98b
       smb.dcerpc.opnum: 0
+- filter:
+    requires:
+      min-version: 9
+    count: 1
+    match:
+      event_type: smb
+      smb.dcerpc.request: "REQUEST"
+      smb.dcerpc.opnum: 0
+      smb.dcerpc.interfaces[0].service: "atsvc"
+      smb.dcerpc.interfaces[0].procedure: "NetrJobAdd"
+- filter:
+    requires:
+      min-version: 9
+    count: 2
+    match:
+      event_type: smb
+      smb.dcerpc.interfaces[0].service: "atsvc"


### PR DESCRIPTION
Previous PR: https://github.com/OISF/suricata-verify/pull/3136

Change since v2:
- more tests to increase coverage for both smb/dcerpc and standalone dcerpc paths
- rebased on top of latest main

## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine tickets:
- https://redmine.openinfosecfoundation.org/issues/2727
- https://redmine.openinfosecfoundation.org/issues/8523