### PR TITLE
tests: verify unix command socket removal in hostbit-add-ip6 v2

### DIFF
--- a/tests/unix-socket/hostbit-add-ip6/README.md
+++ b/tests/unix-socket/hostbit-add-ip6/README.md
@@ -1,6 +1,7 @@
 # Test Description
 
-Test `add-hostbit` unix-socket command with ip6 address
+- Test `add-hostbit` unix-socket command with ip6 address
+- Test socket file to be properly closed and removed after Suricata shutdown
 
 ## PCAP
 
@@ -8,4 +9,5 @@ None
 
 ## Related issues
 
-Ticket https://redmine.openinfosecfoundation.org/issues/8102
+- Ticket https://redmine.openinfosecfoundation.org/issues/8102
+- Ticket https://redmine.openinfosecfoundation.org/issues/8799

--- a/tests/unix-socket/hostbit-add-ip6/test.yaml
+++ b/tests/unix-socket/hostbit-add-ip6/test.yaml
@@ -5,8 +5,17 @@ unix-commands:
   - "add-hostbit fe80:0000:0000:0000:6600:6aff:fe5b:8f4a test 60"
 
 checks:
-- filter:
-    filename: sc.json
-    count: 1
-    match:
-      return: OK
+  - filter:
+      filename: sc.json
+      count: 1
+      match:
+        return: OK
+
+  # The test harness sends "shutdown" over the unix socket after the
+  # commands above. By the time this check runs, Suricata has fully
+  # exited, so the command socket file must be gone.
+  # Ticket: https://redmine.openinfosecfoundation.org/issues/8799
+  - shell:
+      requires:
+        min-version: 9
+      args: test ! -e socket


### PR DESCRIPTION
As suggested in review of OISF/suricata#16117: add a shell check to the existing hostbit-add-ip6 test verifying that the command socket file is removed after the clean 'suricatasc -c 'shutdown'' that the test harness itself issues at the end of a unix-commands test.

This covers the 'suricatasc shutdown' path. Covering a SIGTERM-triggered shutdown requires additional runtime support in the test framework and is thus not part of this test.

This is the follow-up PR to https://github.com/OISF/suricata-verify/pull/3335, adding `min-version: 9` to the newly added test. Also applied some yamllint corrections.

Ticket: 8799

## Ticket

If your pull request is related to a Suricata ticket, please provide
the full URL to the ticket here so this pull request can monitor
changes to the ticket status:

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/8799