### PR TITLE
fw: update yaml to new policy format v2

### DIFF
--- a/tests/firewall/ruletype-firewall-103-default-app-policy-drop-alert/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-103-default-app-policy-drop-alert/suricata.yaml
@@ -20,13 +20,14 @@ outputs:
 
 firewall:
   policies:
-    dns:
-      # Allow DNS requests to start.
-      request-started: ["accept:hook"]
+    app:
+      dns:
+        # Allow DNS requests to start.
+        request-started: ["accept:hook"]
 
-      # Drop and alert on all DNS requests that are not allowed in
-      # firewall.rules.
-      request-complete: ["drop:flow", "alert"]
+        # Drop and alert on all DNS requests that are not allowed in
+        # firewall.rules.
+        request-complete: ["drop:flow", "alert"]
 
-      # Accept all responses.
-      response-started: ["accept:flow"]
+        # Accept all responses.
+        response-started: ["accept:flow"]

--- a/tests/firewall/ruletype-firewall-103-default-app-policy-drop-alert/test.yaml
+++ b/tests/firewall/ruletype-firewall-103-default-app-policy-drop-alert/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.6
+  min-version: 9
 
 pcap: input.pcap
 

--- a/tests/firewall/ruletype-firewall-104-default-app-policy-missed-rule-alert/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-104-default-app-policy-missed-rule-alert/suricata.yaml
@@ -21,6 +21,7 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started: ["accept:hook"]
-      request-line: ["drop:flow", "alert"]
+    app:
+      http1:
+        request-started: ["accept:hook"]
+        request-line: ["drop:flow", "alert"]

--- a/tests/firewall/ruletype-firewall-104-default-app-policy-missed-rule-alert/test.yaml
+++ b/tests/firewall/ruletype-firewall-104-default-app-policy-missed-rule-alert/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.6
+  min-version: 9
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-105-default-packet-policy-alert-app-rule/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-105-default-packet-policy-alert-app-rule/suricata.yaml
@@ -21,17 +21,19 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: ["accept:hook", "alert"]
-    http:
-      request-started: ["accept:hook"]
-      request-line: ["accept:hook"]
-      request-headers: ["accept:hook"]
-      request-body: ["accept:hook"]
-      request-trailer: ["accept:hook"]
-      request-complete: ["accept:hook"]
-      response-started: ["accept:hook"]
-      response-line: ["accept:hook"]
-      response-headers: ["accept:hook"]
-      response-body: ["accept:hook"]
-      response-trailer: ["accept:hook"]
-      response-complete: ["accept:hook"]
+    packet:
+      filter: ["accept:hook", "alert"]
+    app:
+      http1:
+        request-started: ["accept:hook"]
+        request-line: ["accept:hook"]
+        request-headers: ["accept:hook"]
+        request-body: ["accept:hook"]
+        request-trailer: ["accept:hook"]
+        request-complete: ["accept:hook"]
+        response-started: ["accept:hook"]
+        response-line: ["accept:hook"]
+        response-headers: ["accept:hook"]
+        response-body: ["accept:hook"]
+        response-trailer: ["accept:hook"]
+        response-complete: ["accept:hook"]

--- a/tests/firewall/ruletype-firewall-105-default-packet-policy-alert-app-rule/test.yaml
+++ b/tests/firewall/ruletype-firewall-105-default-packet-policy-alert-app-rule/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.6
+  min-version: 9
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-106-default-app-policy-accept-flow-alert/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-106-default-app-policy-accept-flow-alert/suricata.yaml
@@ -21,6 +21,8 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: ["accept:hook"]
-    http:
-      request-started: ["accept:flow", "alert"]
+    packet:
+      filter: ["accept:hook"]
+    app:
+      http1:
+        request-started: ["accept:flow", "alert"]

--- a/tests/firewall/ruletype-firewall-106-default-app-policy-accept-flow-alert/test.yaml
+++ b/tests/firewall/ruletype-firewall-106-default-app-policy-accept-flow-alert/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.6
+  min-version: 9
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-107-default-app-policy-missed-rule-accept-tx-alert/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-107-default-app-policy-missed-rule-accept-tx-alert/suricata.yaml
@@ -21,8 +21,9 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started: ["accept:hook"]
-      request-line:
-        - "accept:tx"
-        - "alert"
+    app:
+      http1:
+        request-started: ["accept:hook"]
+        request-line:
+          - "accept:tx"
+          - "alert"

--- a/tests/firewall/ruletype-firewall-107-default-app-policy-missed-rule-accept-tx-alert/test.yaml
+++ b/tests/firewall/ruletype-firewall-107-default-app-policy-missed-rule-accept-tx-alert/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.6
+  min-version: 9
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-108-default-app-policy-missed-rule-accept-tx-alert/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-108-default-app-policy-missed-rule-accept-tx-alert/suricata.yaml
@@ -21,8 +21,9 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started: ["accept:hook"]
-      request-line:
-        - "accept:tx"
-        - "alert"
+    app:
+      http1:
+        request-started: ["accept:hook"]
+        request-line:
+          - "accept:tx"
+          - "alert"

