### PR TITLE
config: test deterministic glob include ordering (v3)

### DIFF
--- a/tests/config-includes-glob-order/01-order.yaml
+++ b/tests/config-includes-glob-order/01-order.yaml
@@ -1,0 +1,3 @@
+%YAML 1.1
+---
+glob-order-seen-01: present

--- a/tests/config-includes-glob-order/50-order.yaml
+++ b/tests/config-includes-glob-order/50-order.yaml
@@ -1,0 +1,3 @@
+%YAML 1.1
+---
+glob-order-seen-50: present

--- a/tests/config-includes-glob-order/99-order.yaml
+++ b/tests/config-includes-glob-order/99-order.yaml
@@ -1,0 +1,3 @@
+%YAML 1.1
+---
+glob-order-seen-99: present

--- a/tests/config-includes-glob-order/README.md
+++ b/tests/config-includes-glob-order/README.md
@@ -1,0 +1,44 @@
+# config-includes-glob-order
+
+Verifies that a glob pattern in an `include:` directive expands to all matching
+files and includes them in a deterministic (sorted) order.
+
+`glob.yaml` includes `*-order.yaml`, which matches three drop-in files
+(`01-order.yaml`, `50-order.yaml`, `99-order.yaml`). Each file defines its own
+unique marker key (`glob-order-seen-NN`). Because `glob(3)` returns matches in
+sorted (lexicographic) order, the files are merged in ascending numeric-prefix
+order.
+
+The test runs suricata against `glob.yaml` with `--dump-config` (via `command:`)
+and asserts that:
+
+- all three matched files were included (one unique marker key per file), and
+- the marker keys appear in the dump output in sorted-filename order. The
+  config tree preserves insertion order, so the position of each key in the
+  output reflects the order the files were merged. No key is defined twice, so
+  the test does not depend on duplicate-key override behavior.
+
+What this test proves is narrow: sorted glob expansion. Real users care about
+that property because it makes the common numbered drop-in convention
+(`01-*.yaml` .. `99-*.yaml`, as in `conf.d`-style directories) predictable,
+including the case where the same key is set in more than one drop-in. This
+test does not exercise any of those override scenarios. It just pins the sort
+order so it cannot silently regress (for example by expanding with
+`GLOB_NOSORT` or a plain directory scan).
+
+The glob config is kept in `glob.yaml` (not the default `suricata.yaml`) on
+purpose: suricata-verify runs `suricata -c suricata.yaml --dump-config` during
+test setup before the `min-version` check, so a glob `include:` in a shipped
+`suricata.yaml` would break setup on Suricata builds without glob support.
+
+Note: this test requires the `include:` glob support added in OISF/suricata
+(#15574, Redmine #8427). Until that lands, a `requires: script:` probe greps
+`src/conf-yaml-loader.c` for the glob expansion code and skips the test on
+builds that don't have it, so it does not fail CI runs against main or the
+release branches.
+
+A second probe greps `src/autoconf.h` for `HAVE_GLOB_H`. Glob expansion needs
+`glob(3)`, which Windows builds do not have; there an include pattern is
+skipped with a warning and none of the matched files are loaded, so the checks
+below could not hold. Probing the build rather than the platform keeps the test
+running everywhere `glob(3)` is available, including macOS and the BSDs.

--- a/tests/config-includes-glob-order/glob.yaml
+++ b/tests/config-includes-glob-order/glob.yaml
@@ -1,0 +1,10 @@
+%YAML 1.1
+---
+
+# The pattern expands to 01-order.yaml, 50-order.yaml and 99-order.yaml.
+# glob(3) returns matches in sorted (lexicographic) order, so the drop-in files
+# are included in ascending numeric-prefix order. Each file defines its own
+# unique marker key; the order the keys appear in --dump-config output reflects
+# the order the files were merged.
+include:
+  - "*-order.yaml"

--- a/tests/config-includes-glob-order/test.yaml
+++ b/tests/config-includes-glob-order/test.yaml
@@ -1,0 +1,49 @@
+requires:
+  min-version: 9
+  # Glob support in include: is not merged yet (OISF/suricata#15574), so a
+  # min-version alone can't gate this test. Probe the source tree for the
+  # glob(3) expansion code instead and skip on builds that don't have it,
+  # the same way the eve-alert-metadata tests probe for METADATA_DEFAULTS.
+  # Glob expansion needs glob(3). Builds without glob.h, notably Windows,
+  # skip an include pattern with a warning and load none of the matched
+  # files, so the ordering checks below cannot hold there. Probe the build
+  # rather than the platform, so the test still runs anywhere glob(3) is
+  # available.
+  script:
+    - grep globfree src/conf-yaml-loader.c > /dev/null
+    - grep '^#define HAVE_GLOB_H 1' src/autoconf.h > /dev/null
+
+pcap: false
+
+# Run suricata against glob.yaml explicitly rather than shipping a suricata.yaml.
+# suricata-verify always runs `suricata -c <test>/suricata.yaml --dump-config`
+# during test setup (before the min-version check), so a glob include in
+# suricata.yaml would make that setup step fail on Suricata versions without
+# glob support. Using a separate config exercised via `command:` keeps setup on
+# the default suricata.yaml and only runs the glob config on a supported build.
+command: |
+  ${SRCDIR}/src/suricata -c ${TEST_DIR}/glob.yaml -l ${OUTPUT_DIR} --dump-config
+
+checks:
+  # Every globbed drop-in file is included, not just one: the unique marker key
+  # from each of 01/50/99-order.yaml is present in the merged config.
+  - shell:
+      args: grep '^glob-order-seen-01 = present' stdout | wc -l
+      expect: 1
+  - shell:
+      args: grep '^glob-order-seen-50 = present' stdout | wc -l
+      expect: 1
+  - shell:
+      args: grep '^glob-order-seen-99 = present' stdout | wc -l
+      expect: 1
+
+  # Ordering is deterministic: glob(3) returns matches sorted, so the files are
+  # included in ascending numeric-prefix order. Include order is observable in
+  # --dump-config output because the config tree preserves insertion order, so
+  # the distinct per-file marker keys must appear in sorted-filename order.
+  # The test does not exercise override-on-duplicate-keys (each file uses a
+  # unique key on purpose). What this pins is just the sort order, which is
+  # what the numbered conf.d-style drop-in convention relies on in practice.
+  - shell:
+      args: grep -o '^glob-order-seen-[0-9][0-9]' stdout | tr '\n' ' '
+      expect: glob-order-seen-01 glob-order-seen-50 glob-order-seen-99


### PR DESCRIPTION
**Depends on OISF/suricata#16031** (the `include:` glob feature, Redmine #8427, superseding OISF/suricata#15937). This test exercises that feature, so CI here will stay red until it is merged into `OISF/suricata`: suricata-verify CI builds suricata from the official branches (`master`/`main-7.0.x`/`main-8.0.x`), none of which have the feature yet. The pair is validated in the suricata PR's CI (which builds the feature and runs this exact branch via `SV_BRANCH`) and locally.

Previous PR: #3250

### Changes since #3250

- Rebased onto current `master`. No changes to the test itself.

  This is what caused the CI failures on OISF/suricata#15937: that PR's CI checked out this branch (via `SV_BRANCH`) while it was still based on a June 5 `master`, 119 commits behind. The 26 failing tests there (`bug-8489-*`, `detect-email-*`, `mime-dec-*`, `ftp-reply-received-02`, `http2-keywords2`) were all tests whose expectations were updated on `master` on July 21 to match newer suricata `main` behavior — none of them are the glob test added here, which passed.

- New PR rather than a force-push per the contribution workflow: the branch of an open PR should not be updated.

---

Adds `config-includes-glob-order`, a test for the `include:` glob-pattern support added in OISF/suricata (Redmine #8427).

`glob.yaml` includes `*-order.yaml`, which matches three drop-in files (`01-order.yaml`, `50-order.yaml`, `99-order.yaml`). Each defines its own unique marker key (`glob-order-seen-NN`). Because `glob(3)` returns matches in sorted (lexicographic) order, the files are merged in ascending numeric-prefix order. The common `01..99` drop-in directory convention.

Using `--dump-config`, the test asserts:
- all three matched files were included (one unique marker key per file), and
- the marker keys appear in sorted-filename order, observable because the config tree preserves insertion order.

No key is defined twice, so the test does not depend on duplicate-key override behaviour. What it pins is the sort order, which is what the numbered drop-in convention relies on in practice.

The glob config is kept in `glob.yaml` and run via `command:` rather than a shipped `suricata.yaml`, because suricata-verify runs `suricata -c suricata.yaml --dump-config` during test setup, before the `min-version` check.

A `requires: script:` probe greps `src/conf-yaml-loader.c` for the glob expansion code so the test skips on builds without the feature, and a second probe greps `src/autoconf.h` for `HAVE_GLOB_H` so it skips on builds without `glob(3)` (e.g. Windows), where an include pattern is skipped with a warning and the ordering checks cannot hold. See #3250 for the full history.

Ticket: https://redmine.openinfosecfoundation.org/issues/8427
