### PR TITLE
add tls sni auto-accept-prior-hook repro bug validation

### DIFF
--- a/tests/firewall/ruletype-firewall-200-sni-lte-prior-hook-bug/README.md
+++ b/tests/firewall/ruletype-firewall-200-sni-lte-prior-hook-bug/README.md
@@ -1,0 +1,5 @@
+Test that auto-accept-prior-states (`<`) on a catch-all accept covers the prior app-layer hook when a lower-SID same-hook drop rule with a matching prefilter leads the candidate list.
+Rules drop TLS SNI "www.google.com" (sid:200) and accept other SNI via `accept:flow tls:<client_hello_done` (sid:201), with no explicit `accept:hook tls:client_in_progress`.
+Expected: sid:200 drops the flow with an alert. Actual (buggy): the flow is dropped by the default app policy at client_in_progress and sid:200 never fires. Asserts the expected behaviour, so currently FAILS.
+Workaround: add `accept:hook tls:<client_in_progress` to explicitly cover the prior hook.
+

--- a/tests/firewall/ruletype-firewall-200-sni-lte-prior-hook-bug/firewall.rules
+++ b/tests/firewall/ruletype-firewall-200-sni-lte-prior-hook-bug/firewall.rules
@@ -1,0 +1,7 @@
+# allow session setup
+accept:hook tcp:all $HOME_NET any <> $EXTERNAL_NET any (flow:not_established; sid:1021;)
+accept:hook tcp:all $HOME_NET any <> $EXTERNAL_NET any (flow:established; sid:1022;)
+# drop a specific SNI; accept all other SNI via auto-accept-prior-states (<)
+# note: no explicit accept:hook tls:client_in_progress (see README)
+drop:flow tls:client_hello_done $HOME_NET any -> $EXTERNAL_NET any (tls.sni; content:"www.google.com"; endswith; nocase; msg:"Drop www.google.com by SNI"; alert; sid:200;)
+accept:flow tls:<client_hello_done $HOME_NET any -> $EXTERNAL_NET any (alert; sid:201;)

--- a/tests/firewall/ruletype-firewall-200-sni-lte-prior-hook-bug/suricata.yaml
+++ b/tests/firewall/ruletype-firewall-200-sni-lte-prior-hook-bug/suricata.yaml
@@ -1,0 +1,63 @@
+%YAML 1.1
+---
+
+vars:
+  # more specific is better for alert accuracy and performance
+  address-groups:
+    HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
+    #HOME_NET: "[192.168.0.0/16]"
+    #HOME_NET: "[10.0.0.0/8]"
+    #HOME_NET: "[172.16.0.0/12]"
+    #HOME_NET: "any"
+
+    EXTERNAL_NET: "!$HOME_NET"
+    #EXTERNAL_NET: "any"
+
+    HTTP_SERVERS: "$HOME_NET"
+    SMTP_SERVERS: "$HOME_NET"
+    SQL_SERVERS: "$HOME_NET"
+    DNS_SERVERS: "$HOME_NET"
+    TELNET_SERVERS: "$HOME_NET"
+    AIM_SERVERS: "$EXTERNAL_NET"
+    DC_SERVERS: "$HOME_NET"
+    DNP3_SERVER: "$HOME_NET"
+    DNP3_CLIENT: "$HOME_NET"
+    MODBUS_CLIENT: "$HOME_NET"
+    MODBUS_SERVER: "$HOME_NET"
+    ENIP_CLIENT: "$HOME_NET"
+    ENIP_SERVER: "$HOME_NET"
+
+  port-groups:
+    HTTP_PORTS: "80"
+    SHELLCODE_PORTS: "!80"
+    ORACLE_PORTS: 1521
+    SSH_PORTS: 22
+    DNP3_PORTS: 20000
+    MODBUS_PORTS: 502
+    FILE_DATA_PORTS: "[$HTTP_PORTS,110,143]"
+    FTP_PORTS: 21
+    GENEVE_PORTS: 6081
+    VXLAN_PORTS: 4789
+    TEREDO_PORTS: 3544
+    SIP_PORTS: "[5060, 5061]"
+
+# Global stats configuration
+stats:
+  enabled: yes
+  interval: 8
+
+# Configure the type of alert (and other) logging you would like.
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - stats
+        - flow
+        - alert
+        - tls:
+            extended: yes     # enable this for extended logging information
+        - drop:
+            alerts: yes      # log alerts that caused drops
+            flows: all       # start or all: 'start' logs only a single drop

--- a/tests/firewall/ruletype-firewall-200-sni-lte-prior-hook-bug/test.yaml
+++ b/tests/firewall/ruletype-firewall-200-sni-lte-prior-hook-bug/test.yaml
@@ -1,0 +1,29 @@
+# Asserts expected behaviour; currently FAILS (see README).
+pcap: ../../tls/tls-client-hello-frag-01/dump_mtu300.pcap
+requires:
+  min-version: 9
+args:
+  - --simulate-ips
+  - -k none
+checks:
+# sid:200 drops www.google.com by SNI, with alert
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      alert.signature_id: 200
+      alert.action: blocked
+      firewall.hook: "tls:client_hello_done"
+- filter:
+    count: 1
+    match:
+      event_type: flow
+      flow.action: "drop"
+      flow.alerted: true
+# dropped by the rule, not the default app policy
+- filter:
+    count: 1
+    match:
+      event_type: stats
+      stats.firewall.drop_reason.rules: 1
+      stats.firewall.drop_reason.default_app_policy: 0


### PR DESCRIPTION
## Ticket
Add a firewall-mode test showing that the auto-accept-prior-states (`<`) notation on a catch-all accept does not cover the prior app-layer hook when a lower-SID same-hook drop rule with a matching prefilter leads the candidate list.
    
The rules drop TLS SNI "www.google.com" (sid:200) and accept all other SNI via `accept:flow tls:<client_hello_done` (sid:201), without an explicit `accept:hook tls:client_in_progress`. The expected result is a drop by sid:200 with an alert; the actual result is a default-app-policy drop at client_in_progress with sid:200 never firing.
    
The test asserts the expected behaviour and therefore currently fails, documenting the defect. Reuses tests/tls/tls-client-hello-frag-01.

Redmine: https://redmine.openinfosecfoundation.org/issues/8944