--- a/tests/firewall/ruletype-firewall-108-default-app-policy-missed-rule-accept-tx-alert/test.yaml
+++ b/tests/firewall/ruletype-firewall-108-default-app-policy-missed-rule-accept-tx-alert/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.6
+  min-version: 9
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-115-ftp-download-active-user/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-115-ftp-download-active-user/suricata.yaml
@@ -21,8 +21,7 @@ outputs:
 
 firewall:
   policies:
-    ftp-data:
-      request-started:
-        - "accept:flow"
-      response-started:
-        - "accept:flow"
+    app:
+      ftp-data:
+        request-started: ["accept:flow"]
+        response-started: ["accept:flow"]

--- a/tests/firewall/ruletype-firewall-115-ftp-download-active-user/test.yaml
+++ b/tests/firewall/ruletype-firewall-115-ftp-download-active-user/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.6
+  min-version: 9
 
 pcap: ../../ftp/ftp-download-active/input.pcap
 

--- a/tests/firewall/ruletype-firewall-119-ftp-non-anonymous-default-allow/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-119-ftp-non-anonymous-default-allow/suricata.yaml
@@ -22,21 +22,23 @@ outputs:
 
 firewall:
   policies:
-    packet-filter:
-      - "accept:hook"
-
-    ftp:
-      request-started:
-        - "accept:hook"
-      request-complete:
-        - "accept:hook"
-      response-started:
-        - "accept:hook"
-      response-complete:
+    packet:
+      filter:
         - "accept:hook"
 
-    ftp-data:
-      request-started:
-        - "accept:flow"
-      response-started:
-        - "accept:flow"
+    app:
+      ftp:
+        request-started:
+          - "accept:hook"
+        request-complete:
+          - "accept:hook"
+        response-started:
+          - "accept:hook"
+        response-complete:
+          - "accept:hook"
+
+      ftp-data:
+        request-started:
+          - "accept:flow"
+        response-started:
+          - "accept:flow"

--- a/tests/firewall/ruletype-firewall-119-ftp-non-anonymous-default-allow/test.yaml
+++ b/tests/firewall/ruletype-firewall-119-ftp-non-anonymous-default-allow/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.6
+  min-version: 9
 
 pcap: ../../ftp/ftp-download-active/input.pcap
 

--- a/tests/firewall/ruletype-firewall-120-ftp-drop-by-dynamic-port/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-120-ftp-drop-by-dynamic-port/suricata.yaml
@@ -22,21 +22,23 @@ outputs:
 
 firewall:
   policies:
-    packet-filter:
-      - "accept:hook"
-
-    ftp:
-      request-started:
-        - "accept:hook"
-      request-complete:
-        - "accept:hook"
-      response-started:
-        - "accept:hook"
-      response-complete:
+    packet:
+      filter:
         - "accept:hook"
 
-    ftp-data:
-      request-started:
-        - "accept:flow"
-      response-started:
-        - "accept:flow"
+    app:
+      ftp:
+        request-started:
+          - "accept:hook"
+        request-complete:
+          - "accept:hook"
+        response-started:
+          - "accept:hook"
+        response-complete:
+          - "accept:hook"
+
+      ftp-data:
+        request-started:
+          - "accept:flow"
+        response-started:
+          - "accept:flow"

--- a/tests/firewall/ruletype-firewall-120-ftp-drop-by-dynamic-port/test.yaml
+++ b/tests/firewall/ruletype-firewall-120-ftp-drop-by-dynamic-port/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.6
+  min-version: 9
 
 pcap: ../../ftp/ftp-download-active/input.pcap
 

--- a/tests/firewall/ruletype-firewall-121-ftp-bounce/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-121-ftp-bounce/suricata.yaml
@@ -22,21 +22,23 @@ outputs:
 
 firewall:
   policies:
-    packet-filter:
-      - "accept:hook"
-
-    ftp:
-      request-started:
-        - "accept:hook"
-      request-complete:
-        - "accept:hook"
-      response-started:
-        - "accept:hook"
-      response-complete:
+    packet:
+      filter:
         - "accept:hook"
 
-    ftp-data:
-      request-started:
-        - "accept:flow"
-      response-started:
-        - "accept:flow"
+    app:
+      ftp:
+        request-started:
+          - "accept:hook"
+        request-complete:
+          - "accept:hook"
+        response-started:
+          - "accept:hook"
+        response-complete:
+          - "accept:hook"
+
+      ftp-data:
+        request-started:
+          - "accept:flow"
+        response-started:
+          - "accept:flow"

--- a/tests/firewall/ruletype-firewall-121-ftp-bounce/test.yaml
+++ b/tests/firewall/ruletype-firewall-121-ftp-bounce/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.6
+  min-version: 9
 
 pcap: ../../ftp/ftp-bounce/test.pcap
 

--- a/tests/firewall/ruletype-firewall-124-http2-substate-default-policy/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-124-http2-substate-default-policy/suricata.yaml
@@ -64,34 +64,35 @@ outputs:
 
 firewall:
   policies:
