### PR TITLE
backport: support issue 8845 tests for 8.0.x 

### DIFF
--- a/tests/bug-8845/bug-8845-01/test.yaml
+++ b/tests/bug-8845/bug-8845-01/test.yaml
@@ -1,7 +1,15 @@
+# The runtime guard is on 8.0.x as well, so this runs on both branches.
 requires:
-  min-version: 9.0
+  min-version: 8.0.7
 
 checks:
+  # On 8.0.x this rule draws no byte_math warning: a variable shift count is
+  # only known once the rule runs. The pattern is the 8.0.x warning text, so
+  # on main the check cannot match either way.
+  - shell:
+      args: "grep -c 'byte_math rvalue' suricata.log || true"
+      expect: 0
+
   - filter:
       count: 1
       match:

--- a/tests/bug-8845/bug-8845-02/test.yaml
+++ b/tests/bug-8845/bug-8845-02/test.yaml
@@ -1,3 +1,4 @@
+# main rejects these rules; 8.0.x warns instead, and bug-8845-03 covers that.
 requires:
   min-version: 9.0
 

--- a/tests/bug-8845/bug-8845-03/test.rules
+++ b/tests/bug-8845/bug-8845-03/test.rules
@@ -1,0 +1,7 @@
+# A shift of 64 or more always yields 0. On 8.0.x a literal rvalue that large
+# is warned about when the rule is loaded, and the rule still loads.
+alert udp any any -> any 5555 (msg:"byte_math right shift by a literal 64"; byte_math:bytes 4, offset 0, oper >>, rvalue 64, result var; sid:1; rev:1;)
+alert udp any any -> any 5555 (msg:"byte_math left shift by a literal 64"; byte_math:bytes 4, offset 0, oper <<, rvalue 64, result var; sid:2; rev:1;)
+
+# 63 is still accepted.
+alert udp any any -> any 5555 (msg:"byte_math right shift by a literal 63"; byte_math:bytes 4, offset 0, oper >>, rvalue 63, result var; sid:3; rev:1;)

--- a/tests/bug-8845/bug-8845-03/test.yaml
+++ b/tests/bug-8845/bug-8845-03/test.yaml
@@ -1,0 +1,32 @@
+# The 8.0.x side of bug-8845-02. On 8.0.x all three rules load and the two
+# shifting by 64 draw a warning, so the run ends with exit code 0 where main
+# ends with 1. That is why the two cases need separate directories: exit-code
+# is one value for the whole test.
+requires:
+  min-version: 8.0.7
+  lt-version: 9.0
+
+  # No pcap required.
+  pcap: false
+
+args:
+  - --engine-analysis
+
+checks:
+  - shell:
+      args: "grep -c 'signature sid:1: byte_math rvalue 64 is 64 or more' suricata.log"
+      expect: 1
+
+  - shell:
+      args: "grep -c 'signature sid:2: byte_math rvalue 64 is 64 or more' suricata.log"
+      expect: 1
+
+  # sid 3 shifts by 63 and draws no warning.
+  - shell:
+      args: "grep -c 'signature sid:3' suricata.log || true"
+      expect: 0
+
+  # All three load, unlike on main where two are rejected.
+  - shell:
+      args: "grep -c '3 rules successfully loaded, 0 rules failed' suricata.log"
+      expect: 1


### PR DESCRIPTION
Add bug-8845-03, gated with min-version 8.0.7 and lt-version 9.0. It loads the same three rules as bug-8845-02, and on 8.0.x all three load while the two shifting by a literal 64 draw a warning naming sid:1 and sid:2. bug-8845-02 stays at min-version 9.0, where those two rules are rejected and the run exits 1. The two cases need separate directories because exit-code is one value for the whole test.

Lower bug-8845-01 from min-version 9.0 to 8.0.7 now that the right shift guard it exercises is on 8.0.x as well. Add a check there that a rule whose rvalue names a variable draws no warning at load: that count comes from a byte_extract and is known only once the rule runs.

Issue: 8845
Issue: 8902


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/
