### PR TITLE
Bug/8954 action scope verify v2

### DIFF
--- a/tests/firewall/firewall-action-pass-requires-accept-policies-invalid/firewall.rules
+++ b/tests/firewall/firewall-action-pass-requires-accept-policies-invalid/firewall.rules
@@ -1,0 +1,1 @@
+accept:packet,alert tcp:all any any <> any any (sid:1000;)

--- a/tests/firewall/firewall-action-pass-requires-accept-policies-invalid/suricata.yaml
+++ b/tests/firewall/firewall-action-pass-requires-accept-policies-invalid/suricata.yaml
@@ -1,0 +1,20 @@
+%YAML 1.1
+---
+
+engine-analysis:
+  rules-fast-pattern: no
+  rules: yes
+
+logging:
+  default-log-level: notice
+  outputs:
+    - file:
+        enabled: yes
+        level: info
+        filename: suricata.log
+
+firewall:
+  policies:
+    packet:
+      # a "pass" secondary is only evaluated after an "accept" primary
+      filter: [ "rejectboth:packet", "pass:packet", "alert" ]

--- a/tests/firewall/firewall-action-pass-requires-accept-policies-invalid/test.yaml
+++ b/tests/firewall/firewall-action-pass-requires-accept-policies-invalid/test.yaml
@@ -1,0 +1,13 @@
+requires:
+  min-version: 9
+  pcap: false
+
+args:
+  - --engine-analysis
+
+exit-code: 1
+
+checks:
+  - shell:
+      args: "grep -c \"'pass' is only supported as a secondary action for 'accept'\" suricata.log | xargs"
+      expect: 1

--- a/tests/firewall/firewall-action-pass-requires-accept-rule-invalid/firewall.rules
+++ b/tests/firewall/firewall-action-pass-requires-accept-rule-invalid/firewall.rules
@@ -1,0 +1,1 @@
+rejectboth:packet,pass:packet,alert tcp:all any any <> any any (sid:1001;)

--- a/tests/firewall/firewall-action-pass-requires-accept-rule-invalid/suricata.yaml
+++ b/tests/firewall/firewall-action-pass-requires-accept-rule-invalid/suricata.yaml
@@ -1,0 +1,15 @@
+%YAML 1.1
+---
+
+engine-analysis:
+  rules-fast-pattern: no
+  rules: yes
+
+logging:
+  default-log-level: notice
+  outputs:
+    - file:
+        enabled: yes
+        level: info
+        filename: suricata.log
+

--- a/tests/firewall/firewall-action-pass-requires-accept-rule-invalid/test.yaml
+++ b/tests/firewall/firewall-action-pass-requires-accept-rule-invalid/test.yaml
@@ -1,0 +1,13 @@
+requires:
+  min-version: 9
+  pcap: false
+
+args:
+  - --engine-analysis
+
+exit-code: 1
+
+checks:
+  - shell:
+      args: "grep -c \"'pass' is only supported as a secondary action for 'accept'\" suricata.log | xargs"
+      expect: 1

--- a/tests/firewall/firewall-action-pass-requires-accept-valid/firewall.rules
+++ b/tests/firewall/firewall-action-pass-requires-accept-valid/firewall.rules
@@ -1,0 +1,6 @@
+# pass after an accept primary is the documented combination
+accept:packet,pass:packet,alert tcp:all any any <> any any (sid:1;)
+accept:flow,pass:flow tcp:all any any <> any 443 (sid:2;)
+# alert has no such restriction, it is valid after any primary
+drop:packet,alert tcp:all any any <> any 8080 (sid:3;)
+rejectboth:packet,alert tcp:all any any <> any 8081 (sid:4;)

--- a/tests/firewall/firewall-action-pass-requires-accept-valid/suricata.yaml
+++ b/tests/firewall/firewall-action-pass-requires-accept-valid/suricata.yaml
@@ -1,0 +1,15 @@
+%YAML 1.1
+---
+
+engine-analysis:
+  rules-fast-pattern: no
+  rules: yes
+
+logging:
+  default-log-level: notice
+  outputs:
+    - file:
+        enabled: yes
+        level: info
+        filename: suricata.log
+

--- a/tests/firewall/firewall-action-pass-requires-accept-valid/test.yaml
+++ b/tests/firewall/firewall-action-pass-requires-accept-valid/test.yaml
@@ -1,0 +1,11 @@
+requires:
+  min-version: 9
+  pcap: false
+
+args:
+  - --engine-analysis
+
+checks:
+  - shell:
+      args: grep -c "4 rules successfully loaded, 0 rules failed" suricata.log | xargs
+      expect: 1