-    http2:
-      stream:
-        request-started:
-          - "accept:hook"
-        request-headers:
-          - "accept:hook"
-        request-data:
-          - "accept:hook"
-        request-closed:
-          - "accept:hook"
-        request-complete:
-          - "accept:hook"
-        response-started:
-          - "accept:hook"
-        response-headers:
-          - "accept:hook"
-        response-data:
-          - "accept:hook"
-        response-closed:
-          - "accept:hook"
-        response-complete:
-          - "accept:tx"
-      global:
-        request-started:
-          - "accept:hook"
-        request-complete:
-          - "accept:tx"
-        response-started:
-          - "accept:hook"
-        response-complete:
-          - "accept:tx"
+    app:
+      http2:
+        stream:
+          request-started:
+            - "accept:hook"
+          request-headers:
+            - "accept:hook"
+          request-data:
+            - "accept:hook"
+          request-closed:
+            - "accept:hook"
+          request-complete:
+            - "accept:hook"
+          response-started:
+            - "accept:hook"
+          response-headers:
+            - "accept:hook"
+          response-data:
+            - "accept:hook"
+          response-closed:
+            - "accept:hook"
+          response-complete:
+            - "accept:tx"
+        global:
+          request-started:
+            - "accept:hook"
+          request-complete:
+            - "accept:tx"
+          response-started:
+            - "accept:hook"
+          response-complete:
+            - "accept:tx"

--- a/tests/firewall/ruletype-firewall-128-doh2/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-128-doh2/suricata.yaml
@@ -56,93 +56,94 @@ outputs:
 
 firewall:
   policies:
-    http2:
-      stream:
-        request-started:
-          - "accept:hook"
-          - "alert"
-        request-headers:
-          - "accept:hook"
-          - "alert"
-        request-data:
-          - "accept:hook"
-          - "alert"
-        request-closed:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:hook"
-          - "alert"
-        response-started:
-          - "accept:hook"
-          - "alert"
-        response-headers:
-          - "accept:hook"
-          - "alert"
-        response-data:
-          - "accept:hook"
-          - "alert"
-        response-closed:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-      global:
-        request-started:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:tx"
-          - "alert"
-        response-started:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-    doh2:
-      stream:
-        request-started:
-          - "accept:hook"
-          - "alert"
-        request-headers:
-          - "accept:hook"
-          - "alert"
-        request-data:
-          - "accept:hook"
-          - "alert"
-        request-closed:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:hook"
-          - "alert"
-        response-started:
-          - "accept:hook"
-          - "alert"
-        response-headers:
-          - "accept:hook"
-          - "alert"
-        response-data:
-          - "accept:hook"
-          - "alert"
-        response-closed:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-      global:
-        request-started:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:tx"
-          - "alert"
-        response-started:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
+    app:
+      http2:
+        stream:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-headers:
+            - "accept:hook"
+            - "alert"
+          request-data:
+            - "accept:hook"
+            - "alert"
+          request-closed:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:hook"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-headers:
+            - "accept:hook"
+            - "alert"
+          response-data:
+            - "accept:hook"
+            - "alert"
+          response-closed:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+        global:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:tx"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+      doh2:
+        stream:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-headers:
+            - "accept:hook"
+            - "alert"
+          request-data:
+            - "accept:hook"
+            - "alert"
+          request-closed:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:hook"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-headers:
+            - "accept:hook"
+            - "alert"
+          response-data:
+            - "accept:hook"
+            - "alert"
+          response-closed:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+        global:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:tx"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"

--- a/tests/firewall/ruletype-firewall-129-doh2-crash/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-129-doh2-crash/suricata.yaml
@@ -53,93 +53,94 @@ outputs:
 
 firewall:
   policies:
-    http2:
-      stream:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-headers:
-          - "accept:hook"
-          - "alert"
-        request-data:
-          - "accept:hook"
-          - "alert"
-        request-closed:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:hook"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-headers:
-          - "accept:hook"
-          - "alert"
-        response-data:
-          - "accept:hook"
-          - "alert"
-        response-closed:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-      global:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:tx"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-    doh2:
-      stream:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-headers:
-          - "accept:hook"
-          - "alert"
-        request-data:
-          - "accept:hook"
-          - "alert"
-        request-closed:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:hook"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-headers:
-          - "accept:hook"
-          - "alert"
-        response-data:
-          - "accept:hook"
-          - "alert"
-        response-closed:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-      global:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:tx"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
+    app:
+      http2:
+        stream:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-headers:
+            - "accept:hook"
+            - "alert"
+          request-data:
+            - "accept:hook"
+            - "alert"
+          request-closed:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:hook"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-headers:
+            - "accept:hook"
+            - "alert"
+          response-data:
+            - "accept:hook"
+            - "alert"
+          response-closed:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+        global:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:tx"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+      doh2:
+        stream:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-headers:
+            - "accept:hook"
+            - "alert"
+          request-data:
+            - "accept:hook"
+            - "alert"
+          request-closed:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:hook"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-headers:
+            - "accept:hook"
+            - "alert"
+          response-data:
+            - "accept:hook"
+            - "alert"
+          response-closed:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+        global:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:tx"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"

