### PR TITLE
fw: reenable tests for version 8

### DIFF
--- a/tests/firewall/ruletype-firewall-103-default-app-policy-drop-alert/test.yaml
+++ b/tests/firewall/ruletype-firewall-103-default-app-policy-drop-alert/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: input.pcap
 

--- a/tests/firewall/ruletype-firewall-104-default-app-policy-missed-rule-alert/test.yaml
+++ b/tests/firewall/ruletype-firewall-104-default-app-policy-missed-rule-alert/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-105-default-packet-policy-alert-app-rule/test.yaml
+++ b/tests/firewall/ruletype-firewall-105-default-packet-policy-alert-app-rule/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-106-default-app-policy-accept-flow-alert/test.yaml
+++ b/tests/firewall/ruletype-firewall-106-default-app-policy-accept-flow-alert/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-107-default-app-policy-missed-rule-accept-tx-alert/test.yaml
+++ b/tests/firewall/ruletype-firewall-107-default-app-policy-missed-rule-accept-tx-alert/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-108-default-app-policy-missed-rule-accept-tx-alert/test.yaml
+++ b/tests/firewall/ruletype-firewall-108-default-app-policy-missed-rule-accept-tx-alert/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-115-ftp-download-active-user/test.yaml
+++ b/tests/firewall/ruletype-firewall-115-ftp-download-active-user/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../ftp/ftp-download-active/input.pcap
 

--- a/tests/firewall/ruletype-firewall-119-ftp-non-anonymous-default-allow/test.yaml
+++ b/tests/firewall/ruletype-firewall-119-ftp-non-anonymous-default-allow/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../ftp/ftp-download-active/input.pcap
 

--- a/tests/firewall/ruletype-firewall-120-ftp-drop-by-dynamic-port/test.yaml
+++ b/tests/firewall/ruletype-firewall-120-ftp-drop-by-dynamic-port/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../ftp/ftp-download-active/input.pcap
 

--- a/tests/firewall/ruletype-firewall-121-ftp-bounce/test.yaml
+++ b/tests/firewall/ruletype-firewall-121-ftp-bounce/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../ftp/ftp-bounce/test.pcap
 

--- a/tests/firewall/ruletype-firewall-68-config-default-policy-tls/test.yaml
+++ b/tests/firewall/ruletype-firewall-68-config-default-policy-tls/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-69-config-default-policy-tls-accept/test.yaml
+++ b/tests/firewall/ruletype-firewall-69-config-default-policy-tls-accept/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-70-config-default-policy-http/test.yaml
+++ b/tests/firewall/ruletype-firewall-70-config-default-policy-http/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-71-reject-app-default-policy/test.yaml
+++ b/tests/firewall/ruletype-firewall-71-reject-app-default-policy/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
   features:
     - LIBNET1.1
 
@@ -60,21 +60,21 @@ checks:
     match:
       verdict.action: drop
 - filter:
-    # requires:
-    #   min-version: 9
+    requires:
+      min-version: 9
     count: 3
     match:
       verdict.action: drop
       verdict.reject_target: to_client
       verdict.reject[0]: tcp-reset
-# - filter:
-#     requires:
-#       lt-version: 9
-#     count: 3
-#     match:
-#       verdict.action: drop
-#       verdict.reject-target: to_client
-#       verdict.reject[0]: tcp-reset
+- filter:
+    requires:
+      lt-version: 9
+    count: 3
+    match:
+      verdict.action: drop
+      verdict.reject-target: to_client
+      verdict.reject[0]: tcp-reset
 - filter:
     count: 1
     match:

--- a/tests/firewall/ruletype-firewall-72-config-default-policy-http/test.yaml
+++ b/tests/firewall/ruletype-firewall-72-config-default-policy-http/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-73-config-default-policy-http/test.yaml
+++ b/tests/firewall/ruletype-firewall-73-config-default-policy-http/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-74-config-default-policy-dns/test.yaml
+++ b/tests/firewall/ruletype-firewall-74-config-default-policy-dns/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../dns/dns-eve/input.pcap
 

