### PR TITLE
run: allow suricatasc to be specified with an environment var

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Or to run a single test:
 ../path/to/suricata-tests/run.py TEST-NAME
 ```
 
+For Unix socket tests, the path to `suricatasc` can be overridden with the
+`SURICATASC` environment variable:
+
+```
+SURICATASC=/path/to/suricatasc ../path/to/suricata-tests/run.py
+```
+
 ## Adding a New Test
 
 - Create a directory that is the name of the new test.

--- a/run.py
+++ b/run.py
@@ -1383,13 +1383,15 @@ def main():
     HAS_SURICATA_SC = None
     global suricatasc_bin
     if not args.skipunixsocket:
-        sc_path = [".", "rust", "target", "release", "suricatasc"]
-        if "DEBUG" in suricata_config.features:
-            sc_path[3] = "debug"
-        cargo_build_target = os.environ.get("CARGO_BUILD_TARGET")
-        if cargo_build_target != None :
-            sc_path.insert(3, cargo_build_target)
-        suricatasc_bin = os.path.join(*sc_path)
+        suricatasc_bin = os.environ.get("SURICATASC")
+        if suricatasc_bin is None:
+            sc_path = [".", "rust", "target", "release", "suricatasc"]
+            if "DEBUG" in suricata_config.features:
+                sc_path[3] = "debug"
+            cargo_build_target = os.environ.get("CARGO_BUILD_TARGET")
+            if cargo_build_target != None :
+                sc_path.insert(3, cargo_build_target)
+            suricatasc_bin = os.path.join(*sc_path)
         if os.path.exists(suricatasc_bin):
             HAS_SURICATA_SC = True
         else:


### PR DESCRIPTION
Needed for a new Rust+ASAN CI build configuration.