--- a/tests/firewall/ruletype-firewall-130-doh2-disabled/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-130-doh2-disabled/suricata.yaml
@@ -58,93 +58,94 @@ app-layer:
 
 firewall:
   policies:
-    http2:
-      stream:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-headers:
-          - "accept:hook"
-          - "alert"
-        request-data:
-          - "accept:hook"
-          - "alert"
-        request-closed:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:hook"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-headers:
-          - "accept:hook"
-          - "alert"
-        response-data:
-          - "accept:hook"
-          - "alert"
-        response-closed:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-      global:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:tx"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-    doh2:
-      stream:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-headers:
-          - "accept:hook"
-          - "alert"
-        request-data:
-          - "accept:hook"
-          - "alert"
-        request-closed:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:hook"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-headers:
-          - "accept:hook"
-          - "alert"
-        response-data:
-          - "accept:hook"
-          - "alert"
-        response-closed:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-      global:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:tx"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
+    app:
+      http2:
+        stream:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-headers:
+            - "accept:hook"
+            - "alert"
+          request-data:
+            - "accept:hook"
+            - "alert"
+          request-closed:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:hook"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-headers:
+            - "accept:hook"
+            - "alert"
+          response-data:
+            - "accept:hook"
+            - "alert"
+          response-closed:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+        global:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:tx"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+      doh2:
+        stream:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-headers:
+            - "accept:hook"
+            - "alert"
+          request-data:
+            - "accept:hook"
+            - "alert"
+          request-closed:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:hook"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-headers:
+            - "accept:hook"
+            - "alert"
+          response-data:
+            - "accept:hook"
+            - "alert"
+          response-closed:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+        global:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:tx"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"

--- a/tests/firewall/ruletype-firewall-130-doh2-disabled/test.yaml
+++ b/tests/firewall/ruletype-firewall-130-doh2-disabled/test.yaml
@@ -1,3 +1,6 @@
+requires:
+  min-version: 9
+
 args:
   - -T
 

--- a/tests/firewall/ruletype-firewall-131-http2-mixed-rule/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-131-http2-mixed-rule/suricata.yaml
@@ -60,96 +60,97 @@ app-layer:
 
 firewall:
   policies:
-    http2:
-      stream:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-headers:
-          - "accept:hook"
-          - "alert"
-        request-data:
-          - "accept:hook"
-          - "alert"
-        request-closed:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:hook"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-headers:
-          - "accept:hook"
-          - "alert"
-        response-data:
-          - "accept:hook"
-          - "alert"
-        response-closed:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-      global:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:tx"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-    doh2:
-      stream:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-headers:
-          - "accept:hook"
-          - "alert"
-        request-data:
-          - "accept:hook"
-          - "alert"
-        request-closed:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:hook"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-headers:
-          - "accept:hook"
-          - "alert"
-        response-data:
-          - "accept:hook"
-          - "alert"
-        response-closed:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
-      global:
-        request-start:
-          - "accept:hook"
-          - "alert"
-        request-complete:
-          - "accept:tx"
-          - "alert"
-        response-start:
-          - "accept:hook"
-          - "alert"
-        response-complete:
-          - "accept:tx"
-          - "alert"
+    app:
+      http2:
+        stream:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-headers:
+            - "accept:hook"
+            - "alert"
+          request-data:
+            - "accept:hook"
+            - "alert"
+          request-closed:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:hook"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-headers:
+            - "accept:hook"
+            - "alert"
+          response-data:
+            - "accept:hook"
+            - "alert"
+          response-closed:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+        global:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:tx"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+      doh2:
+        stream:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-headers:
+            - "accept:hook"
+            - "alert"
+          request-data:
+            - "accept:hook"
+            - "alert"
+          request-closed:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:hook"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-headers:
+            - "accept:hook"
+            - "alert"
+          response-data:
+            - "accept:hook"
+            - "alert"
+          response-closed:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
+        global:
+          request-started:
+            - "accept:hook"
+            - "alert"
+          request-complete:
+            - "accept:tx"
+            - "alert"
+          response-started:
+            - "accept:hook"
+            - "alert"
+          response-complete:
+            - "accept:tx"
+            - "alert"
 
 engine-analysis:
   rules-fast-pattern: yes

--- a/tests/firewall/ruletype-firewall-68-config-default-policy-tls/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-68-config-default-policy-tls/suricata.yaml
@@ -33,14 +33,15 @@ outputs:
 
 firewall:
   policies:
-    tls:
-      client-in-progress:
-        - "accept:hook"
-      client-hello-done:
-        - "drop:flow"
-      client-cert-done:
-        - "accept:hook"
-      client-handshake-done:
-        - "accept:hook"
-      client-finished:
-        - "accept:hook"
+    app:
+      tls:
+        client-in-progress:
+          - "accept:hook"
+        client-hello-done:
+          - "drop:flow"
+        client-cert-done:
+          - "accept:hook"
+        client-handshake-done:
+          - "accept:hook"
+        client-finished:
+          - "accept:hook"

--- a/tests/firewall/ruletype-firewall-68-config-default-policy-tls/test.yaml
+++ b/tests/firewall/ruletype-firewall-68-config-default-policy-tls/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-69-config-default-policy-tls-accept/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-69-config-default-policy-tls-accept/suricata.yaml
@@ -33,14 +33,15 @@ outputs:
 
 firewall:
   policies:
-    tls:
-      client-in-progress:
-        - "accept:hook"
-      client-hello-done:
-        - "accept:hook"
-      client-cert-done:
-        - "accept:hook"
-      client-handshake-done:
-        - "accept:hook"
-      client-finished:
-        - "accept:hook"
+    app:
+      tls:
+        client-in-progress:
+          - "accept:hook"
+        client-hello-done:
+          - "accept:hook"
+        client-cert-done:
+          - "accept:hook"
+        client-handshake-done:
+          - "accept:hook"
+        client-finished:
+          - "accept:hook"

--- a/tests/firewall/ruletype-firewall-69-config-default-policy-tls-accept/test.yaml
+++ b/tests/firewall/ruletype-firewall-69-config-default-policy-tls-accept/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-70-config-default-policy-http/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-70-config-default-policy-http/suricata.yaml
@@ -64,10 +64,9 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-line:
-        - "accept:hook"
-      request-body:
-        - "accept:hook"
-      request-trailers:
-        - "accept:hook"
+    app:
+      http1:
+        request-line:
+          - "accept:hook"
+        request-body:
+          - "accept:hook"

--- a/tests/firewall/ruletype-firewall-70-config-default-policy-http/test.yaml
+++ b/tests/firewall/ruletype-firewall-70-config-default-policy-http/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-71-reject-app-default-policy/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-71-reject-app-default-policy/suricata.yaml
@@ -66,6 +66,7 @@ outputs:
 
 firewall:
   policies:
-    tls:
-      client-hello-done:
-        - "reject:flow"
+    app:
+      tls:
+        client-hello-done:
+          - "reject:flow"

--- a/tests/firewall/ruletype-firewall-71-reject-app-default-policy/test.yaml
+++ b/tests/firewall/ruletype-firewall-71-reject-app-default-policy/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
   features:
     - LIBNET1.1
 
@@ -60,21 +60,21 @@ checks:
     match:
       verdict.action: drop
 - filter:
-    requires:
-      min-version: 9
+    # requires:
+    #   min-version: 9
     count: 3
     match:
       verdict.action: drop
       verdict.reject_target: to_client
       verdict.reject[0]: tcp-reset
-- filter:
-    requires:
-      lt-version: 9
-    count: 3
-    match:
-      verdict.action: drop
-      verdict.reject-target: to_client
-      verdict.reject[0]: tcp-reset
+# - filter:
+#     requires:
+#       lt-version: 9
+#     count: 3
+#     match:
+#       verdict.action: drop
+#       verdict.reject-target: to_client
+#       verdict.reject[0]: tcp-reset
 - filter:
     count: 1
     match:

--- a/tests/firewall/ruletype-firewall-72-config-default-policy-http/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-72-config-default-policy-http/suricata.yaml
@@ -64,10 +64,11 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started:
-        - "accept:hook"
-      request-trailer:
-        - "accept:hook"
-      request-complete:
-        - "accept:hook"
+    app:
+      http1:
+        request-started:
+          - "accept:hook"
+        request-trailer:
+          - "accept:hook"
+        request-complete:
+          - "accept:hook"

--- a/tests/firewall/ruletype-firewall-72-config-default-policy-http/test.yaml
+++ b/tests/firewall/ruletype-firewall-72-config-default-policy-http/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-73-config-default-policy-http/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-73-config-default-policy-http/suricata.yaml
@@ -64,14 +64,15 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started:
-        - "accept:hook"
-      request-line:
-        - "accept:hook"
-      request-headers:
-        - "accept:hook"
-      request-body:
-        - "accept:hook"
-      request-trailer:
-        - "accept:hook"
+    app:
+      http1:
+        request-started:
+          - "accept:hook"
+        request-line:
+          - "accept:hook"
+        request-headers:
+          - "accept:hook"
+        request-body:
+          - "accept:hook"
+        request-trailer:
+          - "accept:hook"

--- a/tests/firewall/ruletype-firewall-73-config-default-policy-http/test.yaml
+++ b/tests/firewall/ruletype-firewall-73-config-default-policy-http/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-74-config-default-policy-dns/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-74-config-default-policy-dns/suricata.yaml
@@ -64,12 +64,9 @@ outputs:
 
 firewall:
   policies:
-    dns:
-      request-started:
-        - "accept:hook"
-      request-complete:
-        - "drop:flow"
-      response-started:
-        - "accept:hook"
-      response-complete:
-        - "drop:flow"
+    app:
+      dns:
+        request-started: ["accept:hook"]
+        request-complete: ["drop:flow"]
+        response-started: ["accept:hook"]
+        response-complete: ["drop:flow"]

--- a/tests/firewall/ruletype-firewall-74-config-default-policy-dns/test.yaml
+++ b/tests/firewall/ruletype-firewall-74-config-default-policy-dns/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: ../../dns/dns-eve/input.pcap
 

