### PR TITLE
test(firewall): add IMAP app-layer firewall regression test

### DIFF
--- a/tests/firewall/firewall-imap/firewall.rules
+++ b/tests/firewall/firewall-imap/firewall.rules
@@ -1,0 +1,17 @@
+# Proof that firewall-mode app-layer rules are inert for IMAP.
+#
+# IMAP in Suricata is detection-only. src/app-layer-imap.c registers protocol
+# detection patterns but no parser, no transactions and no progress states.
+# An administrator can still write a firewall rule that hooks an IMAP
+# app-layer state and it loads without error, but it never matches: the
+# app-layer firewall never engages for an IMAP flow.
+
+# Packet level: accept the TCP session so packets flow and the flow reaches
+# app-layer classification. This isolates the app-layer behaviour under test.
+accept:hook tcp:all any any <> any any (flow:not_established; alert; sid:1000;)
+accept:hook tcp:all any any <> any any (flow:established; alert; sid:1001;)
+
+# Intended policy: drop every IMAP flow at the request hook. This rule loads
+# cleanly but is completely inert because IMAP has no app-layer transactions
+# for the hook to bind to, so the IMAP flow is never blocked.
+drop:flow imap:request_started any any -> any any (alert; sid:2000;)

--- a/tests/firewall/firewall-imap/suricata.yaml
+++ b/tests/firewall/firewall-imap/suricata.yaml
@@ -1,0 +1,63 @@
+%YAML 1.1
+---
+
+vars:
+  # more specific is better for alert accuracy and performance
+  address-groups:
+    HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
+    #HOME_NET: "[192.168.0.0/16]"
+    #HOME_NET: "[10.0.0.0/8]"
+    #HOME_NET: "[172.16.0.0/12]"
+    #HOME_NET: "any"
+
+    EXTERNAL_NET: "!$HOME_NET"
+    #EXTERNAL_NET: "any"
+
+    HTTP_SERVERS: "$HOME_NET"
+    SMTP_SERVERS: "$HOME_NET"
+    SQL_SERVERS: "$HOME_NET"
+    DNS_SERVERS: "$HOME_NET"
+    TELNET_SERVERS: "$HOME_NET"
+    AIM_SERVERS: "$EXTERNAL_NET"
+    DC_SERVERS: "$HOME_NET"
+    DNP3_SERVER: "$HOME_NET"
+    DNP3_CLIENT: "$HOME_NET"
+    MODBUS_CLIENT: "$HOME_NET"
+    MODBUS_SERVER: "$HOME_NET"
+    ENIP_CLIENT: "$HOME_NET"
+    ENIP_SERVER: "$HOME_NET"
+
+  port-groups:
+    HTTP_PORTS: "80"
+    SHELLCODE_PORTS: "!80"
+    ORACLE_PORTS: 1521
+    SSH_PORTS: 22
+    DNP3_PORTS: 20000
+    MODBUS_PORTS: 502
+    FILE_DATA_PORTS: "[$HTTP_PORTS,110,143]"
+    FTP_PORTS: 21
+    GENEVE_PORTS: 6081
+    VXLAN_PORTS: 4789
+    TEREDO_PORTS: 3544
+    SIP_PORTS: "[5060, 5061]"
+
+# Global stats configuration
+stats:
+  enabled: yes
+  interval: 8
+
+# Configure the type of alert (and other) logging you would like.
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - stats
+        - flow
+        - alert
+        - tls:
+            extended: yes     # enable this for extended logging information
+        - drop:
+            alerts: yes      # log alerts that caused drops
+            flows: all       # start or all: 'start' logs only a single drop

--- a/tests/firewall/firewall-imap/test.yaml
+++ b/tests/firewall/firewall-imap/test.yaml
@@ -1,0 +1,43 @@
+# Regression test for the IMAP firewall app-layer bug.
+#
+# EXPECTED TO FAIL on affected builds: IMAP is detection-only, so the
+# drop:flow imap:request_started rule never matches and the flow is not
+# blocked. This test asserts the CORRECT behaviour (the rule blocks the IMAP
+# flow) so that it starts passing once the underlying issue is fixed.
+#
+# See redmine: firewall app-layer hook rules for IMAP load but never match.
+
+requires:
+  min-version: 8
+
+pcap: ../../imap-detection/input.pcap
+
+args:
+  - --simulate-ips
+  - -k none
+
+checks:
+# Control: IMAP protocol detection works - the flow is classified as imap.
+# (Passes today and must keep passing after the fix.)
+- filter:
+    count: 1
+    match:
+      event_type: flow
+      app_proto: imap
+
+# EXPECTED: the drop:flow rule matches once at the IMAP request hook and
+# blocks the flow. On affected builds this alert is never produced.
+- filter:
+    count: 1
+    match:
+      event_type: alert
+      alert.signature_id: 2000
+      alert.engine: fw
+      alert.action: blocked
+      app_proto: imap
+
+# EXPECTED: the flow is actually dropped by the firewall rule (not merely
+# accepted). On affected builds nothing is dropped.
+- stats:
+    firewall.drop_reason.rules.__gte: 1
+    firewall.blocked.__gte: 1


### PR DESCRIPTION
IMAP is detection-only in Suricata: src/app-layer-imap.c registers protocol detection patterns but no parser, transactions or progress states. A firewall rule that hooks an IMAP app-layer state therefore loads without error yet can never match, and the app-layer firewall never engages for an IMAP flow.

This test loads a drop:flow rule on imap:request_started intending to block every IMAP flow and asserts the expected behaviour:
  - the flow is still detected as app_proto imap (control), and
  - the drop rule fires and blocks the flow (alert sid 2000, action blocked),
  - the flow is actually dropped (firewall drop_reason.rules and blocked >= 1).

It fails on affected builds (reproducing the bug) and will pass once the underlying issue is fixed.


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/8948
