### PR TITLE
tests: add firewall ARP accept-arp config tests for 8.0.x

### DIFF
--- a/tests/firewall/firewall-arp-accept-false/firewall.rules
+++ b/tests/firewall/firewall-arp-accept-false/firewall.rules
@@ -1,0 +1,1 @@
+# No explicit rules

--- a/tests/firewall/firewall-arp-accept-false/suricata.yaml
+++ b/tests/firewall/firewall-arp-accept-false/suricata.yaml
@@ -1,0 +1,28 @@
+%YAML 1.1
+---
+
+firewall:
+  enabled: true
+  policies:
+    accept-arp: false
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - stats
+        - drop:
+            alerts: yes
+            flows: all
+        - flow
+
+stream:
+  inline: yes
+
+logging:
+  default-log-level: notice
+  outputs:
+    - console:
+        enabled: yes

--- a/tests/firewall/firewall-arp-accept-false/test.yaml
+++ b/tests/firewall/firewall-arp-accept-false/test.yaml
@@ -1,0 +1,22 @@
+requires:
+  min-version: 8.0.7
+  lt-version: 9
+
+pcap: ../../decode-arp-1/input.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+  - filter:
+      count: 1
+      match:
+        event_type: drop
+        drop.reason: "firewall default packet policy"
+
+  - filter:
+      count: 0
+      match:
+        event_type: stats
+        stats.firewall.accepted: 1

--- a/tests/firewall/firewall-arp-accept-true/firewall.rules
+++ b/tests/firewall/firewall-arp-accept-true/firewall.rules
@@ -1,0 +1,1 @@
+# No explicit firewall rules, rely on default drop policy and accept-arp config

--- a/tests/firewall/firewall-arp-accept-true/suricata.yaml
+++ b/tests/firewall/firewall-arp-accept-true/suricata.yaml
@@ -1,0 +1,28 @@
+%YAML 1.1
+---
+
+firewall:
+  enabled: true
+  policies:
+    accept-arp: true
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - stats
+        - drop:
+            alerts: yes
+            flows: all
+        - flow
+
+stream:
+  inline: yes
+
+logging:
+  default-log-level: notice
+  outputs:
+    - console:
+        enabled: yes

--- a/tests/firewall/firewall-arp-accept-true/test.yaml
+++ b/tests/firewall/firewall-arp-accept-true/test.yaml
@@ -1,0 +1,22 @@
+requires:
+  min-version: 8.0.7
+  lt-version: 9
+
+pcap: ../../decode-arp-1/input.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+  - filter:
+      count: 0
+      match:
+        event_type: drop
+        drop.reason: "firewall default packet policy"
+
+  - filter:
+      count: 1
+      match:
+        event_type: stats
+        stats.firewall.accepted: 1


### PR DESCRIPTION
Add minimal tests for firewall.policies.accept-arp true/false to validate ARP packets are accepted/dropped with default firewall policy.

Ticket: #8314.


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/