--- a/tests/firewall/ruletype-firewall-75-config-default-policy-http-accept-tx/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-75-config-default-policy-http-accept-tx/suricata.yaml
@@ -64,6 +64,6 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started:
-        - "accept:tx"
+    app:
+      http1:
+        request-started: ["accept:tx"]

--- a/tests/firewall/ruletype-firewall-75-config-default-policy-http-accept-tx/test.yaml
+++ b/tests/firewall/ruletype-firewall-75-config-default-policy-http-accept-tx/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-76-config-default-policy-http-accept-tx-td/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-76-config-default-policy-http-accept-tx-td/suricata.yaml
@@ -64,6 +64,6 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started:
-        - "accept:tx"
+    app:
+      http1:
+        request-started: ["accept:tx"]

--- a/tests/firewall/ruletype-firewall-76-config-default-policy-http-accept-tx-td/test.yaml
+++ b/tests/firewall/ruletype-firewall-76-config-default-policy-http-accept-tx-td/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-77-ruleset-default-packet-policy/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-77-ruleset-default-packet-policy/suricata.yaml
@@ -65,4 +65,5 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "reject:packet" ]
+    packet:
+      filter: ["reject:packet"]

--- a/tests/firewall/ruletype-firewall-77-ruleset-default-packet-policy/test.yaml
+++ b/tests/firewall/ruletype-firewall-77-ruleset-default-packet-policy/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
   features:
     - LIBNET1.1
 

--- a/tests/firewall/ruletype-firewall-78-ruleset-default-packet-policy-accept/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-78-ruleset-default-packet-policy-accept/suricata.yaml
@@ -65,4 +65,5 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "accept:packet" ]
+    packet:
+      filter: ["accept:packet"]

--- a/tests/firewall/ruletype-firewall-78-ruleset-default-packet-policy-accept/test.yaml
+++ b/tests/firewall/ruletype-firewall-78-ruleset-default-packet-policy-accept/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-79-ruleset-default-packet-policy-accept-hook/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-79-ruleset-default-packet-policy-accept-hook/suricata.yaml
@@ -65,4 +65,5 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "accept:hook" ]
+    packet:
+      filter: ["accept:hook"]

--- a/tests/firewall/ruletype-firewall-79-ruleset-default-packet-policy-accept-hook/test.yaml
+++ b/tests/firewall/ruletype-firewall-79-ruleset-default-packet-policy-accept-hook/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-80-ruleset-default-packet-policy-accept-hook-no-rules/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-80-ruleset-default-packet-policy-accept-hook-no-rules/suricata.yaml
@@ -65,4 +65,5 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "accept:hook" ]
+    packet:
+      filter: ["accept:hook"]

--- a/tests/firewall/ruletype-firewall-80-ruleset-default-packet-policy-accept-hook-no-rules/test.yaml
+++ b/tests/firewall/ruletype-firewall-80-ruleset-default-packet-policy-accept-hook-no-rules/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-81-ruleset-default-packet-policy-accept-hook-all/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-81-ruleset-default-packet-policy-accept-hook-all/suricata.yaml
@@ -65,16 +65,18 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "accept:hook" ]
-    tls:
-      client-in-progress: [ "accept:hook" ]
-      client-hello-done: [ "accept:hook" ]
-      client-cert-done: [ "accept:hook" ]
-      client-handshake-done: [ "accept:hook" ]
-      client-finished: [ "accept:hook" ]
-      server-in-progress: [ "accept:hook" ]
-      server-hello: [ "accept:hook" ]
-      server-hello-done: [ "accept:hook" ]
-      server-cert-done: [ "accept:hook" ]
-      server-handshake-done: [ "accept:hook" ]
-      server-finished: [ "accept:hook" ]
+    packet:
+      filter: ["accept:hook"]
+    app:
+      tls:
+        client-in-progress: ["accept:hook"]
+        client-hello-done: ["accept:hook"]
+        client-cert-done: ["accept:hook"]
+        client-handshake-done: ["accept:hook"]
+        client-finished: ["accept:hook"]
+        server-in-progress: ["accept:hook"]
+        server-hello: ["accept:hook"]
+        server-hello-done: ["accept:hook"]
+        server-cert-done: ["accept:hook"]
+        server-handshake-done: ["accept:hook"]
+        server-finished: ["accept:hook"]

--- a/tests/firewall/ruletype-firewall-81-ruleset-default-packet-policy-accept-hook-all/test.yaml
+++ b/tests/firewall/ruletype-firewall-81-ruleset-default-packet-policy-accept-hook-all/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-82-ruleset-default-app-policy-accept-flow/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-82-ruleset-default-app-policy-accept-flow/suricata.yaml
@@ -65,6 +65,8 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "accept:hook" ]
-    tls:
-      client-in-progress: [ "accept:flow" ]
+    packet:
+      filter: ["accept:hook"]
+    app:
+      tls:
+        client-in-progress: ["accept:flow"]

--- a/tests/firewall/ruletype-firewall-82-ruleset-default-app-policy-accept-flow/test.yaml
+++ b/tests/firewall/ruletype-firewall-82-ruleset-default-app-policy-accept-flow/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-83-ruleset-default-packet-policy-accept-flow/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-83-ruleset-default-packet-policy-accept-flow/suricata.yaml
@@ -65,4 +65,5 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "accept:flow" ]
+    packet:
+      filter: ["accept:flow"]

