### PR TITLE
reference: cover reference key handling

### DIFF
--- a/tests/reference-05/suricata.yaml
+++ b/tests/reference-05/suricata.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            metadata:
+              rule:
+                reference: yes

--- a/tests/reference-05/test.rules
+++ b/tests/reference-05/test.rules
@@ -1,0 +1,2 @@
+alert dcerpc any any -> any ![139,445] (msg:"Possible Zerologon Attempt"; flow:established,to_server; dcerpc.opnum:26; content:"|00 00 00 00 00 00 00 00 ff ff 2f 21|"; endswith; reference:unknownkey,001-2010; classtype:attempted-admin; sid:20166330; rev:2;)
+alert dcerpc any any -> any ![139,445] (msg:"Possible Zerologon Attempt"; flow:established,to_server; dcerpc.opnum:26; content:"|00 00 00 00 00 00 00 00 ff ff 2f 21|"; endswith; reference:cve,2014-0160; reference:otherkey,002-2011; classtype:attempted-admin; sid:20166332; rev:2;)

--- a/tests/reference-05/test.yaml
+++ b/tests/reference-05/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  min-version: 9.0
+
+args:
+ - -k none
+
+pcap: ../dcerpc/zerologon/input.pcap
+
+checks:
+  - filter:
+      count: 21
+      match:
+        event_type: alert
+        alert.signature_id: 20166330
+        alert.references: ["undefined001-2010"]
+  - filter:
+      count: 21
+      match:
+        event_type: alert
+        alert.signature_id: 20166332
+        alert.references: ["https://cve.mitre.org/cgi-bin/cvename.cgi?name=2014-0160","undefined002-2011"]

--- a/tests/reference-06/test.rules
+++ b/tests/reference-06/test.rules
@@ -1,0 +1,1 @@
+alert ip any any -> any any (msg:"unknown reference key"; reference:unknownkey,001-2010; sid:1000001; rev:1;)

--- a/tests/reference-06/test.yaml
+++ b/tests/reference-06/test.yaml
@@ -1,0 +1,16 @@
+requires:
+  min-version: 9.0
+
+  # Rule load is the subject; no traffic needed.
+  pcap: false
+
+exit-code: 1
+
+args:
+  - --engine-analysis
+  - --strict-rule-keywords=reference
+
+checks:
+  - shell:
+      args: grep 'unknown reference key "unknownkey"' suricata.log | wc -l | xargs
+      expect: 1

--- a/tests/reference-07/suricata.yaml
+++ b/tests/reference-07/suricata.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            metadata:
+              rule:
+                reference: yes

--- a/tests/reference-07/test.rules
+++ b/tests/reference-07/test.rules
@@ -1,0 +1,2 @@
+alert dcerpc any any -> any ![139,445] (msg:"Possible Zerologon Attempt"; flow:established,to_server; dcerpc.opnum:26; content:"|00 00 00 00 00 00 00 00 ff ff 2f 21|"; endswith; reference:sharedkey,001-2010; classtype:attempted-admin; sid:20166330; rev:2;)
+alert dcerpc any any -> any ![139,445] (msg:"Possible Zerologon Attempt"; flow:established,to_server; dcerpc.opnum:26; content:"|00 00 00 00 00 00 00 00 ff ff 2f 21|"; endswith; reference:sharedkey,002-2011; classtype:attempted-admin; sid:20166332; rev:2;)

--- a/tests/reference-07/test.yaml
+++ b/tests/reference-07/test.yaml
@@ -1,0 +1,21 @@
+requires:
+  min-version: 9.0
+
+args:
+ - -k none
+
+pcap: ../dcerpc/zerologon/input.pcap
+
+checks:
+  - filter:
+      count: 21
+      match:
+        event_type: alert
+        alert.signature_id: 20166330
+        alert.references: ["undefined001-2010"]
+  - filter:
+      count: 21
+      match:
+        event_type: alert
+        alert.signature_id: 20166332
+        alert.references: ["undefined002-2011"]

--- a/tests/reference-08/test.rules
+++ b/tests/reference-08/test.rules
@@ -1,0 +1,3 @@
+alert ip any any -> any any (msg:"key too long"; reference:kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk,001; sid:1000064; rev:1;)
+alert ip any any -> any any (msg:"no reference value"; reference:cve,; sid:1000003; rev:1;)
+alert ip any any -> any any (msg:"no comma"; reference:cve; sid:1000004; rev:1;)

--- a/tests/reference-08/test.yaml
+++ b/tests/reference-08/test.yaml
@@ -1,0 +1,24 @@
+requires:
+  min-version: 9.0
+
+  # Rule load is the subject; no traffic needed.
+  pcap: false
+
+exit-code: 1
+
+args:
+  - --engine-analysis
+
+checks:
+  # A 64 character key leaves no room for the terminator in a buffer of
+  # REFERENCE_SYSTEM_NAME_MAX, so the substring copy fails.
+  - shell:
+      args: grep -c "pcre2_substring_copy_bynumber key failed" suricata.log | xargs
+      expect: 1
+  # A reference needs both a key and a value.
+  - shell:
+      args: grep -c 'Unable to parse .reference. keyword argument' suricata.log | xargs
+      expect: 2
+  - shell:
+      args: grep -c "error parsing signature" suricata.log | xargs
+      expect: 3

--- a/tests/reference-09/suricata.yaml
+++ b/tests/reference-09/suricata.yaml
@@ -1,0 +1,13 @@
+%YAML 1.1
+---
+
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      types:
+        - alert:
+            metadata:
+              rule:
+                reference: yes

--- a/tests/reference-09/test.rules
+++ b/tests/reference-09/test.rules
@@ -1,0 +1,1 @@
+alert dcerpc any any -> any ![139,445] (msg:"Possible Zerologon Attempt"; flow:established,to_server; dcerpc.opnum:26; content:"|00 00 00 00 00 00 00 00 ff ff 2f 21|"; endswith; reference:kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk,001; classtype:attempted-admin; sid:20166363; rev:2;)

--- a/tests/reference-09/test.yaml
+++ b/tests/reference-09/test.yaml
@@ -1,0 +1,17 @@
+requires:
+  min-version: 9.0
+
+args:
+ - -k none
+
+pcap: ../dcerpc/zerologon/input.pcap
+
+checks:
+  # A 63 character key is the longest that fits REFERENCE_SYSTEM_NAME_MAX
+  # alongside its terminator, and resolves through the unknown-key fallback.
+  - filter:
+      count: 21
+      match:
+        event_type: alert
+        alert.signature_id: 20166363
+        alert.references: ["undefined001"]


### PR DESCRIPTION
Add tests for reference keys that are not in reference.config. reference-05 checks that such a key logs "undefined" joined to the reference value. reference-07 checks the ordering behind it: the first rule to name a key registers it, so a second rule reusing that key resolves through the ordinary lookup rather than the fallback, and the two paths have to agree.

reference-06 checks that --strict-rule-keywords=reference rejects the same key. reference-08 covers three rejections -- a key of 64 characters, which cannot fit REFERENCE_SYSTEM_NAME_MAX with its terminator, a reference with no value, and one with no comma. reference-09 takes the accepting side of that bound at 63 characters, separate from reference-08 because run.py passes --init-errors-fatal, so one run cannot hold both a rule that fails to load and a rule that alerts.

Issue: 8849


## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/