--- a/tests/firewall/ruletype-firewall-75-config-default-policy-http-accept-tx/test.yaml
+++ b/tests/firewall/ruletype-firewall-75-config-default-policy-http-accept-tx/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-76-config-default-policy-http-accept-tx-td/test.yaml
+++ b/tests/firewall/ruletype-firewall-76-config-default-policy-http-accept-tx-td/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-77-ruleset-default-packet-policy/test.yaml
+++ b/tests/firewall/ruletype-firewall-77-ruleset-default-packet-policy/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
   features:
     - LIBNET1.1
 

--- a/tests/firewall/ruletype-firewall-78-ruleset-default-packet-policy-accept/test.yaml
+++ b/tests/firewall/ruletype-firewall-78-ruleset-default-packet-policy-accept/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-79-ruleset-default-packet-policy-accept-hook/test.yaml
+++ b/tests/firewall/ruletype-firewall-79-ruleset-default-packet-policy-accept-hook/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-80-ruleset-default-packet-policy-accept-hook-no-rules/test.yaml
+++ b/tests/firewall/ruletype-firewall-80-ruleset-default-packet-policy-accept-hook-no-rules/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-81-ruleset-default-packet-policy-accept-hook-all/test.yaml
+++ b/tests/firewall/ruletype-firewall-81-ruleset-default-packet-policy-accept-hook-all/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-82-ruleset-default-app-policy-accept-flow/test.yaml
+++ b/tests/firewall/ruletype-firewall-82-ruleset-default-app-policy-accept-flow/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-83-ruleset-default-packet-policy-accept-flow/test.yaml
+++ b/tests/firewall/ruletype-firewall-83-ruleset-default-packet-policy-accept-flow/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-84-ruleset-default-app-policy-tls-request-started/test.yaml
+++ b/tests/firewall/ruletype-firewall-84-ruleset-default-app-policy-tls-request-started/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 

--- a/tests/firewall/ruletype-firewall-86-packet-filter-accept-flow-pass-with-td/test.yaml
+++ b/tests/firewall/ruletype-firewall-86-packet-filter-accept-flow-pass-with-td/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-87-broken-default-policy/test.yaml
+++ b/tests/firewall/ruletype-firewall-87-broken-default-policy/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-88-default-accept-tx-pipeline/test.yaml
+++ b/tests/firewall/ruletype-firewall-88-default-accept-tx-pipeline/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: input.pcap
 

--- a/tests/firewall/ruletype-firewall-89-lt-sni/test.yaml
+++ b/tests/firewall/ruletype-firewall-89-lt-sni/test.yaml
@@ -1,7 +1,7 @@
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 args:
   - --simulate-ips

--- a/tests/firewall/ruletype-firewall-92-lt-ua-mix/test.yaml
+++ b/tests/firewall/ruletype-firewall-92-lt-ua-mix/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-93-lt-ua-mix-accept-hook/test.yaml
+++ b/tests/firewall/ruletype-firewall-93-lt-ua-mix-accept-hook/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-94-config-default-policy-http/test.yaml
+++ b/tests/firewall/ruletype-firewall-94-config-default-policy-http/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../flowbit-oring/input.pcap
 

--- a/tests/firewall/ruletype-firewall-95-ruleset-default-packet-policy-accept-hook-alert/test.yaml
+++ b/tests/firewall/ruletype-firewall-95-ruleset-default-packet-policy-accept-hook-alert/test.yaml
@@ -1,5 +1,5 @@
 requires:
-  min-version: 9
+  min-version: 8.0.7
 
 pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
 


### PR DESCRIPTION
Due to YAML format change (https://github.com/OISF/suricata/pull/16021), some tests targetting version 8+ were disabled. With the backport of these changes to 8, the tests can be reenabled again.

Ticket: https://redmine.openinfosecfoundation.org/issues/8770