--- a/tests/firewall/ruletype-firewall-83-ruleset-default-packet-policy-accept-flow/test.yaml
+++ b/tests/firewall/ruletype-firewall-83-ruleset-default-packet-policy-accept-flow/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-84-ruleset-default-app-policy-tls-request-started/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-84-ruleset-default-app-policy-tls-request-started/suricata.yaml
@@ -65,6 +65,8 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "accept:hook" ]
-    tls:
-      request-started: [ "accept:flow" ]
+    packet:
+      filter: ["accept:hook"]
+    app:
+      tls:
+        request-started: ["accept:flow"]

--- a/tests/firewall/ruletype-firewall-84-ruleset-default-app-policy-tls-request-started/test.yaml
+++ b/tests/firewall/ruletype-firewall-84-ruleset-default-app-policy-tls-request-started/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-86-packet-filter-accept-flow-pass-with-td/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-86-packet-filter-accept-flow-pass-with-td/suricata.yaml
@@ -19,6 +19,6 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started: [ "accept:flow" ]
-      #request-started: [ "accept:flow", "pass:flow" ]
+    app:
+      http1:
+        request-started: ["accept:flow"]

--- a/tests/firewall/ruletype-firewall-86-packet-filter-accept-flow-pass-with-td/test.yaml
+++ b/tests/firewall/ruletype-firewall-86-packet-filter-accept-flow-pass-with-td/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-87-broken-default-policy/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-87-broken-default-policy/suricata.yaml
@@ -19,5 +19,6 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started: [ "accept:foo" ]
+    app:
+      http1:
+        request-started: [ "accept:foo" ]

--- a/tests/firewall/ruletype-firewall-87-broken-default-policy/test.yaml
+++ b/tests/firewall/ruletype-firewall-87-broken-default-policy/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-88-default-accept-tx-pipeline/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-88-default-accept-tx-pipeline/suricata.yaml
@@ -19,17 +19,19 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: ["accept:hook"]
-    http:
-      request-started: ["accept:hook"]
-      request-line: ["accept:hook"]
-      request-headers: ["accept:hook"]
-      request-body: ["accept:hook"]
-      request-trailer: ["accept:hook"]
-      request-complete: ["accept:tx"]
-      response-started: ["accept:hook"]
-      response-line: ["accept:hook"]
-      response-headers: ["accept:hook"]
-      response-body: ["accept:hook"]
-      response-trailer: ["accept:hook"]
-      response-complete: ["accept:hook"]
+    packet:
+      filter: ["accept:hook"]
+    app:
+      http1:
+        request-started: ["accept:hook"]
+        request-line: ["accept:hook"]
+        request-headers: ["accept:hook"]
+        request-body: ["accept:hook"]
+        request-trailer: ["accept:hook"]
+        request-complete: ["accept:tx"]
+        response-started: ["accept:hook"]
+        response-line: ["accept:hook"]
+        response-headers: ["accept:hook"]
+        response-body: ["accept:hook"]
+        response-trailer: ["accept:hook"]
+        response-complete: ["accept:hook"]

--- a/tests/firewall/ruletype-firewall-88-default-accept-tx-pipeline/test.yaml
+++ b/tests/firewall/ruletype-firewall-88-default-accept-tx-pipeline/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: input.pcap
 

--- a/tests/firewall/ruletype-firewall-89-defaults-over-drop/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-89-defaults-over-drop/suricata.yaml
@@ -19,17 +19,19 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: ["accept:hook"]
-    http:
-      request-started: ["accept:hook"]
-      request-line: ["accept:hook"]
-      request-headers: ["accept:hook"]
-      request-body: ["accept:hook"]
-      request-trailer: ["accept:hook"]
-      request-complete: ["accept:hook"]
-      response-started: ["accept:hook"]
-      response-line: ["accept:hook"]
-      response-headers: ["accept:hook"]
-      response-body: ["accept:hook"]
-      response-trailer: ["accept:hook"]
-      response-complete: ["accept:hook"]
+    packet:
+      filter: ["accept:hook"]
+    app:
+      http1:
+        request-started: ["accept:hook"]
+        request-line: ["accept:hook"]
+        request-headers: ["accept:hook"]
+        request-body: ["accept:hook"]
+        request-trailer: ["accept:hook"]
+        request-complete: ["accept:hook"]
+        response-started: ["accept:hook"]
+        response-line: ["accept:hook"]
+        response-headers: ["accept:hook"]
+        response-body: ["accept:hook"]
+        response-trailer: ["accept:hook"]
+        response-complete: ["accept:hook"]

--- a/tests/firewall/ruletype-firewall-89-defaults-over-drop/test.yaml
+++ b/tests/firewall/ruletype-firewall-89-defaults-over-drop/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8
+  min-version: 9
 
 pcap: input.pcap
 

--- a/tests/firewall/ruletype-firewall-92-lt-ua-mix/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-92-lt-ua-mix/suricata.yaml
@@ -65,5 +65,6 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started: [ "accept:hook" ]
+    app:
+      http1:
+        request-started: ["accept:hook"]