--- a/tests/firewall/firewall-action-scope-inherited-policies-invalid/firewall.rules
+++ b/tests/firewall/firewall-action-scope-inherited-policies-invalid/firewall.rules
@@ -1,0 +1,1 @@
+# testing default policies, no rules needed

--- a/tests/firewall/firewall-action-scope-inherited-policies-invalid/suricata.yaml
+++ b/tests/firewall/firewall-action-scope-inherited-policies-invalid/suricata.yaml
@@ -1,0 +1,17 @@
+%YAML 1.1
+---
+
+engine-analysis:
+  rules-fast-pattern: no
+  rules: yes
+
+logging:
+  outputs:
+    - file:
+        enabled: yes
+        filename: suricata.log
+
+firewall:
+  policies:
+    default-policy: [ "accept:hook", "pass" ]
+

--- a/tests/firewall/firewall-action-scope-inherited-policies-invalid/test.yaml
+++ b/tests/firewall/firewall-action-scope-inherited-policies-invalid/test.yaml
@@ -1,0 +1,13 @@
+requires:
+  min-version: 9
+  pcap: false
+
+args:
+  - --engine-analysis
+
+exit-code: 1
+
+checks:
+  - shell:
+      args: grep -c "invalid action scope 'hook' in action 'pass'" suricata.log | xargs
+      expect: 1

--- a/tests/firewall/firewall-action-scope-inherited-rule-invalid/firewall.rules
+++ b/tests/firewall/firewall-action-scope-inherited-rule-invalid/firewall.rules
@@ -1,0 +1,4 @@
+# "pass" without an explicit scope inherits the scope of the primary action.
+# pass only supports packet and flow scope, so an inherited hook scope has to be
+# rejected the same way an explicit "pass:hook" is.
+accept:hook,pass tcp:all any any -> any any (sid:1;)

--- a/tests/firewall/firewall-action-scope-inherited-rule-invalid/suricata.yaml
+++ b/tests/firewall/firewall-action-scope-inherited-rule-invalid/suricata.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+---
+
+engine-analysis:
+  rules-fast-pattern: no
+  rules: yes
+
+logging:
+  outputs:
+    - file:
+        enabled: yes
+        filename: suricata.log
+

--- a/tests/firewall/firewall-action-scope-inherited-rule-invalid/test.yaml
+++ b/tests/firewall/firewall-action-scope-inherited-rule-invalid/test.yaml
@@ -1,0 +1,13 @@
+requires:
+  min-version: 9
+  pcap: false
+
+args:
+  - --engine-analysis
+
+exit-code: 1
+
+checks:
+  - shell:
+      args: grep -c "invalid action scope 'hook' in action 'pass'" suricata.log | xargs
+      expect: 1

--- a/tests/firewall/firewall-action-scope-inherited-valid/firewall.rules
+++ b/tests/firewall/firewall-action-scope-inherited-valid/firewall.rules
@@ -1,0 +1,7 @@
+# An inherited scope that is valid for the secondary action must keep working.
+# pass supports flow and packet scope:
+accept:flow,pass tcp:all any any -> any any (sid:1;)
+accept:packet,pass tcp:all any any -> any any (sid:2;)
+# alert takes no scope of its own, so it may inherit any scope:
+accept:hook,alert tcp:all any any -> any any (sid:3;)
+accept:tx,alert http1:request_line any any -> any any (sid:4;)

--- a/tests/firewall/firewall-action-scope-inherited-valid/suricata.yaml
+++ b/tests/firewall/firewall-action-scope-inherited-valid/suricata.yaml
@@ -1,0 +1,14 @@
+%YAML 1.1
+---
+
+engine-analysis:
+  rules-fast-pattern: no
+  rules: yes
+
+logging:
+  default-log-level: notice
+  outputs:
+    - file:
+        enabled: yes
+        level: info
+        filename: suricata.log

--- a/tests/firewall/firewall-action-scope-inherited-valid/test.yaml
+++ b/tests/firewall/firewall-action-scope-inherited-valid/test.yaml
@@ -1,0 +1,12 @@
+requires:
+  min-version: 9
+  pcap: false
+
+args:
+  - --engine-analysis
+
+checks:
+  # all four rules load, none is rejected by the inherited-scope validation
+  - shell:
+      args: grep -c "4 rules successfully loaded, 0 rules failed" suricata.log | xargs
+      expect: 1


### PR DESCRIPTION
Follow-up of https://github.com/OISF/suricata-verify/pull/3323

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/8954

Describe changes:
v2:
- tests for `pass` keyword (in)compatibility added