### PR TITLE
logging: test for multi-threaded double free in deinit v3

### DIFF
--- a/tests/bug-8861-eve-threaded-flow/README.md
+++ b/tests/bug-8861-eve-threaded-flow/README.md
@@ -1,0 +1,17 @@
+# bug-8861-eve-threaded-flow
+
+## Purpose
+
+Regression test for Redmine #8861: a double-free during teardown of threaded
+EVE output.
+
+During the init phase (LogFileNewThreadedCtx), threads shared prefix/sensor
+names through a shallow copy.
+During deinit, all threads attempted to free the variables.
+Suricata would then crash as a result of a double free.
+
+
+## PCAP
+
+The traffic is irrelevant to the bug, the pcap only needs to produce EVE alert
+and flow records.

--- a/tests/bug-8861-eve-threaded-flow/suricata.yaml
+++ b/tests/bug-8861-eve-threaded-flow/suricata.yaml
@@ -1,0 +1,14 @@
+%YAML 1.1
+---
+sensor-name: bug8861sensor
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      threaded: true
+      prefix: "@cee: "
+      types:
+        - alert
+        - flow

--- a/tests/bug-8861-eve-threaded-flow/test.rules
+++ b/tests/bug-8861-eve-threaded-flow/test.rules
@@ -1,0 +1,1 @@
+alert ip any any -> any any (msg:"bug-8861 threaded eve flow"; sid:1; rev:1;)

--- a/tests/bug-8861-eve-threaded-flow/test.yaml
+++ b/tests/bug-8861-eve-threaded-flow/test.yaml
@@ -1,0 +1,35 @@
+requires:
+  min-version: 9
+
+pcap: ../bug-5758/input.pcap
+
+# Strip the configured prefix so the remaining payload can be validated as
+# real JSON by the filter checks below.
+pre-check: |
+  sed 's/^@cee:[[:space:]]*//' eve.*.json > merged.json
+
+checks:
+  # Make sure threaded eve logging works
+  - shell:
+      args: test ! -e eve.json
+
+  - shell:
+      args: "cat eve.*.json | grep -v '^@cee: {' | wc -l | xargs"
+      expect: 0
+  - shell:
+      args: "cat eve.*.json | grep -v '\"host\":\"bug8861sensor\"' | wc -l | xargs"
+      expect: 0
+
+  - filter:
+      filename: merged.json
+      count: 2
+      match:
+        event_type: alert
+        host: bug8861sensor
+
+  - filter:
+      filename: merged.json
+      count: 1
+      match:
+        event_type: flow
+        host: bug8861sensor


### PR DESCRIPTION
Follow-up of https://github.com/OISF/suricata-verify/pull/3301

Suricata crashes on double free without the proposed fix as multiple threads free the same shallow-copied variables.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/8861

Describe changes:
v3:
- removed the `-ge 3` test from test.yaml
- fixed grammar and sed command

v2:
- restrain test to 9+ (the plan is to lower the version check to 8 after backport)