--- a/tests/firewall/ruletype-firewall-92-lt-ua-mix/test.yaml
+++ b/tests/firewall/ruletype-firewall-92-lt-ua-mix/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.6
+  min-version: 9
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-93-lt-ua-mix-accept-hook/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-93-lt-ua-mix-accept-hook/suricata.yaml
@@ -65,9 +65,9 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started: [ "accept:hook" ]
-
-      request-body: [ "accept:hook" ]
-      request-trailer: [ "accept:hook" ]
-      request-complete: [ "accept:tx" ]
+    app:
+      http1:
+        request-started: ["accept:hook"]
+        request-body: ["accept:hook"]
+        request-trailer: ["accept:hook"]
+        request-complete: ["accept:tx"]

--- a/tests/firewall/ruletype-firewall-93-lt-ua-mix-accept-hook/test.yaml
+++ b/tests/firewall/ruletype-firewall-93-lt-ua-mix-accept-hook/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.6
+  min-version: 9
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-94-config-default-policy-http/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-94-config-default-policy-http/suricata.yaml
@@ -64,19 +64,10 @@ outputs:
 
 firewall:
   policies:
-    http:
-      request-started:
-        - "accept:hook"
-        - "alert"
-      request-line:
-        - "accept:hook"
-        - "alert"
-      request-headers:
-        - "accept:hook"
-        - "alert"
-      request-body:
-        - "accept:hook"
-        - "alert"
-      request-trailer:
-        - "accept:hook"
-        - "alert"
+    app:
+      http1:
+        request-started: ["accept:hook", "alert"]
+        request-line: ["accept:hook", "alert"]
+        request-headers: ["accept:hook", "alert"]
+        request-body: ["accept:hook", "alert"]
+        request-trailer: ["accept:hook", "alert"]

--- a/tests/firewall/ruletype-firewall-94-config-default-policy-http/test.yaml
+++ b/tests/firewall/ruletype-firewall-94-config-default-policy-http/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.6
+  min-version: 9
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-95-ruleset-default-packet-policy-accept-hook-alert/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-95-ruleset-default-packet-policy-accept-hook-alert/suricata.yaml
@@ -65,52 +65,30 @@ outputs:
 
 firewall:
   policies:
-    packet-filter: [ "accept:hook", "alert" ]
-    http:
-      request-started:
-        - "accept:hook"
-      request-line:
-        - "accept:hook"
-      request-headers:
-        - "accept:hook"
-      request-body:
-        - "accept:hook"
-      request-trailer:
-        - "accept:hook"
-      request-complete:
-        - "accept:hook"
-      request-started:
-        - "accept:hook"
-      response-line:
-        - "accept:hook"
-      response-headers:
-        - "accept:hook"
-      response-body:
-        - "accept:hook"
-      response-trailer:
-        - "accept:hook"
-      response-complete:
-        - "accept:hook"
-    tls:
-      client-in-progress:
-        - "accept:hook"
-      client-hello-done:
-        - "accept:hook"
-      client-cert-done:
-        - "accept:hook"
-      client-handshake-done:
-        - "accept:hook"
-      client-finished:
-        - "accept:hook"
-      server-in-progress:
-        - "accept:hook"
-      server-hello:
-        - "accept:hook"
-      server-hello-done:
-        - "accept:hook"
-      server-cert-done:
-        - "accept:hook"
-      server-handshake-done:
-        - "accept:hook"
-      server-finished:
-        - "accept:hook"
+    packet:
+      filter: ["accept:hook", "alert"]
+    app:
+      http1:
+        request-started: ["accept:hook"]
+        request-line: ["accept:hook"]
+        request-headers: ["accept:hook"]
+        request-body: ["accept:hook"]
+        request-trailer: ["accept:hook"]
+        request-complete: ["accept:hook"]
+        response-line: ["accept:hook"]
+        response-headers: ["accept:hook"]
+        response-body: ["accept:hook"]
+        response-trailer: ["accept:hook"]
+        response-complete: ["accept:hook"]
+      tls:
+        client-in-progress: ["accept:hook"]
+        client-hello-done: ["accept:hook"]
+        client-cert-done: ["accept:hook"]
+        client-handshake-done: ["accept:hook"]
+        client-finished: ["accept:hook"]
+        server-in-progress: ["accept:hook"]
+        server-hello: ["accept:hook"]
+        server-hello-done: ["accept:hook"]
+        server-cert-done: ["accept:hook"]
+        server-handshake-done: ["accept:hook"]
+        server-finished: ["accept:hook"]

--- a/tests/firewall/ruletype-firewall-95-ruleset-default-packet-policy-accept-hook-alert/test.yaml
+++ b/tests/firewall/ruletype-firewall-95-ruleset-default-packet-policy-accept-hook-alert/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 8.0.6
+  min-version: 9
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 


### PR DESCRIPTION
Follow-up of https://github.com/OISF/suricata-verify/pull/3274

As part of the new effort to accommodate more structural approach to policy settings in firewall, configuration nodes such as packet/app has been added to the structure.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/8712

Describe changes:
- Update to the new config format
